### PR TITLE
ensure unsupported provided and tiers are included in status block

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -388,6 +388,7 @@ github.com/rogpeppe/go-internal v1.3.0 h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhg
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday v0.0.0-20151117072312-300106c228d5/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sclevine/spec v1.0.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
+github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.1.1/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=

--- a/pkg/apis/integreatly/v1alpha1/types.go
+++ b/pkg/apis/integreatly/v1alpha1/types.go
@@ -1,11 +1,15 @@
 package v1alpha1
 
+import "fmt"
+
 var (
-	PhaseInProgress       StatusPhase   = "in progress"
-	PhaseDeleteInProgress StatusPhase   = "deletion in progress"
-	PhaseComplete         StatusPhase   = "complete"
-	PhaseFailed           StatusPhase   = "failed"
-	StatusEmpty           StatusMessage = ""
+	PhaseInProgress                StatusPhase   = "in progress"
+	PhaseDeleteInProgress          StatusPhase   = "deletion in progress"
+	PhaseComplete                  StatusPhase   = "complete"
+	PhaseFailed                    StatusPhase   = "failed"
+	StatusEmpty                    StatusMessage = ""
+	StatusUnsupportedType          StatusMessage = "unsupported deployment type"
+	StatusDeploymentConfigNotFound StatusMessage = "deployment configuration not found"
 )
 
 // SecretRef Represents a namespace-scoped Secret
@@ -22,7 +26,15 @@ type ResourceTypeSpec struct {
 }
 
 type StatusPhase string
+
 type StatusMessage string
+
+func (sm StatusMessage) WrapError(err error) StatusMessage {
+	if err == nil {
+		return sm
+	}
+	return StatusMessage(fmt.Sprintf("%s: %s", sm, err.Error()))
+}
 
 // ResourceTypeStatus Represents the basic status information provided by a resource provider
 type ResourceTypeStatus struct {

--- a/pkg/apis/integreatly/v1alpha1/types_test.go
+++ b/pkg/apis/integreatly/v1alpha1/types_test.go
@@ -1,0 +1,38 @@
+package v1alpha1
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestStatusMessage_WrapError(t *testing.T) {
+	type args struct {
+		err error
+	}
+	tests := []struct {
+		name string
+		sm   StatusMessage
+		args args
+		want StatusMessage
+	}{
+		{
+			name: "test error message displays as expected",
+			sm:   "test",
+			args: args{err: fmt.Errorf("error")},
+			want: "test: error",
+		},
+		{
+			name: "test error is ignored when nil",
+			sm:   "test",
+			args: args{err: nil},
+			want: "test",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.sm.WrapError(tt.args.err); got != tt.want {
+				t.Errorf("WrapError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/smtpcredentialset/smtpcredentialset_controller.go
+++ b/pkg/controller/smtpcredentialset/smtpcredentialset_controller.go
@@ -99,7 +99,7 @@ func (r *ReconcileSMTPCredentialSet) Reconcile(request reconcile.Request) (recon
 
 	stratMap, err := cfgMgr.GetStrategyMappingForDeploymentType(ctx, instance.Spec.Type)
 	if err != nil {
-		if updateErr := resources.UpdatePhase(ctx, r.client, instance, v1alpha1.PhaseFailed, "failed to read deployment type config for deployment"); updateErr != nil {
+		if updateErr := resources.UpdatePhase(ctx, r.client, instance, v1alpha1.PhaseFailed, v1alpha1.StatusDeploymentConfigNotFound.WrapError(err)); updateErr != nil {
 			return reconcile.Result{}, updateErr
 		}
 		return reconcile.Result{}, errorUtil.Wrapf(err, "failed to read deployment type config for deployment %s", instance.Spec.Type)
@@ -116,7 +116,7 @@ func (r *ReconcileSMTPCredentialSet) Reconcile(request reconcile.Request) (recon
 			r.logger.Infof("running deletion handler on smtp credential instance %s", instance.Name)
 			msg, err := p.DeleteSMTPCredentials(ctx, instance)
 			if err != nil {
-				if updateErr := resources.UpdatePhase(ctx, r.client, instance, v1alpha1.PhaseFailed, msg); updateErr != nil {
+				if updateErr := resources.UpdatePhase(ctx, r.client, instance, v1alpha1.PhaseFailed, msg.WrapError(err)); updateErr != nil {
 					return reconcile.Result{}, updateErr
 				}
 				return reconcile.Result{}, errorUtil.Wrapf(err, "failed to run delete handler for smtp credentials instance %s", instance.Name)
@@ -131,7 +131,7 @@ func (r *ReconcileSMTPCredentialSet) Reconcile(request reconcile.Request) (recon
 
 		smtpCredentialSetInst, msg, err := p.CreateSMTPCredentials(ctx, instance)
 		if err != nil {
-			if updateErr := resources.UpdatePhase(ctx, r.client, instance, v1alpha1.PhaseFailed, msg); updateErr != nil {
+			if updateErr := resources.UpdatePhase(ctx, r.client, instance, v1alpha1.PhaseFailed, msg.WrapError(err)); updateErr != nil {
 				return reconcile.Result{}, updateErr
 			}
 			return reconcile.Result{}, errorUtil.Wrapf(err, "failed to create smtp credential set for instance %s", instance.Name)
@@ -152,7 +152,7 @@ func (r *ReconcileSMTPCredentialSet) Reconcile(request reconcile.Request) (recon
 	}
 
 	// unsupported strategy
-	if updatePhaseErr := resources.UpdatePhase(ctx, r.client, instance, v1alpha1.PhaseFailed, "unsupported deployment strategy"); updatePhaseErr != nil {
+	if updatePhaseErr := resources.UpdatePhase(ctx, r.client, instance, v1alpha1.PhaseFailed, v1alpha1.StatusUnsupportedType.WrapError(err)); updatePhaseErr != nil {
 		return reconcile.Result{}, updatePhaseErr
 	}
 	return reconcile.Result{Requeue: true}, nil

--- a/pkg/providers/aws/config.go
+++ b/pkg/providers/aws/config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
@@ -112,6 +111,9 @@ func (m *ConfigMapConfigManager) getTierStrategyForProvider(ctx context.Context,
 	if err = json.Unmarshal([]byte(rawStrategyMapping), &strategyMapping); err != nil {
 		return nil, errorUtil.Wrapf(err, "failed to unmarshal strategy mapping for resource type %s", rt)
 	}
+	if strategyMapping[tier] == nil {
+		return nil, errorUtil.New(fmt.Sprintf("no strategy found for deployment type %s and deployment tier %s", rt, tier))
+	}
 	return strategyMapping[tier], nil
 }
 
@@ -135,8 +137,7 @@ func buildInfraNameFromObject(ctx context.Context, c client.Client, om controlle
 	if err != nil {
 		return "", errorUtil.Wrap(err, "failed to retrieve cluster identifier")
 	}
-	str := resources.ShortenString(fmt.Sprintf("%s-%s-%s", clusterId, om.Namespace, om.Name), n)
-	return strings.Replace(str, "_", "", -1), nil
+	return resources.ShortenString(fmt.Sprintf("%s-%s-%s", clusterId, om.Namespace, om.Name), n), nil
 }
 
 func buildTimestampedInfraNameFromObject(ctx context.Context, c client.Client, om controllerruntime.ObjectMeta, n int) (string, error) {

--- a/pkg/providers/config_test.go
+++ b/pkg/providers/config_test.go
@@ -82,6 +82,7 @@ func TestConfigManager_GetStrategyMappingForDeploymentType(t *testing.T) {
 		name           string
 		cmName         string
 		cmNamespace    string
+		deployType     string
 		client         client.Client
 		expectError    bool
 		validateConfig func(dtc *DeploymentStrategyMapping) error
@@ -91,6 +92,7 @@ func TestConfigManager_GetStrategyMappingForDeploymentType(t *testing.T) {
 			cmName:      "test",
 			cmNamespace: "test",
 			client:      fakeClient,
+			deployType:  ManagedDeploymentType,
 			validateConfig: func(dtc *DeploymentStrategyMapping) error {
 				if dtc.BlobStorage != AWSDeploymentStrategy {
 					return errors.New("strategy mapping has incorrect structure")
@@ -98,11 +100,19 @@ func TestConfigManager_GetStrategyMappingForDeploymentType(t *testing.T) {
 				return nil
 			},
 		},
+		{
+			name:        "test error when strategy isn't found for tier",
+			cmName:      "test",
+			cmNamespace: "test",
+			deployType:  "test",
+			client:      fakeClient,
+			expectError: true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			cm := NewConfigManager(tc.cmName, tc.cmNamespace, tc.client)
-			dtc, err := cm.GetStrategyMappingForDeploymentType(context.TODO(), ManagedDeploymentType)
+			dtc, err := cm.GetStrategyMappingForDeploymentType(context.TODO(), tc.deployType)
 			if err != nil {
 				if tc.expectError {
 					return

--- a/pkg/providers/openshift/config.go
+++ b/pkg/providers/openshift/config.go
@@ -73,9 +73,10 @@ func (m *ConfigMapConfigManager) ReadStorageStrategy(ctx context.Context, rt pro
 	if err = json.Unmarshal([]byte(rawStrategyCfg), &strategies); err != nil {
 		return nil, errorUtil.Wrapf(err, "failed to unmarshal strategy mapping for resource type %s", rt)
 	}
-	tierStrat := strategies[tier]
-
-	return tierStrat, nil
+	if strategies[tier] == nil {
+		return nil, errorUtil.New(fmt.Sprintf("no strategy found for deployment type %s and deployment tier %s", rt, tier))
+	}
+	return strategies[tier], nil
 }
 
 func (m *ConfigMapConfigManager) buildDefaultConfigMap() *v1.ConfigMap {

--- a/pkg/providers/openshift/config_test.go
+++ b/pkg/providers/openshift/config_test.go
@@ -67,12 +67,22 @@ func TestConfigManager_ReadBlobStorageStrategy(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to marshal strategy config", err)
 	}
+	fakeClient := fake.NewFakeClientWithScheme(scheme, &v1.ConfigMap{
+		ObjectMeta: controllerruntime.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Data: map[string]string{
+			"blobstorage": fmt.Sprintf("{\"test\": %s}", string(rawStratCfg)),
+		},
+	})
 	cases := []struct {
 		name                string
 		cmName              string
 		cmNamespace         string
 		tier                string
 		expectedRawStrategy string
+		expectErr           bool
 		client              client.Client
 	}{
 		{
@@ -81,15 +91,15 @@ func TestConfigManager_ReadBlobStorageStrategy(t *testing.T) {
 			cmNamespace:         "test",
 			tier:                "test",
 			expectedRawStrategy: string(sc.RawStrategy),
-			client: fake.NewFakeClientWithScheme(scheme, &v1.ConfigMap{
-				ObjectMeta: controllerruntime.ObjectMeta{
-					Name:      "test",
-					Namespace: "test",
-				},
-				Data: map[string]string{
-					"blobstorage": fmt.Sprintf("{\"test\": %s}", string(rawStratCfg)),
-				},
-			}),
+			client:              fakeClient,
+		},
+		{
+			name:        "test error returned when tier does not exist",
+			cmName:      "test",
+			cmNamespace: "test",
+			tier:        "doesnotexist",
+			expectErr:   true,
+			client:      fakeClient,
 		},
 	}
 	for _, tc := range cases {
@@ -97,6 +107,9 @@ func TestConfigManager_ReadBlobStorageStrategy(t *testing.T) {
 			cm := NewConfigMapConfigManager(tc.cmName, tc.cmNamespace, tc.client)
 			sc, err := cm.ReadStorageStrategy(context.TODO(), providers.BlobStorageResourceType, tc.tier)
 			if err != nil {
+				if tc.expectErr {
+					return
+				}
 				t.Fatal("unexpected error", err)
 			}
 			if string(sc.RawStrategy) != tc.expectedRawStrategy {

--- a/pkg/resources/strings_test.go
+++ b/pkg/resources/strings_test.go
@@ -19,7 +19,7 @@ func TestShortenString(t *testing.T) {
 				s: "my-super-long-test-name",
 				n: 12,
 			},
-			want:    "my-supe-d07q",
+			want:    "mysuper-nm7v",
 			wantLen: 12,
 		},
 		{
@@ -28,7 +28,7 @@ func TestShortenString(t *testing.T) {
 				s: "23",
 				n: -1,
 			},
-			want:    "23-u1-j",
+			want:    "23-knp2",
 			wantLen: 7,
 		},
 		{
@@ -39,6 +39,15 @@ func TestShortenString(t *testing.T) {
 			},
 			want:    "testtest",
 			wantLen: 8,
+		},
+		{
+			name: "test hyphens are ignored in strings",
+			args: args{
+				s: "dimitra-qvxxg-integreatly-operator-some-other-text",
+				n: 40,
+			},
+			want:    "dimitraqvxxgintegreatlyoperatorsome-44q7",
+			wantLen: 40,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
currently, when there is not a provider for the type of the cr a
message is returned.

this change ensures the message returned is a standard.

currently, when an error occurs in a provider, only an overview
message is returned to the status block of the cr.

this change adds a WrapError function to act on the StatusMessage
struct that includes the returned string from the Error function
of an underlying error. This makes the status block slightly more
verbose in error situations.

currently, it is possible that the string returned from the util
string shortening function, ShortenString, is not url or aws
resource name-safe. this is due to a number of reasons that allow
for characters such as underscores due to base64 encoding or double
hyphens due to the way there was no preprocessing on the provided
string.

this change swaps to base32 encoding which does not include any
special characters and ensures all non-alphanumeric characters are
removed from the original provided string before processing the
string.