### PR TITLE
add production defaults for aws

### DIFF
--- a/pkg/providers/aws/config.go
+++ b/pkg/providers/aws/config.go
@@ -120,10 +120,10 @@ func (m *ConfigMapConfigManager) buildDefaultConfigMap() *v1.ConfigMap {
 			Namespace: m.configMapNamespace,
 		},
 		Data: map[string]string{
-			"blobstorage":     "{\"development\": { \"region\": \"eu-west-1\", \"createStrategy\": {}, \"deleteStrategy\": {} }}",
+			"blobstorage":     "{\"development\": { \"region\": \"eu-west-1\", \"createStrategy\": {}, \"deleteStrategy\": {} }, \"production\": { \"region\": \"eu-west-1\", \"createStrategy\": {}, \"deleteStrategy\": {} }}",
 			"smtpcredentials": "{\"development\": { \"region\": \"eu-west-1\", \"createStrategy\": {}, \"deleteStrategy\": {} }, \"production\": { \"region\": \"eu-west-1\", \"createStrategy\": {}, \"deleteStrategy\": {} }}",
-			"redis":           "{\"development\": { \"region\": \"eu-west-1\", \"createStrategy\": {}, \"deleteStrategy\": {} }}",
-			"postgres":        "{\"development\": { \"region\": \"eu-west-1\", \"createStrategy\": {}, \"deleteStrategy\": {} }}",
+			"redis":           "{\"development\": { \"region\": \"eu-west-1\", \"createStrategy\": {}, \"deleteStrategy\": {} }, \"production\": { \"region\": \"eu-west-1\", \"createStrategy\": {}, \"deleteStrategy\": {} }}",
+			"postgres":        "{\"development\": { \"region\": \"eu-west-1\", \"createStrategy\": {}, \"deleteStrategy\": {} }, \"production\": { \"region\": \"eu-west-1\", \"createStrategy\": {}, \"deleteStrategy\": {} }}",
 		},
 	}
 }


### PR DESCRIPTION
## Overview
Currently we have no `production` defaults which causes errors during development on the intly operator