### PR TITLE
Run e2e tests with local operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,10 @@ test/unit/setup:
 	go get -u github.com/rakyll/gotest
 
 .PHONY: test/e2e
-test/e2e:
+test/e2e: cluster/prepare
 	@echo Running e2e tests:
-	operator-sdk test local ./test/e2e --go-test-flags "-v"
-
+	operator-sdk --verbose test local ./test/e2e --namespace $(NAMESPACE) --up-local --go-test-flags "-timeout=60m" --debug
+	oc delete project $(NAMESPACE)
 
 .PHONY: test/unit
 test/unit:

--- a/test/e2e/cro_test.go
+++ b/test/e2e/cro_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis"
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
-	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
-
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 )
 
@@ -49,17 +47,9 @@ func CROCluster(t *testing.T) {
 		t.Fatalf("failed to initialize cluster resources: %v", err)
 	}
 	t.Log("initialized cluster resources")
-	namespace, err := ctx.GetNamespace()
-	if err != nil {
-		t.Fatal(err)
-	}
+
 	// get global framework variables
 	f := framework.Global
-	// wait for cloud-resource-operator to be ready
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "cloud-resource-operator", 1, retryInterval, timeout)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	// run postgres test
 	if err = PostgresBasicTest(t, f, *ctx); err != nil {


### PR DESCRIPTION
## Overview

Currently we are running e2e tests from a built image of the operator, to allow for easier CI we need to run the operator locally during testing.

## Verification

- Clone this branch
- Run `make cluster/clean`
- Run `make test/e2e`
- Ensure tests pass