### PR TITLE
update make cluster clean to remove config maps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ cluster/clean:
 	oc delete -f ./deploy/crds/integreatly_v1alpha1_blobstorage_crd.yaml
 	oc delete -f ./deploy/crds/integreatly_v1alpha1_smtpcredentialset_crd.yaml
 	oc delete -f ./deploy/crds/integreatly_v1alpha1_redis_crd.yaml
+	oc delete -f ./deploy/examples/
 	oc delete project $(NAMESPACE)
 
 .PHONY: test/unit/setup


### PR DESCRIPTION
## Overview

Currently we do not remove config-maps in our make clean.

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Ensure the config-maps have been created
- Run `make cluster/clean`
- Ensure the config-maps have been removed