### PR TITLE
fix make cluser/clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,10 @@ cluster/seed/blobstorage:
 
 .PHONY: cluster/clean
 cluster/clean:
-	oc delete -f ./deploy/crds/*_crd.yaml
+	oc project $(NAMESPACE)
+	oc delete -f ./deploy/crds/integreatly_v1alpha1_blobstorage_crd.yaml
+	oc delete -f ./deploy/crds/integreatly_v1alpha1_smtpcredentialset_crd.yaml
+	oc delete -f ./deploy/crds/integreatly_v1alpha1_redis_crd.yaml
 	oc delete project $(NAMESPACE)
 
 .PHONY: test/unit


### PR DESCRIPTION
## Overview
`make cluster/clean` was not working using the wildcard

Added the full commands for removing the crd.