### PR TITLE
use default config when configmap cannot be found

### DIFF
--- a/pkg/providers/aws/config.go
+++ b/pkg/providers/aws/config.go
@@ -5,6 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
+
+	controllerruntime "sigs.k8s.io/controller-runtime"
+
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers"
 	errorUtil "github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -91,8 +95,7 @@ func (m *ConfigMapConfigManager) GetDefaultRegionSMTPServerMapping() map[string]
 }
 
 func (m *ConfigMapConfigManager) getTierStrategyForProvider(ctx context.Context, rt string, tier string) (*StrategyConfig, error) {
-	cm := &v1.ConfigMap{}
-	err := m.client.Get(ctx, types.NamespacedName{Name: m.configMapName, Namespace: m.configMapNamespace}, cm)
+	cm, err := resources.GetConfigMapOrDefault(ctx, m.client, types.NamespacedName{Name: m.configMapName, Namespace: m.configMapNamespace}, m.buildDefaultConfigMap())
 	if err != nil {
 		return nil, errorUtil.Wrapf(err, "failed to get aws strategy config map %s in namespace %s", m.configMapName, m.configMapNamespace)
 	}
@@ -105,4 +108,19 @@ func (m *ConfigMapConfigManager) getTierStrategyForProvider(ctx context.Context,
 		return nil, errorUtil.Wrapf(err, "failed to unmarshal strategy mapping for resource type %s", rt)
 	}
 	return strategyMapping[tier], nil
+}
+
+func (m *ConfigMapConfigManager) buildDefaultConfigMap() *v1.ConfigMap {
+	return &v1.ConfigMap{
+		ObjectMeta: controllerruntime.ObjectMeta{
+			Name:      m.configMapName,
+			Namespace: m.configMapNamespace,
+		},
+		Data: map[string]string{
+			"blobstorage":     "{\"development\": { \"region\": \"eu-west-1\", \"strategy\": {} }}",
+			"smtpcredentials": "{\"development\": { \"region\": \"eu-west-1\", \"strategy\": {} }}",
+			"redis":           "{\"development\": { \"region\": \"eu-west-1\", \"strategy\": {} }}",
+			"postgres":        "{\"development\": { \"region\": \"eu-west-1\", \"strategy\": {} }}",
+		},
+	}
 }

--- a/pkg/providers/aws/provider_blobstorage.go
+++ b/pkg/providers/aws/provider_blobstorage.go
@@ -31,6 +31,8 @@ import (
 )
 
 const (
+	blobstorageProviderName = "aws-s3"
+
 	dataBucketName          = "bucketName"
 	dataCredentialKeyID     = "credentialKeyID"
 	dataCredentialSecretKey = "credentialSecretKey"
@@ -64,14 +66,14 @@ type BlobStorageProvider struct {
 func NewAWSBlobStorageProvider(client client.Client, logger *logrus.Entry) *BlobStorageProvider {
 	return &BlobStorageProvider{
 		Client:            client,
-		Logger:            logger.WithFields(logrus.Fields{"provider": "aws_s3"}),
+		Logger:            logger.WithFields(logrus.Fields{"provider": blobstorageProviderName}),
 		CredentialManager: NewCredentialMinterCredentialManager(client),
 		ConfigManager:     NewDefaultConfigMapConfigManager(client),
 	}
 }
 
 func (p *BlobStorageProvider) GetName() string {
-	return providers.AWSDeploymentStrategy
+	return blobstorageProviderName
 }
 
 func (p *BlobStorageProvider) SupportsStrategy(d string) bool {

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -24,6 +24,8 @@ import (
 )
 
 const (
+	redisProviderName = "aws-elasticache"
+
 	defaultCacheNodeType     = "cache.t2.micro"
 	defaultEngineVersion     = "3.2.10"
 	defaultDescription       = "A Redis replication group"
@@ -43,14 +45,14 @@ type AWSRedisProvider struct {
 func NewAWSRedisProvider(client client.Client, logger *logrus.Entry) *AWSRedisProvider {
 	return &AWSRedisProvider{
 		Client:            client,
-		Logger:            logger.WithFields(logrus.Fields{"provider": "aws_redis"}),
+		Logger:            logger.WithFields(logrus.Fields{"provider": redisProviderName}),
 		CredentialManager: NewCredentialMinterCredentialManager(client),
 		ConfigManager:     NewDefaultConfigMapConfigManager(client),
 	}
 }
 
 func (p *AWSRedisProvider) GetName() string {
-	return providers.AWSDeploymentStrategy
+	return redisProviderName
 }
 
 func (p *AWSRedisProvider) SupportsStrategy(d string) bool {

--- a/pkg/providers/aws/provider_smtpcredentialset.go
+++ b/pkg/providers/aws/provider_smtpcredentialset.go
@@ -25,6 +25,8 @@ import (
 )
 
 const (
+	smtpCredentialProviderName = "aws-ses"
+
 	detailsSMTPUsernameKey = "username"
 	detailsSMTPPasswordKey = "password"
 	detailsSMTPPortKey     = "port"
@@ -63,14 +65,14 @@ type SMTPCredentialProvider struct {
 func NewAWSSMTPCredentialProvider(client client.Client, logger *logrus.Entry) *SMTPCredentialProvider {
 	return &SMTPCredentialProvider{
 		Client:            client,
-		Logger:            logger.WithFields(logrus.Fields{"provider": "aws_ses"}),
+		Logger:            logger.WithFields(logrus.Fields{"provider": smtpCredentialProviderName}),
 		CredentialManager: NewCredentialMinterCredentialManager(client),
 		ConfigManager:     NewDefaultConfigMapConfigManager(client),
 	}
 }
 
 func (p *SMTPCredentialProvider) GetName() string {
-	return providers.AWSDeploymentStrategy
+	return smtpCredentialProviderName
 }
 
 func (p *SMTPCredentialProvider) SupportsStrategy(d string) bool {

--- a/pkg/providers/config.go
+++ b/pkg/providers/config.go
@@ -74,8 +74,8 @@ func (m *ConfigMapConfigManager) buildDefaultConfigMap() *v1.ConfigMap {
 			Namespace: m.providerConfigMapNamespace,
 		},
 		Data: map[string]string{
-			"managed":  "{\"blobstorage\":\"aws\", \"smtpcredentials\": \"aws\"}",
-			"workshop": "{\"blobstorage\":\"aws\", \"smtpcredentials\": \"aws\"}",
+			"managed":  "{\"blobstorage\":\"aws\", \"smtpcredentials\": \"aws\", \"redis\":\"aws\", \"postgres\":\"aws\"}",
+			"workshop": "{\"blobstorage\":\"aws\", \"smtpcredentials\": \"aws\", \"redis\":\"openshift\", \"postgres\":\"openshift\"}",
 		},
 	}
 }

--- a/pkg/providers/config_test.go
+++ b/pkg/providers/config_test.go
@@ -98,13 +98,6 @@ func TestConfigManager_GetStrategyMappingForDeploymentType(t *testing.T) {
 				return nil
 			},
 		},
-		{
-			name:        "test error is returned when config map doesn't exist",
-			cmName:      "err",
-			cmNamespace: "err",
-			client:      fakeClient,
-			expectError: true,
-		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/providers/openshift/provider_postgres.go
+++ b/pkg/providers/openshift/provider_postgres.go
@@ -30,6 +30,8 @@ import (
 )
 
 var (
+	postgresProviderName = "openshift-postgres-template"
+
 	defaultPostgresPort        = 5432
 	defaultPostgresUser        = "user"
 	defaultPostgresPassword    = "password"
@@ -76,13 +78,13 @@ type OpenShiftPostgresProvider struct {
 func NewOpenShiftPostgresProvider(client client.Client, logger *logrus.Entry) *OpenShiftPostgresProvider {
 	return &OpenShiftPostgresProvider{
 		Client:        client,
-		Logger:        logger.WithFields(logrus.Fields{"provider": "openshift_postgres"}),
+		Logger:        logger.WithFields(logrus.Fields{"provider": postgresProviderName}),
 		ConfigManager: NewDefaultConfigManager(client),
 	}
 }
 
 func (p *OpenShiftPostgresProvider) GetName() string {
-	return providers.OpenShiftDeploymentStrategy
+	return postgresProviderName
 }
 
 func (p *OpenShiftPostgresProvider) SupportsStrategy(d string) bool {

--- a/pkg/providers/openshift/provider_redis.go
+++ b/pkg/providers/openshift/provider_redis.go
@@ -30,6 +30,8 @@ import (
 )
 
 const (
+	redisProviderName = "openshift-redis-template"
+
 	redisObjectMetaName   = "redis"
 	redisDCSelectorName   = redisObjectMetaName
 	redisConfigVolumeName = "redis-config"
@@ -49,13 +51,13 @@ type OpenShiftRedisProvider struct {
 func NewOpenShiftRedisProvider(client client.Client, logger *logrus.Entry) *OpenShiftRedisProvider {
 	return &OpenShiftRedisProvider{
 		Client:        client,
-		Logger:        logger.WithFields(logrus.Fields{"provider": "openshift_redis"}),
+		Logger:        logger.WithFields(logrus.Fields{"provider": redisProviderName}),
 		ConfigManager: NewDefaultConfigManager(client),
 	}
 }
 
 func (p *OpenShiftRedisProvider) GetName() string {
-	return providers.OpenShiftDeploymentStrategy
+	return redisProviderName
 }
 
 func (p *OpenShiftRedisProvider) SupportsStrategy(d string) bool {

--- a/pkg/resources/configmaps.go
+++ b/pkg/resources/configmaps.go
@@ -1,0 +1,22 @@
+package resources
+
+import (
+	"context"
+
+	errorUtil "github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetConfigMapOrDefault(ctx context.Context, c client.Client, name types.NamespacedName, def *v1.ConfigMap) (*v1.ConfigMap, error) {
+	cm := &v1.ConfigMap{}
+	if err := c.Get(ctx, name, cm); err != nil {
+		if errors.IsNotFound(err) {
+			return def, nil
+		}
+		return nil, errorUtil.Wrap(err, "failed to get config map, not returning default")
+	}
+	return cm, nil
+}


### PR DESCRIPTION
currently, if the config for either the operator or each provider
cannot be found, the operator will crash with a config missing error.

this is not ideal, and with rhmi we would like to not have to
pre-create configmaps.

this solution, simply provides an entirely default configmap that
is used if the expected configmap is not found.

there is also some general cleanup around provider logging
included.

verification:
- run the operator without any config maps present
- ensure the operator doesn't crash
- attempt a deploy of a service e.g. blobstorage without any
  provider config map present
- ensure it completes successfully