### PR TITLE
Change from kube-system namespace by default

### DIFF
--- a/deploy/examples/cloud_resource_config.yaml
+++ b/deploy/examples/cloud_resource_config.yaml
@@ -2,7 +2,6 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: cloud-resource-config
-  namespace: kube-system
 data:
   managed: |
     {"blobstorage":"aws", "smtpcredentials":"aws", "redis":"aws", "postgres":"aws"}

--- a/deploy/examples/cloud_resource_openshift_strategies.yaml
+++ b/deploy/examples/cloud_resource_openshift_strategies.yaml
@@ -2,7 +2,6 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: cloud-resources-openshift-strategies
-  namespace: kube-system
 data:
   blobstorage: |
     {"development": { "strategy": {} }}

--- a/deploy/examples/cloud_resources_aws_strategies.yaml
+++ b/deploy/examples/cloud_resources_aws_strategies.yaml
@@ -2,7 +2,6 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: cloud-resources-aws-strategies
-  namespace: kube-system
 data:
   blobstorage: |
     {"development": { "region": "eu-west-1", "createStrategy": {}, "deleteStrategy": {} }}

--- a/pkg/providers/aws/config.go
+++ b/pkg/providers/aws/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"time"
 
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
@@ -18,8 +19,7 @@ import (
 )
 
 const (
-	DefaultConfigMapName      = "cloud-resources-aws-strategies"
-	DefaultConfigMapNamespace = "kube-system"
+	DefaultConfigMapName = "cloud-resources-aws-strategies"
 
 	DefaultFinalizer = "finalizers.cloud-resources-operator.integreatly.org"
 	DefaultRegion    = "eu-west-1"
@@ -34,6 +34,9 @@ const (
 	sesSMTPEndpointUSWest2 = "email-smtp.us-west-2.amazonaws.com"
 	sesSMTPEndpointEUWest1 = "email-smtp.eu-west-1.amazonaws.com"
 )
+
+//get default namespace
+var DefaultConfigMapNamespace, _ = k8sutil.GetWatchNamespace()
 
 //go:generate moq -out config_moq.go . ConfigManager
 type ConfigManager interface {

--- a/pkg/providers/aws/config_test.go
+++ b/pkg/providers/aws/config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"testing"
 
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers"
@@ -15,6 +16,8 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var configMapNameSpace, _ = k8sutil.GetWatchNamespace()
 
 func TestNewConfigManager(t *testing.T) {
 	cases := []struct {
@@ -30,7 +33,7 @@ func TestNewConfigManager(t *testing.T) {
 			cmName:            "",
 			cmNamespace:       "",
 			expectedName:      "cloud-resources-aws-strategies",
-			expectedNamespace: "kube-system",
+			expectedNamespace: configMapNameSpace,
 			client:            nil,
 		},
 		{

--- a/pkg/providers/config.go
+++ b/pkg/providers/config.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"context"
 	"encoding/json"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
 
@@ -16,9 +17,11 @@ import (
 )
 
 const (
-	DefaultConfigNamespace       = "kube-system"
 	DefaultProviderConfigMapName = "cloud-resource-config"
 )
+
+//get default namespace
+var DefaultConfigNamespace, _ = k8sutil.GetWatchNamespace()
 
 type DeploymentStrategyMapping struct {
 	BlobStorage     string `json:"blobstorage"`

--- a/pkg/providers/openshift/config.go
+++ b/pkg/providers/openshift/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"time"
 
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
@@ -17,12 +18,13 @@ import (
 )
 
 const (
-	DefaultConfigMapName      = "cloud-resources-openshift-strategies"
-	DefaultConfigMapNamespace = "kube-system"
-	DefaultFinalizer          = "finalizers.cloud-resources-operator.integreatly.org"
-
+	DefaultConfigMapName = "cloud-resources-openshift-strategies"
+	DefaultFinalizer     = "finalizers.cloud-resources-operator.integreatly.org"
 	defaultReconcileTime = time.Second * 30
 )
+
+//get default namespace
+var DefaultConfigMapNamespace, _ = k8sutil.GetWatchNamespace()
 
 type StrategyConfig struct {
 	RawStrategy json.RawMessage `json:"strategy"`

--- a/pkg/providers/openshift/config_test.go
+++ b/pkg/providers/openshift/config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"testing"
 
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers"
@@ -13,6 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+var configMapNameSpace, _ = k8sutil.GetWatchNamespace()
 
 func TestNewConfigManager(t *testing.T) {
 	cases := []struct {
@@ -28,7 +31,7 @@ func TestNewConfigManager(t *testing.T) {
 			cmName:            "",
 			cmNamespace:       "",
 			expectedName:      "cloud-resources-openshift-strategies",
-			expectedNamespace: "kube-system",
+			expectedNamespace: configMapNameSpace,
 			client:            nil,
 		},
 		{


### PR DESCRIPTION
## Overview

Jira: https://issues.jboss.org/browse/INTLY-3896

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make cluster/seed/postgres`
- Run `make run`
- Ensure that cro configmap's are created in the `cloud-resources-operator` namespace
- Change the `NAMESPACE=` var in the makefile
- Run `make cluster/prepare`
- Run `make cluster/seed/postgres`
- Run `make run`
- Ensure that cro configmap's are created in the new namespace
- Ensure no cro resources are created under the `kube-system` namespace