### PR TITLE
add provider specified reconcile timeouts

### DIFF
--- a/deploy/olm-catalog/cloud-resources/cloud-resource-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/cloud-resources/cloud-resource-operator.clusterserviceversion.yaml
@@ -144,6 +144,7 @@ spec:
           - ""
           resources:
           - pods
+          - pods/exec
           - services
           - services/finalizers
           - endpoints

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -8,6 +8,7 @@ rules:
   - ""
   resources:
   - pods
+  - pods/exec
   - services
   - services/finalizers
   - endpoints

--- a/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
@@ -31,6 +31,7 @@ func schema_pkg_apis_integreatly_v1alpha1_BlobStorage(ref common.ReferenceCallba
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "BlobStorage is the Schema for the blobstorages API",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -74,6 +75,7 @@ func schema_pkg_apis_integreatly_v1alpha1_BlobStorageSpec(ref common.ReferenceCa
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "BlobStorageSpec defines the desired state of BlobStorage",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
@@ -106,6 +108,7 @@ func schema_pkg_apis_integreatly_v1alpha1_BlobStorageStatus(ref common.Reference
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "BlobStorageStatus defines the observed state of BlobStorage",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"strategy": {
 						SchemaProps: spec.SchemaProps{
@@ -149,6 +152,7 @@ func schema_pkg_apis_integreatly_v1alpha1_Postgres(ref common.ReferenceCallback)
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "Postgres is the Schema for the postgres API",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -192,6 +196,7 @@ func schema_pkg_apis_integreatly_v1alpha1_PostgresSpec(ref common.ReferenceCallb
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "PostgresSpec defines the desired state of Postgres",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
@@ -224,6 +229,7 @@ func schema_pkg_apis_integreatly_v1alpha1_PostgresStatus(ref common.ReferenceCal
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "PostgresStatus defines the observed state of Postgres",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"strategy": {
 						SchemaProps: spec.SchemaProps{
@@ -267,6 +273,7 @@ func schema_pkg_apis_integreatly_v1alpha1_Redis(ref common.ReferenceCallback) co
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "Redis is the Schema for the redis API",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -310,6 +317,7 @@ func schema_pkg_apis_integreatly_v1alpha1_RedisSpec(ref common.ReferenceCallback
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "RedisSpec defines the desired state of Redis",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
@@ -342,6 +350,7 @@ func schema_pkg_apis_integreatly_v1alpha1_RedisStatus(ref common.ReferenceCallba
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "RedisStatus defines the observed state of Redis",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"strategy": {
 						SchemaProps: spec.SchemaProps{
@@ -385,6 +394,7 @@ func schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSet(ref common.Reference
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "SMTPCredentials is the Schema for the smtpcredentialset API",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -428,6 +438,7 @@ func schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSetSpec(ref common.Refer
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "SMTPCredentialsSpec defines the desired state of SMTPCredentials",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
@@ -460,6 +471,7 @@ func schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSetStatus(ref common.Ref
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "SMTPCredentialsStatus defines the observed state of SMTPCredentials",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"strategy": {
 						SchemaProps: spec.SchemaProps{

--- a/pkg/controller/blobstorage/blobstorage_controller.go
+++ b/pkg/controller/blobstorage/blobstorage_controller.go
@@ -3,8 +3,6 @@ package blobstorage
 import (
 	"context"
 	"fmt"
-	"time"
-
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
 
 	"github.com/sirupsen/logrus"
@@ -124,7 +122,7 @@ func (r *ReconcileBlobStorage) Reconcile(request reconcile.Request) (reconcile.R
 			if err = resources.UpdatePhase(ctx, r.client, instance, v1alpha1.PhaseDeleteInProgress, msg); err != nil {
 				return reconcile.Result{}, err
 			}
-			return reconcile.Result{Requeue: true, RequeueAfter: time.Second * resources.GetReconcileTime()}, nil
+			return reconcile.Result{Requeue: true, RequeueAfter: p.GetReconcileTime(instance)}, nil
 		}
 
 		bsi, msg, err := p.CreateStorage(ctx, instance)
@@ -141,7 +139,7 @@ func (r *ReconcileBlobStorage) Reconcile(request reconcile.Request) (reconcile.R
 			if err = resources.UpdatePhase(ctx, r.client, instance, v1alpha1.PhaseInProgress, msg); err != nil {
 				return reconcile.Result{}, err
 			}
-			return reconcile.Result{Requeue: true, RequeueAfter: time.Second * resources.GetReconcileTime()}, nil
+			return reconcile.Result{Requeue: true, RequeueAfter: p.GetReconcileTime(instance)}, nil
 		}
 
 		if err := r.resourceProvider.ReconcileResultSecret(ctx, instance, bsi.DeploymentDetails.Data()); err != nil {
@@ -156,7 +154,7 @@ func (r *ReconcileBlobStorage) Reconcile(request reconcile.Request) (reconcile.R
 		if err = r.client.Status().Update(ctx, instance); err != nil {
 			return reconcile.Result{}, errorUtil.Wrapf(err, "failed to update instance %s in namespace %s", instance.Name, instance.Namespace)
 		}
-		return reconcile.Result{Requeue: true, RequeueAfter: time.Second * resources.GetReconcileTime()}, nil
+		return reconcile.Result{Requeue: true, RequeueAfter: p.GetReconcileTime(instance)}, nil
 	}
 
 	// unsupported strategy

--- a/pkg/controller/postgres/postgres_controller.go
+++ b/pkg/controller/postgres/postgres_controller.go
@@ -3,8 +3,6 @@ package postgres
 import (
 	"context"
 	"fmt"
-	"time"
-
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers/aws"
@@ -148,7 +146,7 @@ func (r *ReconcilePostgres) Reconcile(request reconcile.Request) (reconcile.Resu
 			if err = resources.UpdatePhase(ctx, r.client, instance, v1alpha1.PhaseDeleteInProgress, msg); err != nil {
 				return reconcile.Result{}, err
 			}
-			return reconcile.Result{Requeue: true, RequeueAfter: time.Second * resources.GetReconcileTime()}, nil
+			return reconcile.Result{Requeue: true, RequeueAfter: p.GetReconcileTime(instance)}, nil
 		}
 
 		// create the postgres instance
@@ -166,7 +164,7 @@ func (r *ReconcilePostgres) Reconcile(request reconcile.Request) (reconcile.Resu
 			if err = resources.UpdatePhase(ctx, r.client, instance, v1alpha1.PhaseInProgress, msg); err != nil {
 				return reconcile.Result{}, err
 			}
-			return reconcile.Result{Requeue: true, RequeueAfter: time.Second * resources.GetReconcileTime()}, nil
+			return reconcile.Result{Requeue: true, RequeueAfter: p.GetReconcileTime(instance)}, nil
 		}
 
 		// return the connection secret
@@ -182,7 +180,7 @@ func (r *ReconcilePostgres) Reconcile(request reconcile.Request) (reconcile.Resu
 		if err = r.client.Status().Update(ctx, instance); err != nil {
 			return reconcile.Result{}, errorUtil.Wrapf(err, "failed to update instance %s in namespace %s", instance.Name, instance.Namespace)
 		}
-		return reconcile.Result{Requeue: true, RequeueAfter: time.Second * resources.GetReconcileTime()}, nil
+		return reconcile.Result{Requeue: true, RequeueAfter: p.GetReconcileTime(instance)}, nil
 	}
 
 	// unsupported strategy

--- a/pkg/controller/redis/redis_controller.go
+++ b/pkg/controller/redis/redis_controller.go
@@ -3,8 +3,6 @@ package redis
 import (
 	"context"
 	"fmt"
-	"time"
-
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
 
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
@@ -140,7 +138,7 @@ func (r *ReconcileRedis) Reconcile(request reconcile.Request) (reconcile.Result,
 			if err = resources.UpdatePhase(ctx, r.client, instance, v1alpha1.PhaseDeleteInProgress, msg); err != nil {
 				return reconcile.Result{}, err
 			}
-			return reconcile.Result{Requeue: true, RequeueAfter: time.Second * resources.GetReconcileTime()}, nil
+			return reconcile.Result{Requeue: true, RequeueAfter: p.GetReconcileTime(instance)}, nil
 		}
 
 		// handle creation of redis and apply any finalizers to instance required for deletion
@@ -158,7 +156,7 @@ func (r *ReconcileRedis) Reconcile(request reconcile.Request) (reconcile.Result,
 			if err = resources.UpdatePhase(ctx, r.client, instance, v1alpha1.PhaseInProgress, msg); err != nil {
 				return reconcile.Result{}, err
 			}
-			return reconcile.Result{Requeue: true, RequeueAfter: time.Second * resources.GetReconcileTime()}, nil
+			return reconcile.Result{Requeue: true, RequeueAfter: p.GetReconcileTime(instance)}, nil
 		}
 
 		// create the secret with the redis cluster connection details
@@ -175,7 +173,7 @@ func (r *ReconcileRedis) Reconcile(request reconcile.Request) (reconcile.Result,
 		if err = r.client.Status().Update(ctx, instance); err != nil {
 			return reconcile.Result{}, errorUtil.Wrapf(err, "failed to update instance %s in namespace %s", instance.Name, instance.Namespace)
 		}
-		return reconcile.Result{Requeue: true, RequeueAfter: time.Second * resources.GetReconcileTime()}, nil
+		return reconcile.Result{Requeue: true, RequeueAfter: p.GetReconcileTime(instance)}, nil
 	}
 
 	// unsupported strategy

--- a/pkg/controller/smtpcredentialset/smtpcredentialset_controller.go
+++ b/pkg/controller/smtpcredentialset/smtpcredentialset_controller.go
@@ -2,8 +2,6 @@ package smtpcredentialset
 
 import (
 	"context"
-	"time"
-
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
 
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers"
@@ -128,7 +126,7 @@ func (r *ReconcileSMTPCredentialSet) Reconcile(request reconcile.Request) (recon
 			if updateErr := resources.UpdatePhase(ctx, r.client, instance, v1alpha1.PhaseDeleteInProgress, msg); updateErr != nil {
 				return reconcile.Result{}, updateErr
 			}
-			return reconcile.Result{Requeue: true, RequeueAfter: time.Second * resources.GetReconcileTime()}, nil
+			return reconcile.Result{Requeue: true, RequeueAfter: p.GetReconcileTime(instance)}, nil
 		}
 
 		smtpCredentialSetInst, msg, err := p.CreateSMTPCredentials(ctx, instance)
@@ -150,7 +148,7 @@ func (r *ReconcileSMTPCredentialSet) Reconcile(request reconcile.Request) (recon
 		if err = r.client.Status().Update(ctx, instance); err != nil {
 			return reconcile.Result{}, errorUtil.Wrapf(err, "failed to update instance %s in namespace %s", instance.Name, instance.Namespace)
 		}
-		return reconcile.Result{Requeue: true, RequeueAfter: time.Second * resources.GetReconcileTime()}, nil
+		return reconcile.Result{Requeue: true, RequeueAfter: p.GetReconcileTime(instance)}, nil
 	}
 
 	// unsupported strategy

--- a/pkg/controller/smtpcredentialset/smtpcredentialset_controller_test.go
+++ b/pkg/controller/smtpcredentialset/smtpcredentialset_controller_test.go
@@ -107,6 +107,9 @@ func TestReconcileSMTPCredentialSet_Reconcile(t *testing.T) {
 								},
 							}, "", nil
 						},
+						GetReconcileTimeFunc: func(smtpCreds *v1alpha1.SMTPCredentialSet) time.Duration {
+							return time.Second * 10
+						},
 						DeleteSMTPCredentialsFunc: func(ctx context.Context, smtpCreds *v1alpha1.SMTPCredentialSet) (v1alpha1.StatusMessage, error) {
 							return "", nil
 						},
@@ -137,7 +140,7 @@ func TestReconcileSMTPCredentialSet_Reconcile(t *testing.T) {
 			want: struct {
 				Requeue      bool
 				RequeueAfter time.Duration
-			}{Requeue: true, RequeueAfter: resources.GetReconcileTime() * time.Second},
+			}{Requeue: true, RequeueAfter: time.Second * 10},
 			wantErr: false,
 		},
 	}

--- a/pkg/providers/aws/config.go
+++ b/pkg/providers/aws/config.go
@@ -25,6 +25,8 @@ const (
 	DefaultFinalizer = "finalizers.cloud-resources-operator.integreatly.org"
 	DefaultRegion    = "eu-west-1"
 
+	defaultReconcileTime = time.Second * 300
+
 	regionUSEast1 = "us-east-1"
 	regionUSWest2 = "us-west-2"
 	regionEUWest1 = "eu-west-1"

--- a/pkg/providers/aws/provider_blobstorage.go
+++ b/pkg/providers/aws/provider_blobstorage.go
@@ -88,6 +88,13 @@ func (p *BlobStorageProvider) SupportsStrategy(d string) bool {
 	return d == providers.AWSDeploymentStrategy
 }
 
+func (p *BlobStorageProvider) GetReconcileTime(bs *v1alpha1.BlobStorage) time.Duration {
+	if bs.Status.Phase != v1alpha1.PhaseComplete {
+		return time.Second * 60
+	}
+	return resources.GetForcedReconcileTimeOrDefault(defaultReconcileTime)
+}
+
 // custom s3 delete strat
 type S3DeleteStrat struct {
 	_ struct{} `type:"structure"`

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -61,6 +61,8 @@ var (
 	defaultSupportedEngineVersions = []string{"10.6", "9.6", "9.5"}
 )
 
+var _ providers.PostgresProvider = (*AWSPostgresProvider)(nil)
+
 type AWSPostgresProvider struct {
 	Client            client.Client
 	Logger            *logrus.Entry
@@ -83,6 +85,13 @@ func (p *AWSPostgresProvider) GetName() string {
 
 func (p *AWSPostgresProvider) SupportsStrategy(d string) bool {
 	return d == providers.AWSDeploymentStrategy
+}
+
+func (p *AWSPostgresProvider) GetReconcileTime(pg *v1alpha1.Postgres) time.Duration {
+	if pg.Status.Phase != v1alpha1.PhaseComplete {
+		return time.Second * 60
+	}
+	return resources.GetForcedReconcileTimeOrDefault(defaultReconcileTime)
 }
 
 // CreatePostgres creates an RDS Instance from strategy config

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -35,6 +35,8 @@ const (
 	NoFinalSnapshotIdentifier = ""
 )
 
+var _ providers.RedisProvider = (*AWSRedisProvider)(nil)
+
 // AWS Redis Provider implementation for AWS Elasticache
 type AWSRedisProvider struct {
 	Client            client.Client
@@ -59,6 +61,13 @@ func (p *AWSRedisProvider) GetName() string {
 
 func (p *AWSRedisProvider) SupportsStrategy(d string) bool {
 	return d == providers.AWSDeploymentStrategy
+}
+
+func (p *AWSRedisProvider) GetReconcileTime(r *v1alpha1.Redis) time.Duration {
+	if r.Status.Phase != v1alpha1.PhaseComplete {
+		return time.Second * 60
+	}
+	return resources.GetForcedReconcileTimeOrDefault(defaultReconcileTime)
 }
 
 // CreateRedis Create an Elasticache Replication Group from strategy config

--- a/pkg/providers/aws/provider_smtpcredentialset.go
+++ b/pkg/providers/aws/provider_smtpcredentialset.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strconv"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 
@@ -78,6 +79,13 @@ func (p *SMTPCredentialProvider) GetName() string {
 func (p *SMTPCredentialProvider) SupportsStrategy(d string) bool {
 	p.Logger.Infof("checking for support of strategy %s, supported strategies are %s", d, providers.AWSDeploymentStrategy)
 	return providers.AWSDeploymentStrategy == d
+}
+
+func (p *SMTPCredentialProvider) GetReconcileTime(smtpCreds *v1alpha1.SMTPCredentialSet) time.Duration {
+	if smtpCreds.Status.Phase != v1alpha1.PhaseComplete {
+		return time.Second * 30
+	}
+	return resources.GetForcedReconcileTimeOrDefault(defaultReconcileTime)
 }
 
 func (p *SMTPCredentialProvider) CreateSMTPCredentials(ctx context.Context, smtpCreds *v1alpha1.SMTPCredentialSet) (*providers.SMTPCredentialSetInstance, v1alpha1.StatusMessage, error) {

--- a/pkg/providers/openshift/config.go
+++ b/pkg/providers/openshift/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
 
@@ -19,6 +20,8 @@ const (
 	DefaultConfigMapName      = "cloud-resources-openshift-strategies"
 	DefaultConfigMapNamespace = "kube-system"
 	DefaultFinalizer          = "finalizers.cloud-resources-operator.integreatly.org"
+
+	defaultReconcileTime = time.Second * 30
 )
 
 type StrategyConfig struct {

--- a/pkg/providers/types.go
+++ b/pkg/providers/types.go
@@ -2,9 +2,9 @@ package providers
 
 import (
 	"context"
-	"strconv"
-
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
+	"strconv"
+	"time"
 )
 
 //go:generate moq -out types_moq.go . DeploymentDetails BlobStorageProvider SMTPCredentialsProvider
@@ -46,6 +46,7 @@ type PostgresInstance struct {
 type BlobStorageProvider interface {
 	GetName() string
 	SupportsStrategy(s string) bool
+	GetReconcileTime(bs *v1alpha1.BlobStorage) time.Duration
 	CreateStorage(ctx context.Context, bs *v1alpha1.BlobStorage) (*BlobStorageInstance, v1alpha1.StatusMessage, error)
 	DeleteStorage(ctx context.Context, bs *v1alpha1.BlobStorage) (v1alpha1.StatusMessage, error)
 }
@@ -53,6 +54,7 @@ type BlobStorageProvider interface {
 type SMTPCredentialsProvider interface {
 	GetName() string
 	SupportsStrategy(s string) bool
+	GetReconcileTime(smtpCreds *v1alpha1.SMTPCredentialSet) time.Duration
 	CreateSMTPCredentials(ctx context.Context, smtpCreds *v1alpha1.SMTPCredentialSet) (*SMTPCredentialSetInstance, v1alpha1.StatusMessage, error)
 	DeleteSMTPCredentials(ctx context.Context, smtpCreds *v1alpha1.SMTPCredentialSet) (v1alpha1.StatusMessage, error)
 }
@@ -60,6 +62,7 @@ type SMTPCredentialsProvider interface {
 type RedisProvider interface {
 	GetName() string
 	SupportsStrategy(s string) bool
+	GetReconcileTime(r *v1alpha1.Redis) time.Duration
 	CreateRedis(ctx context.Context, r *v1alpha1.Redis) (*RedisCluster, v1alpha1.StatusMessage, error)
 	DeleteRedis(ctx context.Context, r *v1alpha1.Redis) (v1alpha1.StatusMessage, error)
 }
@@ -67,6 +70,7 @@ type RedisProvider interface {
 type PostgresProvider interface {
 	GetName() string
 	SupportsStrategy(s string) bool
+	GetReconcileTime(ps *v1alpha1.Postgres) time.Duration
 	CreatePostgres(ctx context.Context, ps *v1alpha1.Postgres) (*PostgresInstance, v1alpha1.StatusMessage, error)
 	DeletePostgres(ctx context.Context, ps *v1alpha1.Postgres) (v1alpha1.StatusMessage, error)
 }

--- a/pkg/providers/types_moq.go
+++ b/pkg/providers/types_moq.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
 	"sync"
+	"time"
 )
 
 var (
@@ -74,6 +75,7 @@ var (
 	lockBlobStorageProviderMockCreateStorage    sync.RWMutex
 	lockBlobStorageProviderMockDeleteStorage    sync.RWMutex
 	lockBlobStorageProviderMockGetName          sync.RWMutex
+	lockBlobStorageProviderMockGetReconcileTime sync.RWMutex
 	lockBlobStorageProviderMockSupportsStrategy sync.RWMutex
 )
 
@@ -96,6 +98,9 @@ var _ BlobStorageProvider = &BlobStorageProviderMock{}
 //             GetNameFunc: func() string {
 // 	               panic("mock out the GetName method")
 //             },
+//             GetReconcileTimeFunc: func(bs *v1alpha1.BlobStorage) time.Duration {
+// 	               panic("mock out the GetReconcileTime method")
+//             },
 //             SupportsStrategyFunc: func(s string) bool {
 // 	               panic("mock out the SupportsStrategy method")
 //             },
@@ -114,6 +119,9 @@ type BlobStorageProviderMock struct {
 
 	// GetNameFunc mocks the GetName method.
 	GetNameFunc func() string
+
+	// GetReconcileTimeFunc mocks the GetReconcileTime method.
+	GetReconcileTimeFunc func(bs *v1alpha1.BlobStorage) time.Duration
 
 	// SupportsStrategyFunc mocks the SupportsStrategy method.
 	SupportsStrategyFunc func(s string) bool
@@ -136,6 +144,11 @@ type BlobStorageProviderMock struct {
 		}
 		// GetName holds details about calls to the GetName method.
 		GetName []struct {
+		}
+		// GetReconcileTime holds details about calls to the GetReconcileTime method.
+		GetReconcileTime []struct {
+			// Bs is the bs argument value.
+			Bs *v1alpha1.BlobStorage
 		}
 		// SupportsStrategy holds details about calls to the SupportsStrategy method.
 		SupportsStrategy []struct {
@@ -241,6 +254,37 @@ func (mock *BlobStorageProviderMock) GetNameCalls() []struct {
 	return calls
 }
 
+// GetReconcileTime calls GetReconcileTimeFunc.
+func (mock *BlobStorageProviderMock) GetReconcileTime(bs *v1alpha1.BlobStorage) time.Duration {
+	if mock.GetReconcileTimeFunc == nil {
+		panic("BlobStorageProviderMock.GetReconcileTimeFunc: method is nil but BlobStorageProvider.GetReconcileTime was just called")
+	}
+	callInfo := struct {
+		Bs *v1alpha1.BlobStorage
+	}{
+		Bs: bs,
+	}
+	lockBlobStorageProviderMockGetReconcileTime.Lock()
+	mock.calls.GetReconcileTime = append(mock.calls.GetReconcileTime, callInfo)
+	lockBlobStorageProviderMockGetReconcileTime.Unlock()
+	return mock.GetReconcileTimeFunc(bs)
+}
+
+// GetReconcileTimeCalls gets all the calls that were made to GetReconcileTime.
+// Check the length with:
+//     len(mockedBlobStorageProvider.GetReconcileTimeCalls())
+func (mock *BlobStorageProviderMock) GetReconcileTimeCalls() []struct {
+	Bs *v1alpha1.BlobStorage
+} {
+	var calls []struct {
+		Bs *v1alpha1.BlobStorage
+	}
+	lockBlobStorageProviderMockGetReconcileTime.RLock()
+	calls = mock.calls.GetReconcileTime
+	lockBlobStorageProviderMockGetReconcileTime.RUnlock()
+	return calls
+}
+
 // SupportsStrategy calls SupportsStrategyFunc.
 func (mock *BlobStorageProviderMock) SupportsStrategy(s string) bool {
 	if mock.SupportsStrategyFunc == nil {
@@ -276,6 +320,7 @@ var (
 	lockSMTPCredentialsProviderMockCreateSMTPCredentials sync.RWMutex
 	lockSMTPCredentialsProviderMockDeleteSMTPCredentials sync.RWMutex
 	lockSMTPCredentialsProviderMockGetName               sync.RWMutex
+	lockSMTPCredentialsProviderMockGetReconcileTime      sync.RWMutex
 	lockSMTPCredentialsProviderMockSupportsStrategy      sync.RWMutex
 )
 
@@ -298,6 +343,9 @@ var _ SMTPCredentialsProvider = &SMTPCredentialsProviderMock{}
 //             GetNameFunc: func() string {
 // 	               panic("mock out the GetName method")
 //             },
+//             GetReconcileTimeFunc: func(smtpCreds *v1alpha1.SMTPCredentialSet) time.Duration {
+// 	               panic("mock out the GetReconcileTime method")
+//             },
 //             SupportsStrategyFunc: func(s string) bool {
 // 	               panic("mock out the SupportsStrategy method")
 //             },
@@ -316,6 +364,9 @@ type SMTPCredentialsProviderMock struct {
 
 	// GetNameFunc mocks the GetName method.
 	GetNameFunc func() string
+
+	// GetReconcileTimeFunc mocks the GetReconcileTime method.
+	GetReconcileTimeFunc func(smtpCreds *v1alpha1.SMTPCredentialSet) time.Duration
 
 	// SupportsStrategyFunc mocks the SupportsStrategy method.
 	SupportsStrategyFunc func(s string) bool
@@ -338,6 +389,11 @@ type SMTPCredentialsProviderMock struct {
 		}
 		// GetName holds details about calls to the GetName method.
 		GetName []struct {
+		}
+		// GetReconcileTime holds details about calls to the GetReconcileTime method.
+		GetReconcileTime []struct {
+			// SmtpCreds is the smtpCreds argument value.
+			SmtpCreds *v1alpha1.SMTPCredentialSet
 		}
 		// SupportsStrategy holds details about calls to the SupportsStrategy method.
 		SupportsStrategy []struct {
@@ -440,6 +496,37 @@ func (mock *SMTPCredentialsProviderMock) GetNameCalls() []struct {
 	lockSMTPCredentialsProviderMockGetName.RLock()
 	calls = mock.calls.GetName
 	lockSMTPCredentialsProviderMockGetName.RUnlock()
+	return calls
+}
+
+// GetReconcileTime calls GetReconcileTimeFunc.
+func (mock *SMTPCredentialsProviderMock) GetReconcileTime(smtpCreds *v1alpha1.SMTPCredentialSet) time.Duration {
+	if mock.GetReconcileTimeFunc == nil {
+		panic("SMTPCredentialsProviderMock.GetReconcileTimeFunc: method is nil but SMTPCredentialsProvider.GetReconcileTime was just called")
+	}
+	callInfo := struct {
+		SmtpCreds *v1alpha1.SMTPCredentialSet
+	}{
+		SmtpCreds: smtpCreds,
+	}
+	lockSMTPCredentialsProviderMockGetReconcileTime.Lock()
+	mock.calls.GetReconcileTime = append(mock.calls.GetReconcileTime, callInfo)
+	lockSMTPCredentialsProviderMockGetReconcileTime.Unlock()
+	return mock.GetReconcileTimeFunc(smtpCreds)
+}
+
+// GetReconcileTimeCalls gets all the calls that were made to GetReconcileTime.
+// Check the length with:
+//     len(mockedSMTPCredentialsProvider.GetReconcileTimeCalls())
+func (mock *SMTPCredentialsProviderMock) GetReconcileTimeCalls() []struct {
+	SmtpCreds *v1alpha1.SMTPCredentialSet
+} {
+	var calls []struct {
+		SmtpCreds *v1alpha1.SMTPCredentialSet
+	}
+	lockSMTPCredentialsProviderMockGetReconcileTime.RLock()
+	calls = mock.calls.GetReconcileTime
+	lockSMTPCredentialsProviderMockGetReconcileTime.RUnlock()
 	return calls
 }
 

--- a/pkg/resources/config.go
+++ b/pkg/resources/config.go
@@ -11,19 +11,21 @@ import (
 	errorUtil "github.com/pkg/errors"
 )
 
-const DefaulReconcileTime = 300
+const (
+	EnvForceReconcileTimeout = "ENV_FORCE_RECONCILE_TIMEOUT"
+)
 
 // returns envar for reconcile time else returns default time
-func GetReconcileTime() time.Duration {
-	recTime, exist := os.LookupEnv("RECTIME")
+func GetForcedReconcileTimeOrDefault(defaultTo time.Duration) time.Duration {
+	recTime, exist := os.LookupEnv(EnvForceReconcileTimeout)
 	if exist {
 		rt, err := strconv.ParseInt(recTime, 10, 64)
 		if err != nil {
-			return time.Duration(DefaulReconcileTime)
+			return defaultTo
 		}
 		return time.Duration(rt)
 	}
-	return time.Duration(DefaulReconcileTime)
+	return defaultTo
 }
 
 func GeneratePassword() (string, error) {

--- a/pkg/resources/config_test.go
+++ b/pkg/resources/config_test.go
@@ -6,39 +6,40 @@ import (
 	"time"
 )
 
-func TestGetReconcileTime(t *testing.T) {
+func TestGetForcedReconcileTimeOrDefault(t *testing.T) {
 	type args struct {
-		recTime string
+		defaultTo time.Duration
 	}
 	var tests = []struct {
-		name string
-		want time.Duration
-		args args
+		name                  string
+		want                  time.Duration
+		envForceReconcileTime string
+		args                  args
 	}{
 		{
 			name: "test function returns default",
 			args: args{
-				recTime: "",
+				defaultTo: time.Second * 60,
 			},
-			want: time.Duration(DefaulReconcileTime),
+			want: time.Second * 60,
 		},
 		{
 			name: "test accepts env var and returns value",
 			args: args{
-				recTime: "30",
+				defaultTo: time.Second * 60,
 			},
-			want: time.Duration(30),
+			envForceReconcileTime: "30",
+			want:                  time.Nanosecond * 30,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.args.recTime != "" {
-				err := os.Setenv("RECTIME", tt.args.recTime)
-				if err != nil {
-					t.Error(err)
+			if tt.envForceReconcileTime != "" {
+				if err := os.Setenv(EnvForceReconcileTimeout, tt.envForceReconcileTime); err != nil {
+					t.Errorf("GetReconcileTime() err = %v", err)
 				}
 			}
-			if got := GetReconcileTime(); got != tt.want {
+			if got := GetForcedReconcileTimeOrDefault(tt.args.defaultTo); got != tt.want {
 				t.Errorf("GetReconcileTime() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
currently we have a global override for the reconcile timings in
each resource type. however this should be more individual instead
of allowing a controller to decide what the timings should be.

this change performs a slight refactor to the current reconcile
time override function and also ensures each provider can return
it's own reconcile time based on knowledge of the cr state.