### PR TITLE
Add FinalSnapshotIdentifier to force snapshot on deletion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,10 @@ cluster/clean:
 .PHONY: test/unit
 test/unit:
 	@echo Running tests:
-	go test -v -covermode=count -coverprofile=coverage.out ./pkg/...
+	gotest -v -covermode=count -coverprofile=coverage.out ./pkg/...
 
 .PHONY: test/unit/ci
-test/unit/ci: test/unit
+test/unit/ci:
 	@echo Removing mock file coverage
+	go test -v -covermode=count -coverprofile=coverage.out ./pkg/...
 	sed -i.bak '/_moq.go/d' coverage.out

--- a/deploy/examples/cloud_resources_aws_strategies.yaml
+++ b/deploy/examples/cloud_resources_aws_strategies.yaml
@@ -9,6 +9,6 @@ data:
   smtpcredentials: |
     {"development": { "region": "eu-west-1", "createStrategy": {} }}
   redis: |
-    {"development": { "region": "eu-west-1", "createStrategy": {} }}
+    {"development": { "region": "eu-west-1", "createStrategy": {}, "deleteStrategy": {} }}
   postgres: |
     {"development": { "region": "eu-west-1", "createStrategy": {}, "deleteStrategy": {} }}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/integr8ly/cloud-resource-operator
 
 require (
 	github.com/aws/aws-sdk-go v1.23.17
+	github.com/fatih/color v1.7.0 // indirect
 	github.com/go-openapi/spec v0.19.0
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
@@ -10,6 +11,8 @@ require (
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
+	github.com/mattn/go-colorable v0.1.4 // indirect
+	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/onsi/ginkgo v1.10.1 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/openshift/api v3.9.1-0.20191002160657-d92789481b05+incompatible
@@ -19,6 +22,7 @@ require (
 	github.com/prometheus/client_golang v1.1.0 // indirect
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect
 	github.com/prometheus/procfs v0.0.4 // indirect
+	github.com/rakyll/gotest v0.0.0-20180125184505-86f0749cd8cc // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/evanphx/json-patch v4.1.0+incompatible h1:K1MDoo4AZ4wU0GIU/fPmtZg7Vpz
 github.com/evanphx/json-patch v4.1.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
+github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -272,6 +274,11 @@ github.com/markbates/inflect v1.0.4 h1:5fh1gzTFhfae06u3hzHYO9xe3l3v3nW5Pwt3naLTP
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/martinlindhe/base36 v0.0.0-20180729042928-5cda0030da17/go.mod h1:+AtEs8xrBpCeYgSLoY/aJ6Wf37jtBuR0s35750M27+8=
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
+github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
+github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
+github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
@@ -364,6 +371,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.0.4 h1:w8DjqFMJDjuVwdZBQoOozr4MVWOnwF7RcL/7uxBjY78=
 github.com/prometheus/procfs v0.0.4/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
+github.com/rakyll/gotest v0.0.0-20180125184505-86f0749cd8cc h1:hrzpgS8mnUi65ieVrD3TKJMxHP84bzmybMTQIdK/XhM=
+github.com/rakyll/gotest v0.0.0-20180125184505-86f0749cd8cc/go.mod h1:iln+RRtJaJ52lKwqrSmNgQYw32Fk16CgChX85eFqBgI=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/robfig/cron v0.0.0-20170526150127-736158dc09e1/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
@@ -507,6 +516,7 @@ golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181218192612-074acd46bca6/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -515,6 +525,8 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69 h1:rOhMmluY6kLMhdnrivzec6lLgaVbMHMn2ISQXJeJ5EM=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191008105621-543471e840be h1:QAcqgptGM8IQBC9K/RC4o+O9YmqEm0diQn9QmZw/0mU=
+golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/providers/aws/config.go
+++ b/pkg/providers/aws/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
 
@@ -132,4 +133,13 @@ func buildInfraNameFromObject(ctx context.Context, c client.Client, om controlle
 		return "", errorUtil.Wrap(err, "failed to retrieve cluster identifier")
 	}
 	return resources.ShortenString(fmt.Sprintf("%s-%s-%s", clusterId, om.Namespace, om.Name), n), nil
+}
+
+func buildTimestampedInfraNameFromObject(ctx context.Context, c client.Client, om controllerruntime.ObjectMeta, n int) (string, error) {
+	clusterId, err := resources.GetClusterId(ctx, c)
+	if err != nil {
+		return "", errorUtil.Wrap(err, "failed to retrieve timestamped cluster identifier")
+	}
+	curTime := time.Now().Unix()
+	return resources.ShortenString(fmt.Sprintf("%s-%s-%s-%d", clusterId, om.Namespace, om.Name, curTime), n), nil
 }

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -168,10 +168,11 @@ func TestAWSRedisProvider_deleteRedisCluster(t *testing.T) {
 		CacheSvc          elasticacheiface.ElastiCacheAPI
 	}
 	type args struct {
-		cacheSvc    elasticacheiface.ElastiCacheAPI
-		redisConfig *elasticache.CreateReplicationGroupInput
-		ctx         context.Context
-		redis       *v1alpha1.Redis
+		cacheSvc          elasticacheiface.ElastiCacheAPI
+		redisCreateConfig *elasticache.CreateReplicationGroupInput
+		redisDeleteConfig *elasticache.DeleteReplicationGroupInput
+		ctx               context.Context
+		redis             *v1alpha1.Redis
 	}
 	tests := []struct {
 		name    string
@@ -182,11 +183,12 @@ func TestAWSRedisProvider_deleteRedisCluster(t *testing.T) {
 		{
 			name: "test successful delete with no redis",
 			args: args{
-				redisConfig: &elasticache.CreateReplicationGroupInput{},
-				redis:       buildTestRedisCR(),
+				redisCreateConfig: &elasticache.CreateReplicationGroupInput{},
+				redisDeleteConfig: &elasticache.DeleteReplicationGroupInput{},
+				redis:             buildTestRedisCR(),
 			},
 			fields: fields{
-				Client:            fake.NewFakeClientWithScheme(scheme, buildTestRedisCR()),
+				Client:            fake.NewFakeClientWithScheme(scheme, buildTestRedisCR(), builtTestCredSecret(), buildTestInfra()),
 				Logger:            testLogger,
 				CredentialManager: &CredentialManagerMock{},
 				ConfigManager:     &ConfigManagerMock{},
@@ -198,11 +200,12 @@ func TestAWSRedisProvider_deleteRedisCluster(t *testing.T) {
 			name: "test successful delete with existing unavailable redis",
 			args: args{
 
-				redisConfig: &elasticache.CreateReplicationGroupInput{ReplicationGroupId: aws.String("test-id")},
-				redis:       buildTestRedisCR(),
+				redisCreateConfig: &elasticache.CreateReplicationGroupInput{ReplicationGroupId: aws.String("test-id")},
+				redisDeleteConfig: &elasticache.DeleteReplicationGroupInput{ReplicationGroupId: aws.String("test-id")},
+				redis:             buildTestRedisCR(),
 			},
 			fields: fields{
-				Client:            fake.NewFakeClientWithScheme(scheme, buildTestRedisCR()),
+				Client:            fake.NewFakeClientWithScheme(scheme, buildTestRedisCR(), builtTestCredSecret(), buildTestInfra()),
 				Logger:            testLogger,
 				CredentialManager: &CredentialManagerMock{},
 				ConfigManager:     &ConfigManagerMock{},
@@ -214,11 +217,12 @@ func TestAWSRedisProvider_deleteRedisCluster(t *testing.T) {
 			name: "test successful delete with existing available redis",
 			args: args{
 
-				redisConfig: &elasticache.CreateReplicationGroupInput{ReplicationGroupId: aws.String("test-id")},
-				redis:       buildTestRedisCR(),
+				redisCreateConfig: &elasticache.CreateReplicationGroupInput{ReplicationGroupId: aws.String("test-id")},
+				redisDeleteConfig: &elasticache.DeleteReplicationGroupInput{ReplicationGroupId: aws.String("test-id")},
+				redis:             buildTestRedisCR(),
 			},
 			fields: fields{
-				Client:            fake.NewFakeClientWithScheme(scheme, buildTestRedisCR()),
+				Client:            fake.NewFakeClientWithScheme(scheme, buildTestRedisCR(), builtTestCredSecret(), buildTestInfra()),
 				Logger:            testLogger,
 				CredentialManager: &CredentialManagerMock{},
 				ConfigManager:     &ConfigManagerMock{},
@@ -236,7 +240,7 @@ func TestAWSRedisProvider_deleteRedisCluster(t *testing.T) {
 				ConfigManager:     tt.fields.ConfigManager,
 				CacheSvc:          tt.fields.CacheSvc,
 			}
-			if _, err := p.deleteRedisCluster(tt.fields.CacheSvc, tt.args.redisConfig, tt.args.ctx, tt.args.redis); (err != nil) != tt.wantErr {
+			if _, err := p.deleteRedisCluster(tt.fields.CacheSvc, tt.args.redisCreateConfig, tt.args.redisDeleteConfig, tt.args.ctx, tt.args.redis); (err != nil) != tt.wantErr {
 				t.Errorf("deleteRedisCluster() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/tools.go
+++ b/tools.go
@@ -3,5 +3,6 @@
 package tools
 
 import (
+	"github.com/rakyll/gotest"
 	_ "sigs.k8s.io/controller-tools/pkg/crd/generator"
 )


### PR DESCRIPTION
## Overview

Jira: https://issues.jboss.org/browse/INTLY-3568
This PR adds a snapshot/backup on delete of Redis 

FYI Redis takes a while to create but sometimes its worth hitting refresh aws console pages, and to create a snapshot on aws

## Verification
### Verify install
- Clone this branch
- Run `make cluster/clean`
- Run `make cluster/prepare`
- Run `make run`
- [ ] Check AWS elasticache  to see if the redis instance has been provisioned
## Verify delete
- Remove the CR
```sh
oc delete -f ./deploy/crds/integreatly_v1alpha1_redis_cr.yaml
```
- [ ] Make sure that the Redis instance is deleted on AWS
- [ ] Make sure there is a backup on AWS of the deleted instance
- [ ] Make sure that the redis secret has been removed from the cloud-resource-operator namespace
## Verify no snapshot
- Apply the CR again
```sh
oc apply -f ./deploy/crds/integreatly_v1alpha1_redis_cr.yaml
```
- Edit the configmap `cloud-resources-aws-strategies` redis `deleteStrategy` , in the namespace: `kube-system`  and set the `FinalSnapshotIdentifier` to an empty string
```yaml
data:
  blobstorage: |
    {"development": { "region": "eu-west-1", "createStrategy": {} }}
  postgres: >
    {"development": { "region": "eu-west-1", "createStrategy": {},
    "deleteStrategy": {} }}
  redis: >
    {"development": { "region": "eu-west-1", "createStrategy": {},
    "deleteStrategy": {FinalSnapshotIdentifier: "",} }}
  smtpcredentials: |
    {"development": { "region": "eu-west-1", "createStrategy": {} }}
```
- Remove the CR again
- [ ] Make sure that the Redis instance is deleted on AWS
- [ ] Make sure there is no backup on AWS of the deleted instance
- [ ] Make sure that the redis secret has been removed from the cloud-resource-operator namespace

### Verify Custom snapshot name
- Apply the CR again
- edit the `FinalSnapshotIdentifier` again and set it to some string
- remove the CR again
- [ ] Make sure that the Redis instance is deleted on AWS
- [ ] Make sure there is a backup on AWS of the deleted instance with a name matching the string you set in the `FinalSnapshotIdentifier`
- [ ] Make sure that the redis secret has been removed from the cloud-resource-operator namespace