### PR TITLE
remove namespace from postgres cr and set the finilizers to the same name

### DIFF
--- a/deploy/crds/integreatly_v1alpha1_postgres_cr.yaml
+++ b/deploy/crds/integreatly_v1alpha1_postgres_cr.yaml
@@ -7,7 +7,6 @@ spec:
   # i want my postgres storage information output in a Secret named test in the Namespace cloud-resource-operator
   secretRef:
     name: example-postgres-sec
-    namespace: cloud-resource-operator
   # i want a postgres storage of a development-level tier
   tier: development
   # i want a postgres storage for the type managed

--- a/pkg/providers/aws/config.go
+++ b/pkg/providers/aws/config.go
@@ -22,7 +22,7 @@ const (
 	DefaultConfigMapName      = "cloud-resources-aws-strategies"
 	DefaultConfigMapNamespace = "kube-system"
 
-	DefaultFinalizer = "finalizers.aws.cloud-resources-operator.integreatly.org"
+	DefaultFinalizer = "finalizers.cloud-resources-operator.integreatly.org"
 	DefaultRegion    = "eu-west-1"
 
 	regionUSEast1 = "us-east-1"

--- a/pkg/providers/openshift/config.go
+++ b/pkg/providers/openshift/config.go
@@ -18,7 +18,7 @@ import (
 const (
 	DefaultConfigMapName      = "cloud-resources-openshift-strategies"
 	DefaultConfigMapNamespace = "kube-system"
-	DefaultFinalizer          = "finalizers.openshift.cloud-resources-operator.integreatly.org"
+	DefaultFinalizer          = "finalizers.cloud-resources-operator.integreatly.org"
 )
 
 type StrategyConfig struct {


### PR DESCRIPTION
## Overview
bug fix, remove namespace from postgres cr and set the finilizers to the same name


## Verification
### Setup
- Clone this branch
- Change the name space in the Makefile `integreatly-operator`
- Deploy `managed` and `workshop` by changing the postgres cr
- Run `make cluster/prepare`
- Run `make cluster/seed/postgres`
- Run `make run`
### Verify
- make sure that the postgres cr points at `integreatly-operator`
- make sure that when the postgres cr is deleted all resources are removed .
