### PR TITLE
format aws redis secret to match openshift redis secret

### DIFF
--- a/deploy/crds/integreatly_v1alpha1_redis_cr.yaml
+++ b/deploy/crds/integreatly_v1alpha1_redis_cr.yaml
@@ -11,4 +11,4 @@ spec:
   # i want a redis storage of a development-level tier
   tier: development
   # i want a redis storage for the type managed
-  type: workshop
+  type: managed

--- a/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
@@ -11,15 +11,15 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorage":             schema_pkg_apis_integreatly_v1alpha1_BlobStorage(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorageSpec":         schema_pkg_apis_integreatly_v1alpha1_BlobStorageSpec(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorageStatus":       schema_pkg_apis_integreatly_v1alpha1_BlobStorageStatus(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.Redis":                   schema_pkg_apis_integreatly_v1alpha1_Redis(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.RedisSpec":               schema_pkg_apis_integreatly_v1alpha1_RedisSpec(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.RedisStatus":             schema_pkg_apis_integreatly_v1alpha1_RedisStatus(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSet":       schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSet(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSetSpec":   schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSetSpec(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSetStatus": schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSetStatus(ref),
+		"./pkg/apis/integreatly/v1alpha1.BlobStorage":             schema_pkg_apis_integreatly_v1alpha1_BlobStorage(ref),
+		"./pkg/apis/integreatly/v1alpha1.BlobStorageSpec":         schema_pkg_apis_integreatly_v1alpha1_BlobStorageSpec(ref),
+		"./pkg/apis/integreatly/v1alpha1.BlobStorageStatus":       schema_pkg_apis_integreatly_v1alpha1_BlobStorageStatus(ref),
+		"./pkg/apis/integreatly/v1alpha1.Redis":                   schema_pkg_apis_integreatly_v1alpha1_Redis(ref),
+		"./pkg/apis/integreatly/v1alpha1.RedisSpec":               schema_pkg_apis_integreatly_v1alpha1_RedisSpec(ref),
+		"./pkg/apis/integreatly/v1alpha1.RedisStatus":             schema_pkg_apis_integreatly_v1alpha1_RedisStatus(ref),
+		"./pkg/apis/integreatly/v1alpha1.SMTPCredentialSet":       schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSet(ref),
+		"./pkg/apis/integreatly/v1alpha1.SMTPCredentialSetSpec":   schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSetSpec(ref),
+		"./pkg/apis/integreatly/v1alpha1.SMTPCredentialSetStatus": schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSetStatus(ref),
 	}
 }
 
@@ -50,19 +50,19 @@ func schema_pkg_apis_integreatly_v1alpha1_BlobStorage(ref common.ReferenceCallba
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorageSpec"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.BlobStorageSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorageStatus"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.BlobStorageStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorageSpec", "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorageStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./pkg/apis/integreatly/v1alpha1.BlobStorageSpec", "./pkg/apis/integreatly/v1alpha1.BlobStorageStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -86,7 +86,7 @@ func schema_pkg_apis_integreatly_v1alpha1_BlobStorageSpec(ref common.ReferenceCa
 					},
 					"secretRef": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SecretRef"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.SecretRef"),
 						},
 					},
 				},
@@ -94,7 +94,7 @@ func schema_pkg_apis_integreatly_v1alpha1_BlobStorageSpec(ref common.ReferenceCa
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SecretRef"},
+			"./pkg/apis/integreatly/v1alpha1.SecretRef"},
 	}
 }
 
@@ -118,14 +118,14 @@ func schema_pkg_apis_integreatly_v1alpha1_BlobStorageStatus(ref common.Reference
 					},
 					"secretRef": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SecretRef"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.SecretRef"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SecretRef"},
+			"./pkg/apis/integreatly/v1alpha1.SecretRef"},
 	}
 }
 
@@ -156,19 +156,19 @@ func schema_pkg_apis_integreatly_v1alpha1_Redis(ref common.ReferenceCallback) co
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.RedisSpec"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.RedisSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.RedisStatus"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.RedisStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.RedisSpec", "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.RedisStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./pkg/apis/integreatly/v1alpha1.RedisSpec", "./pkg/apis/integreatly/v1alpha1.RedisStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -192,7 +192,7 @@ func schema_pkg_apis_integreatly_v1alpha1_RedisSpec(ref common.ReferenceCallback
 					},
 					"secretRef": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SecretRef"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.SecretRef"),
 						},
 					},
 				},
@@ -200,7 +200,7 @@ func schema_pkg_apis_integreatly_v1alpha1_RedisSpec(ref common.ReferenceCallback
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SecretRef"},
+			"./pkg/apis/integreatly/v1alpha1.SecretRef"},
 	}
 }
 
@@ -224,14 +224,14 @@ func schema_pkg_apis_integreatly_v1alpha1_RedisStatus(ref common.ReferenceCallba
 					},
 					"secretRef": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SecretRef"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.SecretRef"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SecretRef"},
+			"./pkg/apis/integreatly/v1alpha1.SecretRef"},
 	}
 }
 
@@ -262,19 +262,19 @@ func schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSet(ref common.Reference
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSetSpec"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.SMTPCredentialSetSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSetStatus"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.SMTPCredentialSetStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSetSpec", "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSetStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./pkg/apis/integreatly/v1alpha1.SMTPCredentialSetSpec", "./pkg/apis/integreatly/v1alpha1.SMTPCredentialSetStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -298,7 +298,7 @@ func schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSetSpec(ref common.Refer
 					},
 					"secretRef": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SecretRef"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.SecretRef"),
 						},
 					},
 				},
@@ -306,7 +306,7 @@ func schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSetSpec(ref common.Refer
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SecretRef"},
+			"./pkg/apis/integreatly/v1alpha1.SecretRef"},
 	}
 }
 
@@ -330,13 +330,13 @@ func schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSetStatus(ref common.Ref
 					},
 					"secretRef": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SecretRef"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.SecretRef"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SecretRef"},
+			"./pkg/apis/integreatly/v1alpha1.SecretRef"},
 	}
 }

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"context"
 	"encoding/json"
-	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/elasticache/elasticacheiface"
@@ -31,15 +30,6 @@ const (
 	defaultNumCacheClusters  = 2
 	defaultSnapshotRetention = 30
 )
-
-// AWSRedisDeploymentDetails provider specific details about the AWS Redis Cluster created
-type AWSRedisDeploymentDetails struct {
-	Connection map[string][]byte
-}
-
-func (d *AWSRedisDeploymentDetails) Data() map[string][]byte {
-	return d.Connection
-}
 
 // AWS Redis Provider implementation for AWS Elasticache
 type AWSRedisProvider struct {
@@ -128,11 +118,10 @@ func createRedisCluster(cacheSvc elasticacheiface.ElastiCacheAPI, redisConfig *e
 		if *foundCache.Status == "available" {
 			logrus.Info("found existing redis cluster")
 			primaryEndpoint := foundCache.NodeGroups[0].PrimaryEndpoint
-			connData := map[string][]byte{
-				"uri":  []byte(*primaryEndpoint.Address),
-				"port": []byte(strconv.FormatInt(*primaryEndpoint.Port, 10)),
-			}
-			return &providers.RedisCluster{DeploymentDetails: &AWSRedisDeploymentDetails{Connection: connData}}, nil
+			return &providers.RedisCluster{DeploymentDetails: &providers.RedisDeploymentDetails{
+				URI:  *primaryEndpoint.Address,
+				Port: *primaryEndpoint.Port,
+			}}, nil
 		}
 		return nil, nil
 	}

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -130,7 +129,8 @@ func createRedisCluster(cacheSvc elasticacheiface.ElastiCacheAPI, redisConfig *e
 			logrus.Info("found existing redis cluster")
 			primaryEndpoint := foundCache.NodeGroups[0].PrimaryEndpoint
 			connData := map[string][]byte{
-				"connection": []byte(fmt.Sprintf("%s:%s", *primaryEndpoint.Address, strconv.FormatInt(*primaryEndpoint.Port, 10))),
+				"uri":  []byte(*primaryEndpoint.Address),
+				"port": []byte(strconv.FormatInt(*primaryEndpoint.Port, 10)),
 			}
 			return &providers.RedisCluster{DeploymentDetails: &AWSRedisDeploymentDetails{Connection: connData}}, nil
 		}

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"strconv"
 
@@ -101,7 +100,8 @@ func buildTestRedisCluster() *providers.RedisCluster {
 		Port:    testPort,
 	}
 	connData := map[string][]byte{
-		"connection": []byte(fmt.Sprintf("%s:%s", *primaryEndpoint.Address, strconv.FormatInt(*primaryEndpoint.Port, 10))),
+		"uri":  []byte(*primaryEndpoint.Address),
+		"port": []byte(strconv.FormatInt(*primaryEndpoint.Port, 10)),
 	}
 	return &providers.RedisCluster{DeploymentDetails: &AWSRedisDeploymentDetails{Connection: connData}}
 }

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"context"
 	"reflect"
-	"strconv"
 
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -95,15 +94,10 @@ func buildReplicationGroupReady() []*elasticache.ReplicationGroup {
 }
 
 func buildTestRedisCluster() *providers.RedisCluster {
-	primaryEndpoint := &elasticache.Endpoint{
-		Address: testAddress,
-		Port:    testPort,
-	}
-	connData := map[string][]byte{
-		"uri":  []byte(*primaryEndpoint.Address),
-		"port": []byte(strconv.FormatInt(*primaryEndpoint.Port, 10)),
-	}
-	return &providers.RedisCluster{DeploymentDetails: &AWSRedisDeploymentDetails{Connection: connData}}
+	return &providers.RedisCluster{DeploymentDetails: &providers.RedisDeploymentDetails{
+		URI:  *testAddress,
+		Port: *testPort,
+	}}
 }
 
 func Test_createRedisCluster(t *testing.T) {

--- a/pkg/providers/openshift/provider_redis.go
+++ b/pkg/providers/openshift/provider_redis.go
@@ -36,17 +36,9 @@ const (
 	redisConfigMapName    = "redis-config"
 	redisConfigMapKey     = "redis.conf"
 	redisContainerName    = "redis"
-	redisPort             = "6379"
+	redisPort             = 6379
 	redisContainerCommand = "/opt/rh/rh-redis32/root/usr/bin/redis-server"
 )
-
-type OpenShiftRedisDeploymentDetails struct {
-	Connection map[string][]byte
-}
-
-func (d *OpenShiftRedisDeploymentDetails) Data() map[string][]byte {
-	return d.Connection
-}
 
 type OpenShiftRedisProvider struct {
 	Client        client.Client
@@ -111,11 +103,9 @@ func (p *OpenShiftRedisProvider) CreateRedis(ctx context.Context, r *v1alpha1.Re
 	for _, s := range dpl.Status.Conditions {
 		if s.Type == appsv1.DeploymentAvailable && s.Status == "True" {
 			p.Logger.Info("found redis deployment")
-			connData := map[string][]byte{
-				"uri":  []byte(fmt.Sprintf("%s.%s.svc.cluster.local", r.Name, r.Namespace)),
-				"port": []byte(redisPort),
-			}
-			return &providers.RedisCluster{DeploymentDetails: &OpenShiftRedisDeploymentDetails{Connection: connData}}, nil
+			return &providers.RedisCluster{DeploymentDetails: &providers.RedisDeploymentDetails{
+				URI:  fmt.Sprintf("%s.%s.svc.cluster.local", r.Name, r.Namespace),
+				Port: redisPort}}, nil
 		}
 	}
 	return nil, nil

--- a/pkg/providers/openshift/provider_redis_test.go
+++ b/pkg/providers/openshift/provider_redis_test.go
@@ -129,11 +129,9 @@ func buildTestDeploymentReady() *appsv1.Deployment {
 }
 
 func buildTestRedisCluster() *providers.RedisCluster {
-	connData := map[string][]byte{
-		"uri":  []byte(fmt.Sprintf("%s.%s.svc.cluster.local", testRedisName, testRedisNamespace)),
-		"port": []byte(redisPort),
-	}
-	return &providers.RedisCluster{DeploymentDetails: &OpenShiftRedisDeploymentDetails{Connection: connData}}
+	return &providers.RedisCluster{DeploymentDetails: &providers.RedisDeploymentDetails{
+		URI:  fmt.Sprintf("%s.%s.svc.cluster.local", testRedisName, testRedisNamespace),
+		Port: redisPort}}
 }
 
 func TestOpenShiftRedisProvider_SupportsStrategy(t *testing.T) {

--- a/pkg/providers/types.go
+++ b/pkg/providers/types.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
 )
@@ -57,4 +58,18 @@ type RedisProvider interface {
 	SupportsStrategy(s string) bool
 	CreateRedis(ctx context.Context, r *v1alpha1.Redis) (*RedisCluster, error)
 	DeleteRedis(ctx context.Context, r *v1alpha1.Redis) error
+}
+
+// RedisDeploymentDetails provider specific details about the AWS Redis Cluster created
+type RedisDeploymentDetails struct {
+	URI  string
+	Port int64
+}
+
+// Redis provider Data function
+func (r *RedisDeploymentDetails) Data() map[string][]byte {
+	return map[string][]byte{
+		"uri":  []byte(r.URI),
+		"port": []byte(strconv.FormatInt(r.Port, 10)),
+	}
 }


### PR DESCRIPTION
## Overview
Current the redis secret created for AWS and Openshift are different. This change formats the secrets so that they are the same

## Verification

### Creation 
- Run `make cluster/prepare` and `make cluster/seed/redis`
- Run `make run`
- Verify the secret created is split to `uri` and `port`