### PR TITLE
remove namespace prefix from blob storage name

### DIFF
--- a/pkg/providers/aws/provider_blobstorage.go
+++ b/pkg/providers/aws/provider_blobstorage.go
@@ -99,7 +99,7 @@ func (p *BlobStorageProvider) CreateStorage(ctx context.Context, bs *v1alpha1.Bl
 		return nil, errorUtil.Wrapf(err, "failed to retrieve aws s3 bucket config for blob storage instance %s", bs.Name)
 	}
 	if bucketCreateCfg.Bucket == nil {
-		bucketCreateCfg.Bucket = aws.String(fmt.Sprintf("%s-%s", bs.Namespace, bs.Name))
+		bucketCreateCfg.Bucket = aws.String(bs.Name)
 	}
 
 	// create the credentials to be used by the end-user, whoever created the blobstorage instance


### PR DESCRIPTION
## Overview

Currently we prefix blob storage resource with the name space. This change removes the prefix to match how we handle resource names in Redis and Postgres. 