### PR TITLE
Openshift Basic Providers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ test/e2e/image:
 .PHONY: test/unit
 test/unit:
 	@echo Running tests:
+	go get -u github.com/rakyll/gotest
 	gotest -v -covermode=count -coverprofile=coverage.out ./pkg/controller/... ./pkg/providers/... ./pkg/resources/... ./pkg/apis/integreatly/v1alpha1/types/...
 
 .PHONY: test/unit/coverage

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,7 @@
 module github.com/integr8ly/cloud-resource-operator
 
 require (
-	github.com/ant31/crd-validation v0.0.0-20180801212718-38f6a293f140 // indirect
 	github.com/aws/aws-sdk-go v1.23.17
-	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
@@ -11,12 +9,10 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
-	github.com/hashicorp/go-version v1.2.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/lib/pq v1.2.0
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
-	github.com/mitchellh/hashstructure v1.0.0 // indirect
 	github.com/onsi/ginkgo v1.10.1 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/openshift/api v3.9.1-0.20191002160657-d92789481b05+incompatible
@@ -26,7 +22,7 @@ require (
 	github.com/prometheus/client_golang v1.1.0 // indirect
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect
 	github.com/prometheus/procfs v0.0.4 // indirect
-	github.com/rakyll/gotest v0.0.0-20180125184505-86f0749cd8cc
+	github.com/rakyll/gotest v0.0.0-20191108192113-45d501058f2a
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.4.0 // indirect
@@ -35,6 +31,7 @@ require (
 	golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392 // indirect
 	golang.org/x/net v0.0.0-20191003171128-d98b1b443823 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
+	golang.org/x/sys v0.0.0-20191110163157-d32e6e3b99c4 // indirect
 	golang.org/x/tools v0.0.0-20190924052046-3ac2a5bbd98a // indirect
 	google.golang.org/appengine v1.6.2 // indirect
 	google.golang.org/grpc v1.22.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,9 @@
 module github.com/integr8ly/cloud-resource-operator
 
 require (
+	github.com/ant31/crd-validation v0.0.0-20180801212718-38f6a293f140 // indirect
 	github.com/aws/aws-sdk-go v1.23.17
+	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
@@ -9,10 +11,12 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
+	github.com/hashicorp/go-version v1.2.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/lib/pq v1.2.0
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
+	github.com/mitchellh/hashstructure v1.0.0 // indirect
 	github.com/onsi/ginkgo v1.10.1 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/openshift/api v3.9.1-0.20191002160657-d92789481b05+incompatible

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
-github.com/ant31/crd-validation v0.0.0-20180801212718-38f6a293f140 h1:ljF9TLBK+JYXKB8aklLhcubPDBUjpvzWKiqgZ37s+QY=
-github.com/ant31/crd-validation v0.0.0-20180801212718-38f6a293f140/go.mod h1:X0noFIik9YqfhGYBLEHg8LJKEwy7QIitLQuFMpKLcPk=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30 h1:Kn3rqvbUFqSepE2OqVu0Pn1CbDw9IuMlONapol0zuwk=
 github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30/go.mod h1:4AJxUpXUhv4N+ziTvIcWWXgeorXpxPZOfk9HdEVr96M=
@@ -46,8 +44,6 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
-github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/census-instrumentation/opencensus-proto v0.2.0 h1:LzQXZOgg4CQfE6bFvXGM30YZL1WW/M337pXml+GrcZ4=
@@ -230,8 +226,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.6.3/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpg
 github.com/grpc-ecosystem/grpc-gateway v1.8.5 h1:2+KSC78XiO6Qy0hIjfc1OD9H+hsaJdJlb8Kqsd41CTE=
 github.com/grpc-ecosystem/grpc-gateway v1.8.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-health-probe v0.2.0/go.mod h1:4GVx/bTCtZaSzhjbGueDY5YgBdsmKeVx+LErv/n0L6s=
-github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
-github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.0.0-20160207214719-a0d98a5f2880/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -301,8 +295,6 @@ github.com/maxbrunsfeld/counterfeiter v0.0.0-20181017030959-1aadac120687/go.mod 
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
-github.com/mitchellh/hashstructure v1.0.0 h1:ZkRJX1CyOoTkar7p/mLS5TZU4nJ1Rn/F8u9dGS02Q3Y=
-github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
@@ -390,6 +382,8 @@ github.com/prometheus/procfs v0.0.4 h1:w8DjqFMJDjuVwdZBQoOozr4MVWOnwF7RcL/7uxBjY
 github.com/prometheus/procfs v0.0.4/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/rakyll/gotest v0.0.0-20180125184505-86f0749cd8cc h1:hrzpgS8mnUi65ieVrD3TKJMxHP84bzmybMTQIdK/XhM=
 github.com/rakyll/gotest v0.0.0-20180125184505-86f0749cd8cc/go.mod h1:iln+RRtJaJ52lKwqrSmNgQYw32Fk16CgChX85eFqBgI=
+github.com/rakyll/gotest v0.0.0-20191108192113-45d501058f2a h1:/kX+lZpr87Pb0yJKyxW40ZZO6jl52jFMmoQ0YhfwGLM=
+github.com/rakyll/gotest v0.0.0-20191108192113-45d501058f2a/go.mod h1:jpFrc1UTqK0FtfF3doi3pEUBgWHYELkOPPECUlDsM2Q=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/robfig/cron v0.0.0-20170526150127-736158dc09e1/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
@@ -546,6 +540,8 @@ golang.org/x/sys v0.0.0-20190922100055-0a153f010e69 h1:rOhMmluY6kLMhdnrivzec6lLg
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be h1:QAcqgptGM8IQBC9K/RC4o+O9YmqEm0diQn9QmZw/0mU=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191110163157-d32e6e3b99c4 h1:Hynbrlo6LbYI3H1IqXpkVDOcX/3HiPdhVEuyj5a59RM=
+golang.org/x/sys v0.0.0-20191110163157-d32e6e3b99c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
+github.com/ant31/crd-validation v0.0.0-20180801212718-38f6a293f140 h1:ljF9TLBK+JYXKB8aklLhcubPDBUjpvzWKiqgZ37s+QY=
+github.com/ant31/crd-validation v0.0.0-20180801212718-38f6a293f140/go.mod h1:X0noFIik9YqfhGYBLEHg8LJKEwy7QIitLQuFMpKLcPk=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30 h1:Kn3rqvbUFqSepE2OqVu0Pn1CbDw9IuMlONapol0zuwk=
 github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30/go.mod h1:4AJxUpXUhv4N+ziTvIcWWXgeorXpxPZOfk9HdEVr96M=
@@ -44,6 +46,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/census-instrumentation/opencensus-proto v0.2.0 h1:LzQXZOgg4CQfE6bFvXGM30YZL1WW/M337pXml+GrcZ4=
@@ -226,6 +230,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.6.3/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpg
 github.com/grpc-ecosystem/grpc-gateway v1.8.5 h1:2+KSC78XiO6Qy0hIjfc1OD9H+hsaJdJlb8Kqsd41CTE=
 github.com/grpc-ecosystem/grpc-gateway v1.8.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-health-probe v0.2.0/go.mod h1:4GVx/bTCtZaSzhjbGueDY5YgBdsmKeVx+LErv/n0L6s=
+github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
+github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.0.0-20160207214719-a0d98a5f2880/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -295,6 +301,8 @@ github.com/maxbrunsfeld/counterfeiter v0.0.0-20181017030959-1aadac120687/go.mod 
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/hashstructure v1.0.0 h1:ZkRJX1CyOoTkar7p/mLS5TZU4nJ1Rn/F8u9dGS02Q3Y=
+github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=

--- a/pkg/controller/blobstorage/blobstorage_controller.go
+++ b/pkg/controller/blobstorage/blobstorage_controller.go
@@ -3,11 +3,9 @@ package blobstorage
 import (
 	"context"
 	"fmt"
-<<<<<<< HEAD
+
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
-=======
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers/openshift"
->>>>>>> add basic blobstorage and smtp providers for openshift
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
 
 	"github.com/sirupsen/logrus"

--- a/pkg/controller/blobstorage/blobstorage_controller.go
+++ b/pkg/controller/blobstorage/blobstorage_controller.go
@@ -3,7 +3,11 @@ package blobstorage
 import (
 	"context"
 	"fmt"
+<<<<<<< HEAD
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
+=======
+	"github.com/integr8ly/cloud-resource-operator/pkg/providers/openshift"
+>>>>>>> add basic blobstorage and smtp providers for openshift
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
 
 	"github.com/sirupsen/logrus"
@@ -37,7 +41,7 @@ func Add(mgr manager.Manager) error {
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	client := mgr.GetClient()
 	logger := logrus.WithFields(logrus.Fields{"controller": "controller_blobstorage"})
-	providerList := []providers.BlobStorageProvider{aws.NewAWSBlobStorageProvider(client, logger)}
+	providerList := []providers.BlobStorageProvider{aws.NewAWSBlobStorageProvider(client, logger), openshift.NewBlobStorageProvider(client, logger)}
 	rp := resources.NewResourceProvider(client, mgr.GetScheme(), logger)
 	return &ReconcileBlobStorage{
 		client:           client,

--- a/pkg/controller/smtpcredentialset/smtpcredentialset_controller.go
+++ b/pkg/controller/smtpcredentialset/smtpcredentialset_controller.go
@@ -2,11 +2,9 @@ package smtpcredentialset
 
 import (
 	"context"
-<<<<<<< HEAD
+
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
-=======
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers/openshift"
->>>>>>> add basic blobstorage and smtp providers for openshift
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
 
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers"

--- a/pkg/controller/smtpcredentialset/smtpcredentialset_controller.go
+++ b/pkg/controller/smtpcredentialset/smtpcredentialset_controller.go
@@ -2,7 +2,11 @@ package smtpcredentialset
 
 import (
 	"context"
+<<<<<<< HEAD
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
+=======
+	"github.com/integr8ly/cloud-resource-operator/pkg/providers/openshift"
+>>>>>>> add basic blobstorage and smtp providers for openshift
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
 
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers"
@@ -35,7 +39,7 @@ func Add(mgr manager.Manager) error {
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	client := mgr.GetClient()
 	logger := logrus.WithFields(logrus.Fields{"controller": "controller_smtpcredentialset"})
-	providerList := []providers.SMTPCredentialsProvider{aws.NewAWSSMTPCredentialProvider(client, logger)}
+	providerList := []providers.SMTPCredentialsProvider{aws.NewAWSSMTPCredentialProvider(client, logger), openshift.NewSMTPCredentialSetProvider(client, logger)}
 	rp := resources.NewResourceProvider(client, mgr.GetScheme(), logger)
 	return &ReconcileSMTPCredentialSet{
 		client:           mgr.GetClient(),

--- a/pkg/providers/aws/provider_blobstorage.go
+++ b/pkg/providers/aws/provider_blobstorage.go
@@ -38,11 +38,11 @@ const (
 	blobstorageProviderName    = "aws-s3"
 	defaultAwsBucketNameLength = 40
 	// default create options
-	dataBucketName             = "bucketName"
-	dataBucketRegion           = "bucketRegion"
-	dataCredentialKeyID        = "credentialKeyID"
-	dataCredentialSecretKey    = "credentialSecretKey"
-	defaultForceBucketDeletion = false
+	DetailsBlobStorageBucketName          = "bucketName"
+	DetailsBlobStorageBucketRegion        = "bucketRegion"
+	DetailsBlobStorageCredentialKeyID     = "credentialKeyID"
+	DetailsBlobStorageCredentialSecretKey = "credentialSecretKey"
+	defaultForceBucketDeletion            = false
 )
 
 // BlobStorageDeploymentDetails Provider-specific details about the AWS S3 bucket created
@@ -55,10 +55,10 @@ type BlobStorageDeploymentDetails struct {
 
 func (d *BlobStorageDeploymentDetails) Data() map[string][]byte {
 	return map[string][]byte{
-		dataBucketName:          []byte(d.BucketName),
-		dataBucketRegion:        []byte(d.BucketRegion),
-		dataCredentialKeyID:     []byte(d.CredentialKeyID),
-		dataCredentialSecretKey: []byte(d.CredentialSecretKey),
+		DetailsBlobStorageBucketName:          []byte(d.BucketName),
+		DetailsBlobStorageBucketRegion:        []byte(d.BucketRegion),
+		DetailsBlobStorageCredentialKeyID:     []byte(d.CredentialKeyID),
+		DetailsBlobStorageCredentialSecretKey: []byte(d.CredentialSecretKey),
 	}
 }
 

--- a/pkg/providers/aws/provider_smtpcredentialset.go
+++ b/pkg/providers/aws/provider_smtpcredentialset.go
@@ -29,11 +29,11 @@ import (
 const (
 	smtpCredentialProviderName = "aws-ses"
 	// default create options
-	detailsSMTPUsernameKey = "username"
-	detailsSMTPPasswordKey = "password"
-	detailsSMTPPortKey     = "port"
-	detailsSMTPHostKey     = "host"
-	detailsSMTPTLSKey      = "tls"
+	DetailsSMTPUsernameKey = "username"
+	DetailsSMTPPasswordKey = "password"
+	DetailsSMTPPortKey     = "port"
+	DetailsSMTPHostKey     = "host"
+	DetailsSMTPTLSKey      = "tls"
 )
 
 // SMTPCredentialSetDetails Provider-specific details about SMTP credentials derived from an AWS IAM role
@@ -47,11 +47,11 @@ type SMTPCredentialSetDetails struct {
 
 func (d *SMTPCredentialSetDetails) Data() map[string][]byte {
 	return map[string][]byte{
-		detailsSMTPUsernameKey: []byte(d.Username),
-		detailsSMTPPasswordKey: []byte(d.Password),
-		detailsSMTPPortKey:     []byte(strconv.Itoa(d.Port)),
-		detailsSMTPHostKey:     []byte(d.Host),
-		detailsSMTPTLSKey:      []byte(strconv.FormatBool(d.TLS)),
+		DetailsSMTPUsernameKey: []byte(d.Username),
+		DetailsSMTPPasswordKey: []byte(d.Password),
+		DetailsSMTPPortKey:     []byte(strconv.Itoa(d.Port)),
+		DetailsSMTPHostKey:     []byte(d.Host),
+		DetailsSMTPTLSKey:      []byte(strconv.FormatBool(d.TLS)),
 	}
 }
 
@@ -139,7 +139,7 @@ func (p *SMTPCredentialProvider) CreateSMTPCredentials(ctx context.Context, smtp
 		DeploymentDetails: &SMTPCredentialSetDetails{
 			Username: sendMailCreds.AccessKeyID,
 			Password: smtpPass,
-			Port:     465,
+			Port:     587,
 			Host:     sesSMTPHost,
 			TLS:      true,
 		},

--- a/pkg/providers/aws/provider_smtpcredentialset_test.go
+++ b/pkg/providers/aws/provider_smtpcredentialset_test.go
@@ -339,11 +339,11 @@ func TestSMTPCredentialProvider_CreateSMTPCredentials(t *testing.T) {
 				return nil
 			},
 			wantData: map[string][]byte{
-				detailsSMTPUsernameKey: []byte("test"),
-				detailsSMTPPasswordKey: []byte("AsuNxtdhciTpIaQYwF9CtO/nlNX2hCZkD8E+4vZzrjs0"),
-				detailsSMTPPortKey:     []byte("465"),
-				detailsSMTPHostKey:     []byte(sesSMTPEndpointEUWest1),
-				detailsSMTPTLSKey:      []byte("true"),
+				DetailsSMTPUsernameKey: []byte("test"),
+				DetailsSMTPPasswordKey: []byte("AsuNxtdhciTpIaQYwF9CtO/nlNX2hCZkD8E+4vZzrjs0"),
+				DetailsSMTPPortKey:     []byte("587"),
+				DetailsSMTPHostKey:     []byte(sesSMTPEndpointEUWest1),
+				DetailsSMTPTLSKey:      []byte("true"),
 			},
 		},
 		{

--- a/pkg/providers/openshift/provider_blobstorage.go
+++ b/pkg/providers/openshift/provider_blobstorage.go
@@ -1,0 +1,75 @@
+package openshift
+
+import (
+	"context"
+	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/cloud-resource-operator/pkg/providers"
+	"github.com/integr8ly/cloud-resource-operator/pkg/providers/aws"
+	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+const (
+	varPlaceholder = "REPLACE_ME"
+)
+
+var _ providers.BlobStorageProvider = (*BlobStorageProvider)(nil)
+
+type BlobStorageProvider struct {
+	Client client.Client
+	Logger *logrus.Entry
+}
+
+func NewBlobStorageProvider(c client.Client, l *logrus.Entry) *BlobStorageProvider {
+	return &BlobStorageProvider{
+		Client: c,
+		Logger: l,
+	}
+}
+
+func (b BlobStorageProvider) GetName() string {
+	return "openshift-blobstorage"
+}
+
+func (b BlobStorageProvider) SupportsStrategy(s string) bool {
+	return providers.OpenShiftDeploymentStrategy == s
+}
+
+func (b BlobStorageProvider) GetReconcileTime(bs *v1alpha1.BlobStorage) time.Duration {
+	return time.Second * 10
+}
+
+func (b BlobStorageProvider) CreateStorage(ctx context.Context, bs *v1alpha1.BlobStorage) (*providers.BlobStorageInstance, v1alpha1.StatusMessage, error) {
+	// default to an empty s3 set of credentials for now. in the future. this should determine the cloud provider being
+	// used by checking the infrastructure cr.
+	dd := &aws.BlobStorageDeploymentDetails{
+		BucketName:          varPlaceholder,
+		BucketRegion:        varPlaceholder,
+		CredentialKeyID:     varPlaceholder,
+		CredentialSecretKey: varPlaceholder,
+	}
+
+	if bs.Status.Phase != v1alpha1.PhaseComplete || bs.Status.SecretRef.Name == "" || bs.Status.SecretRef.Namespace == "" {
+		return &providers.BlobStorageInstance{
+			DeploymentDetails: dd,
+		}, "reconcile complete", nil
+	}
+	sec := &v1.Secret{}
+	if err := b.Client.Get(ctx, client.ObjectKey{Name: bs.Status.SecretRef.Name, Namespace: bs.Status.SecretRef.Namespace}, sec); err != nil {
+		return nil, "failed to reconcile", err
+	}
+	dd.BucketName = resources.StringOrDefault(string(sec.Data[aws.DetailsBlobStorageBucketName]), varPlaceholder)
+	dd.BucketRegion = resources.StringOrDefault(string(sec.Data[aws.DetailsBlobStorageBucketRegion]), varPlaceholder)
+	dd.CredentialKeyID = resources.StringOrDefault(string(sec.Data[aws.DetailsBlobStorageCredentialKeyID]), varPlaceholder)
+	dd.CredentialSecretKey = resources.StringOrDefault(string(sec.Data[aws.DetailsBlobStorageCredentialSecretKey]), varPlaceholder)
+	return &providers.BlobStorageInstance{
+		DeploymentDetails: dd,
+	}, "reconcile complete", nil
+}
+
+func (b BlobStorageProvider) DeleteStorage(ctx context.Context, bs *v1alpha1.BlobStorage) (v1alpha1.StatusMessage, error) {
+	return "deletion complete", nil
+}

--- a/pkg/providers/openshift/provider_blobstorage.go
+++ b/pkg/providers/openshift/provider_blobstorage.go
@@ -2,14 +2,16 @@ package openshift
 
 import (
 	"context"
+	"time"
+
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers"
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers/aws"
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 const (
@@ -42,7 +44,7 @@ func (b BlobStorageProvider) GetReconcileTime(bs *v1alpha1.BlobStorage) time.Dur
 	return time.Second * 10
 }
 
-func (b BlobStorageProvider) CreateStorage(ctx context.Context, bs *v1alpha1.BlobStorage) (*providers.BlobStorageInstance, v1alpha1.StatusMessage, error) {
+func (b BlobStorageProvider) CreateStorage(ctx context.Context, bs *v1alpha1.BlobStorage) (*providers.BlobStorageInstance, types.StatusMessage, error) {
 	// default to an empty s3 set of credentials for now. in the future. this should determine the cloud provider being
 	// used by checking the infrastructure cr.
 	dd := &aws.BlobStorageDeploymentDetails{
@@ -52,7 +54,7 @@ func (b BlobStorageProvider) CreateStorage(ctx context.Context, bs *v1alpha1.Blo
 		CredentialSecretKey: varPlaceholder,
 	}
 
-	if bs.Status.Phase != v1alpha1.PhaseComplete || bs.Status.SecretRef.Name == "" || bs.Status.SecretRef.Namespace == "" {
+	if bs.Status.Phase != types.PhaseComplete || bs.Status.SecretRef.Name == "" || bs.Status.SecretRef.Namespace == "" {
 		return &providers.BlobStorageInstance{
 			DeploymentDetails: dd,
 		}, "reconcile complete", nil
@@ -70,6 +72,6 @@ func (b BlobStorageProvider) CreateStorage(ctx context.Context, bs *v1alpha1.Blo
 	}, "reconcile complete", nil
 }
 
-func (b BlobStorageProvider) DeleteStorage(ctx context.Context, bs *v1alpha1.BlobStorage) (v1alpha1.StatusMessage, error) {
+func (b BlobStorageProvider) DeleteStorage(ctx context.Context, bs *v1alpha1.BlobStorage) (types.StatusMessage, error) {
 	return "deletion complete", nil
 }

--- a/pkg/providers/openshift/provider_blobstorage_test.go
+++ b/pkg/providers/openshift/provider_blobstorage_test.go
@@ -46,6 +46,12 @@ func TestBlobStorageProvider_CreateStorage(t *testing.T) {
 						Name:      "test",
 						Namespace: "test",
 					},
+					Spec: v1alpha1.BlobStorageSpec{
+						SecretRef: &types.SecretRef{
+							Name:      "test-sec",
+							Namespace: "",
+						},
+					},
 					Status: v1alpha1.BlobStorageStatus{},
 				},
 			},
@@ -82,6 +88,12 @@ func TestBlobStorageProvider_CreateStorage(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "test",
 						Namespace: "test",
+					},
+					Spec: v1alpha1.BlobStorageSpec{
+						SecretRef: &types.SecretRef{
+							Name:      "test-sec",
+							Namespace: "",
+						},
 					},
 					Status: v1alpha1.BlobStorageStatus{
 						Phase: types.PhaseComplete,
@@ -122,6 +134,12 @@ func TestBlobStorageProvider_CreateStorage(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "test",
 						Namespace: "test",
+					},
+					Spec: v1alpha1.BlobStorageSpec{
+						SecretRef: &types.SecretRef{
+							Name:      "test-sec",
+							Namespace: "",
+						},
 					},
 					Status: v1alpha1.BlobStorageStatus{
 						Phase: types.PhaseComplete,

--- a/pkg/providers/openshift/provider_blobstorage_test.go
+++ b/pkg/providers/openshift/provider_blobstorage_test.go
@@ -2,17 +2,19 @@ package openshift
 
 import (
 	"context"
+	"reflect"
+	"testing"
+	"time"
+
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers"
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers/aws"
 	"github.com/sirupsen/logrus"
 	v12 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
-	"time"
 )
 
 func TestBlobStorageProvider_CreateStorage(t *testing.T) {
@@ -82,8 +84,8 @@ func TestBlobStorageProvider_CreateStorage(t *testing.T) {
 						Namespace: "test",
 					},
 					Status: v1alpha1.BlobStorageStatus{
-						Phase: v1alpha1.PhaseComplete,
-						SecretRef: &v1alpha1.SecretRef{
+						Phase: types.PhaseComplete,
+						SecretRef: &types.SecretRef{
 							Name:      "test",
 							Namespace: "test",
 						},
@@ -122,8 +124,8 @@ func TestBlobStorageProvider_CreateStorage(t *testing.T) {
 						Namespace: "test",
 					},
 					Status: v1alpha1.BlobStorageStatus{
-						Phase: v1alpha1.PhaseComplete,
-						SecretRef: &v1alpha1.SecretRef{
+						Phase: types.PhaseComplete,
+						SecretRef: &types.SecretRef{
 							Name:      "test",
 							Namespace: "test",
 						},

--- a/pkg/providers/openshift/provider_blobstorage_test.go
+++ b/pkg/providers/openshift/provider_blobstorage_test.go
@@ -1,0 +1,230 @@
+package openshift
+
+import (
+	"context"
+	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/cloud-resource-operator/pkg/providers"
+	"github.com/integr8ly/cloud-resource-operator/pkg/providers/aws"
+	"github.com/sirupsen/logrus"
+	v12 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+	"time"
+)
+
+func TestBlobStorageProvider_CreateStorage(t *testing.T) {
+	type fields struct {
+		Client client.Client
+		Logger *logrus.Entry
+	}
+	type args struct {
+		ctx context.Context
+		bs  *v1alpha1.BlobStorage
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *providers.BlobStorageInstance
+		wantErr bool
+	}{
+		{
+			name: "test secret is created",
+			fields: fields{
+				Client: fake.NewFakeClient(),
+				Logger: &logrus.Entry{},
+			},
+			args: args{
+				ctx: context.TODO(),
+				bs: &v1alpha1.BlobStorage{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Status: v1alpha1.BlobStorageStatus{},
+				},
+			},
+			want: &providers.BlobStorageInstance{
+				DeploymentDetails: &aws.BlobStorageDeploymentDetails{
+					BucketName:          varPlaceholder,
+					BucketRegion:        varPlaceholder,
+					CredentialKeyID:     varPlaceholder,
+					CredentialSecretKey: varPlaceholder,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test existing secret is not overridden",
+			fields: fields{
+				Client: fake.NewFakeClient(&v12.Secret{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "test",
+						Name:      "test",
+					},
+					Data: map[string][]byte{
+						aws.DetailsBlobStorageBucketName:          []byte("test"),
+						aws.DetailsBlobStorageBucketRegion:        []byte("test"),
+						aws.DetailsBlobStorageCredentialKeyID:     []byte("test"),
+						aws.DetailsBlobStorageCredentialSecretKey: []byte("test"),
+					},
+				}),
+				Logger: &logrus.Entry{},
+			},
+			args: args{
+				ctx: context.TODO(),
+				bs: &v1alpha1.BlobStorage{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Status: v1alpha1.BlobStorageStatus{
+						Phase: v1alpha1.PhaseComplete,
+						SecretRef: &v1alpha1.SecretRef{
+							Name:      "test",
+							Namespace: "test",
+						},
+					},
+				},
+			},
+			want: &providers.BlobStorageInstance{
+				DeploymentDetails: &aws.BlobStorageDeploymentDetails{
+					BucketName:          "test",
+					BucketRegion:        "test",
+					CredentialKeyID:     "test",
+					CredentialSecretKey: "test",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test missing secret values are reset",
+			fields: fields{
+				Client: fake.NewFakeClient(&v12.Secret{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "test",
+						Name:      "test",
+					},
+					Data: map[string][]byte{
+						aws.DetailsBlobStorageCredentialKeyID: []byte("test"),
+					},
+				}),
+				Logger: &logrus.Entry{},
+			},
+			args: args{
+				ctx: context.TODO(),
+				bs: &v1alpha1.BlobStorage{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Status: v1alpha1.BlobStorageStatus{
+						Phase: v1alpha1.PhaseComplete,
+						SecretRef: &v1alpha1.SecretRef{
+							Name:      "test",
+							Namespace: "test",
+						},
+					},
+				},
+			},
+			want: &providers.BlobStorageInstance{
+				DeploymentDetails: &aws.BlobStorageDeploymentDetails{
+					BucketName:          varPlaceholder,
+					BucketRegion:        varPlaceholder,
+					CredentialKeyID:     "test",
+					CredentialSecretKey: varPlaceholder,
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := BlobStorageProvider{
+				Client: tt.fields.Client,
+				Logger: tt.fields.Logger,
+			}
+			got, _, err := b.CreateStorage(tt.args.ctx, tt.args.bs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateStorage() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateStorage() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBlobStorageProvider_GetReconcileTime(t *testing.T) {
+	type fields struct {
+		Client client.Client
+		Logger *logrus.Entry
+	}
+	type args struct {
+		bs *v1alpha1.BlobStorage
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   time.Duration
+	}{
+		{
+			name: "test expected value for regression",
+			want: time.Second * 10,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := BlobStorageProvider{
+				Client: tt.fields.Client,
+				Logger: tt.fields.Logger,
+			}
+			if got := b.GetReconcileTime(tt.args.bs); got != tt.want {
+				t.Errorf("GetReconcileTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBlobStorageProvider_SupportsStrategy(t *testing.T) {
+	type fields struct {
+		Client client.Client
+		Logger *logrus.Entry
+	}
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "test success",
+			args: args{s: "openshift"},
+			want: true,
+		},
+		{
+			name: "test failure",
+			args: args{s: "test"},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := BlobStorageProvider{
+				Client: tt.fields.Client,
+				Logger: tt.fields.Logger,
+			}
+			if got := b.SupportsStrategy(tt.args.s); got != tt.want {
+				t.Errorf("SupportsStrategy() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/providers/openshift/provider_smtpcredentialset.go
+++ b/pkg/providers/openshift/provider_smtpcredentialset.go
@@ -1,0 +1,87 @@
+package openshift
+
+import (
+	"context"
+	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/cloud-resource-operator/pkg/providers"
+	"github.com/integr8ly/cloud-resource-operator/pkg/providers/aws"
+	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strconv"
+	"time"
+)
+
+const (
+	smtpPortPlaceholder = 587
+	smtpTLSPlaceholder  = true
+)
+
+var _ providers.SMTPCredentialsProvider = (*SMTPCredentialProvider)(nil)
+
+type SMTPCredentialProvider struct {
+	Client client.Client
+	Logger *logrus.Entry
+}
+
+func NewSMTPCredentialSetProvider(c client.Client, l *logrus.Entry) *SMTPCredentialProvider {
+	return &SMTPCredentialProvider{
+		Client: c,
+		Logger: l,
+	}
+}
+
+func (s SMTPCredentialProvider) GetName() string {
+	return "openshift-smtp"
+}
+
+func (s SMTPCredentialProvider) SupportsStrategy(str string) bool {
+	return providers.OpenShiftDeploymentStrategy == str
+}
+
+func (s SMTPCredentialProvider) GetReconcileTime(smtpCreds *v1alpha1.SMTPCredentialSet) time.Duration {
+	return time.Second * 10
+}
+
+func (s SMTPCredentialProvider) CreateSMTPCredentials(ctx context.Context, smtpCreds *v1alpha1.SMTPCredentialSet) (*providers.SMTPCredentialSetInstance, v1alpha1.StatusMessage, error) {
+	dd := &aws.SMTPCredentialSetDetails{
+		Username: varPlaceholder,
+		Password: varPlaceholder,
+		Port:     smtpPortPlaceholder,
+		Host:     varPlaceholder,
+		TLS:      smtpTLSPlaceholder,
+	}
+
+	if smtpCreds.Status.Phase != v1alpha1.PhaseComplete || smtpCreds.Status.SecretRef.Name == "" || smtpCreds.Status.SecretRef.Namespace == "" {
+		return &providers.SMTPCredentialSetInstance{
+			DeploymentDetails: dd,
+		}, "reconcile complete", nil
+	}
+	sec := &v1.Secret{}
+	if err := s.Client.Get(ctx, client.ObjectKey{Name: smtpCreds.Status.SecretRef.Name, Namespace: smtpCreds.Status.SecretRef.Namespace}, sec); err != nil {
+		return nil, "failed to reconcile", err
+	}
+	dd.Host = resources.StringOrDefault(string(sec.Data[aws.DetailsSMTPHostKey]), varPlaceholder)
+	dd.Password = resources.StringOrDefault(string(sec.Data[aws.DetailsSMTPPasswordKey]), varPlaceholder)
+	dd.Username = resources.StringOrDefault(string(sec.Data[aws.DetailsSMTPUsernameKey]), varPlaceholder)
+	ddPortStr := resources.StringOrDefault(string(sec.Data[aws.DetailsSMTPPortKey]), strconv.Itoa(smtpPortPlaceholder))
+	ddPort, err := strconv.Atoi(ddPortStr)
+	if err != nil {
+		ddPort = smtpPortPlaceholder
+	}
+	ddTLSStr := resources.StringOrDefault(string(sec.Data[aws.DetailsSMTPTLSKey]), strconv.FormatBool(smtpTLSPlaceholder))
+	ddTLS, err := strconv.ParseBool(ddTLSStr)
+	if err != nil {
+		ddTLS = smtpTLSPlaceholder
+	}
+	dd.Port = ddPort
+	dd.TLS = ddTLS
+	return &providers.SMTPCredentialSetInstance{
+		DeploymentDetails: dd,
+	}, "reconcile complete", nil
+}
+
+func (s SMTPCredentialProvider) DeleteSMTPCredentials(ctx context.Context, smtpCreds *v1alpha1.SMTPCredentialSet) (v1alpha1.StatusMessage, error) {
+	return "deletion complete", nil
+}

--- a/pkg/providers/openshift/provider_smtpcredentialset.go
+++ b/pkg/providers/openshift/provider_smtpcredentialset.go
@@ -2,15 +2,20 @@ package openshift
 
 import (
 	"context"
+
+	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
+
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
+
+	"strconv"
+	"time"
+
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers"
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers/aws"
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
-	"time"
 )
 
 const (
@@ -44,7 +49,7 @@ func (s SMTPCredentialProvider) GetReconcileTime(smtpCreds *v1alpha1.SMTPCredent
 	return time.Second * 10
 }
 
-func (s SMTPCredentialProvider) CreateSMTPCredentials(ctx context.Context, smtpCreds *v1alpha1.SMTPCredentialSet) (*providers.SMTPCredentialSetInstance, v1alpha1.StatusMessage, error) {
+func (s SMTPCredentialProvider) CreateSMTPCredentials(ctx context.Context, smtpCreds *v1alpha1.SMTPCredentialSet) (*providers.SMTPCredentialSetInstance, types.StatusMessage, error) {
 	dd := &aws.SMTPCredentialSetDetails{
 		Username: varPlaceholder,
 		Password: varPlaceholder,
@@ -53,7 +58,7 @@ func (s SMTPCredentialProvider) CreateSMTPCredentials(ctx context.Context, smtpC
 		TLS:      smtpTLSPlaceholder,
 	}
 
-	if smtpCreds.Status.Phase != v1alpha1.PhaseComplete || smtpCreds.Status.SecretRef.Name == "" || smtpCreds.Status.SecretRef.Namespace == "" {
+	if smtpCreds.Status.Phase != types.PhaseComplete || smtpCreds.Status.SecretRef.Name == "" || smtpCreds.Status.SecretRef.Namespace == "" {
 		return &providers.SMTPCredentialSetInstance{
 			DeploymentDetails: dd,
 		}, "reconcile complete", nil
@@ -82,6 +87,6 @@ func (s SMTPCredentialProvider) CreateSMTPCredentials(ctx context.Context, smtpC
 	}, "reconcile complete", nil
 }
 
-func (s SMTPCredentialProvider) DeleteSMTPCredentials(ctx context.Context, smtpCreds *v1alpha1.SMTPCredentialSet) (v1alpha1.StatusMessage, error) {
+func (s SMTPCredentialProvider) DeleteSMTPCredentials(ctx context.Context, smtpCreds *v1alpha1.SMTPCredentialSet) (types.StatusMessage, error) {
 	return "deletion complete", nil
 }

--- a/pkg/providers/openshift/provider_smtpcredentialset.go
+++ b/pkg/providers/openshift/provider_smtpcredentialset.go
@@ -58,6 +58,10 @@ func (s SMTPCredentialProvider) CreateSMTPCredentials(ctx context.Context, smtpC
 		TLS:      smtpTLSPlaceholder,
 	}
 
+	if smtpCreds.Spec.SecretRef.Namespace == "" {
+		smtpCreds.Spec.SecretRef.Namespace = smtpCreds.Namespace
+	}
+
 	if smtpCreds.Status.Phase != types.PhaseComplete || smtpCreds.Status.SecretRef.Name == "" || smtpCreds.Status.SecretRef.Namespace == "" {
 		return &providers.SMTPCredentialSetInstance{
 			DeploymentDetails: dd,

--- a/pkg/providers/openshift/provider_smtpcredentialset_test.go
+++ b/pkg/providers/openshift/provider_smtpcredentialset_test.go
@@ -1,0 +1,232 @@
+package openshift
+
+import (
+	"context"
+	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/cloud-resource-operator/pkg/providers"
+	"github.com/integr8ly/cloud-resource-operator/pkg/providers/aws"
+	"github.com/sirupsen/logrus"
+	v12 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+	"time"
+)
+
+func TestSMTPCredentialProvider_CreateSMTPCredentials(t *testing.T) {
+	type fields struct {
+		Client client.Client
+		Logger *logrus.Entry
+	}
+	type args struct {
+		ctx       context.Context
+		smtpCreds *v1alpha1.SMTPCredentialSet
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *providers.SMTPCredentialSetInstance
+		wantErr bool
+	}{
+		{
+			name: "test placeholders used when secret does not exist",
+			fields: fields{
+				Client: fake.NewFakeClient(),
+				Logger: &logrus.Entry{},
+			},
+			args: args{
+				ctx: context.TODO(),
+				smtpCreds: &v1alpha1.SMTPCredentialSet{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+				},
+			},
+			want: &providers.SMTPCredentialSetInstance{
+				DeploymentDetails: &aws.SMTPCredentialSetDetails{
+					Username: varPlaceholder,
+					Password: varPlaceholder,
+					Port:     smtpPortPlaceholder,
+					Host:     varPlaceholder,
+					TLS:      smtpTLSPlaceholder,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test existing secret values are used if exist",
+			fields: fields{
+				Client: fake.NewFakeClient(&v12.Secret{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Data: map[string][]byte{
+						aws.DetailsSMTPUsernameKey: []byte("test"),
+						aws.DetailsSMTPPasswordKey: []byte("test"),
+						aws.DetailsSMTPHostKey:     []byte("test"),
+						aws.DetailsSMTPTLSKey:      []byte("false"),
+						aws.DetailsSMTPPortKey:     []byte("123"),
+					},
+				}),
+				Logger: &logrus.Entry{},
+			},
+			args: args{
+				ctx: context.TODO(),
+				smtpCreds: &v1alpha1.SMTPCredentialSet{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Status: v1alpha1.SMTPCredentialSetStatus{
+						Phase: v1alpha1.PhaseComplete,
+						SecretRef: &v1alpha1.SecretRef{
+							Name:      "test",
+							Namespace: "test",
+						},
+					},
+				},
+			},
+			want: &providers.SMTPCredentialSetInstance{
+				DeploymentDetails: &aws.SMTPCredentialSetDetails{
+					Username: "test",
+					Password: "test",
+					Port:     123,
+					Host:     "test",
+					TLS:      false,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test missing values are replaced with placeholders",
+			fields: fields{
+				Client: fake.NewFakeClient(&v12.Secret{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Data: map[string][]byte{
+						aws.DetailsSMTPPortKey: []byte("123"),
+					},
+				}), Logger: &logrus.Entry{},
+			},
+			args: args{
+				ctx: context.TODO(),
+				smtpCreds: &v1alpha1.SMTPCredentialSet{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Status: v1alpha1.SMTPCredentialSetStatus{
+						Phase: v1alpha1.PhaseComplete,
+						SecretRef: &v1alpha1.SecretRef{
+							Name:      "test",
+							Namespace: "test",
+						},
+					},
+				},
+			},
+			want: &providers.SMTPCredentialSetInstance{
+				DeploymentDetails: &aws.SMTPCredentialSetDetails{
+					Username: varPlaceholder,
+					Password: varPlaceholder,
+					Port:     123,
+					Host:     varPlaceholder,
+					TLS:      smtpTLSPlaceholder,
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := SMTPCredentialProvider{
+				Client: tt.fields.Client,
+				Logger: tt.fields.Logger,
+			}
+			got, _, err := s.CreateSMTPCredentials(tt.args.ctx, tt.args.smtpCreds)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateSMTPCredentials() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateSMTPCredentials() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSMTPCredentialProvider_GetReconcileTime(t *testing.T) {
+	type fields struct {
+		Client client.Client
+		Logger *logrus.Entry
+	}
+	type args struct {
+		smtpCreds *v1alpha1.SMTPCredentialSet
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   time.Duration
+	}{
+		{
+			name: "test expected time for regression",
+			want: time.Second * 10,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := SMTPCredentialProvider{
+				Client: tt.fields.Client,
+				Logger: tt.fields.Logger,
+			}
+			if got := s.GetReconcileTime(tt.args.smtpCreds); got != tt.want {
+				t.Errorf("GetReconcileTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSMTPCredentialProvider_SupportsStrategy(t *testing.T) {
+	type fields struct {
+		Client client.Client
+		Logger *logrus.Entry
+	}
+	type args struct {
+		str string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "test supported",
+			args: args{str: "openshift"},
+			want: true,
+		},
+		{
+			name: "test unsupported",
+			args: args{str: "test"},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := SMTPCredentialProvider{
+				Client: tt.fields.Client,
+				Logger: tt.fields.Logger,
+			}
+			if got := s.SupportsStrategy(tt.args.str); got != tt.want {
+				t.Errorf("SupportsStrategy() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/providers/openshift/provider_smtpcredentialset_test.go
+++ b/pkg/providers/openshift/provider_smtpcredentialset_test.go
@@ -46,6 +46,12 @@ func TestSMTPCredentialProvider_CreateSMTPCredentials(t *testing.T) {
 						Name:      "test",
 						Namespace: "test",
 					},
+					Spec: v1alpha1.SMTPCredentialSetSpec{
+						SecretRef: &types.SecretRef{
+							Name:      "test-sec",
+							Namespace: "",
+						},
+					},
 				},
 			},
 			want: &providers.SMTPCredentialSetInstance{
@@ -83,6 +89,12 @@ func TestSMTPCredentialProvider_CreateSMTPCredentials(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "test",
 						Namespace: "test",
+					},
+					Spec: v1alpha1.SMTPCredentialSetSpec{
+						SecretRef: &types.SecretRef{
+							Name:      "test-sec",
+							Namespace: "",
+						},
 					},
 					Status: v1alpha1.SMTPCredentialSetStatus{
 						Phase: types.PhaseComplete,
@@ -123,6 +135,12 @@ func TestSMTPCredentialProvider_CreateSMTPCredentials(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "test",
 						Namespace: "test",
+					},
+					Spec: v1alpha1.SMTPCredentialSetSpec{
+						SecretRef: &types.SecretRef{
+							Name:      "test-sec",
+							Namespace: "",
+						},
 					},
 					Status: v1alpha1.SMTPCredentialSetStatus{
 						Phase: types.PhaseComplete,

--- a/pkg/providers/openshift/provider_smtpcredentialset_test.go
+++ b/pkg/providers/openshift/provider_smtpcredentialset_test.go
@@ -2,17 +2,19 @@ package openshift
 
 import (
 	"context"
+	"reflect"
+	"testing"
+	"time"
+
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers"
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers/aws"
 	"github.com/sirupsen/logrus"
 	v12 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
-	"time"
 )
 
 func TestSMTPCredentialProvider_CreateSMTPCredentials(t *testing.T) {
@@ -83,8 +85,8 @@ func TestSMTPCredentialProvider_CreateSMTPCredentials(t *testing.T) {
 						Namespace: "test",
 					},
 					Status: v1alpha1.SMTPCredentialSetStatus{
-						Phase: v1alpha1.PhaseComplete,
-						SecretRef: &v1alpha1.SecretRef{
+						Phase: types.PhaseComplete,
+						SecretRef: &types.SecretRef{
 							Name:      "test",
 							Namespace: "test",
 						},
@@ -123,8 +125,8 @@ func TestSMTPCredentialProvider_CreateSMTPCredentials(t *testing.T) {
 						Namespace: "test",
 					},
 					Status: v1alpha1.SMTPCredentialSetStatus{
-						Phase: v1alpha1.PhaseComplete,
-						SecretRef: &v1alpha1.SecretRef{
+						Phase: types.PhaseComplete,
+						SecretRef: &types.SecretRef{
 							Name:      "test",
 							Namespace: "test",
 						},

--- a/pkg/resources/strings.go
+++ b/pkg/resources/strings.go
@@ -48,3 +48,10 @@ func buildAlphanumRegexp() (*regexp.Regexp, error) {
 	}
 	return anReg, nil
 }
+
+func StringOrDefault(str, defaultTo string) string {
+	if str == "" {
+		return defaultTo
+	}
+	return str
+}

--- a/pkg/resources/strings_test.go
+++ b/pkg/resources/strings_test.go
@@ -62,3 +62,39 @@ func TestShortenString(t *testing.T) {
 		})
 	}
 }
+
+func TestStringOrDefault(t *testing.T) {
+	type args struct {
+		str       string
+		defaultTo string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test default is returned",
+			args:args{
+				str:       "",
+				defaultTo: "def",
+			},
+			want: "def",
+		},
+		{
+			name: "test value is returned",
+			args:args{
+				str:       "test",
+				defaultTo: "def",
+			},
+			want: "test",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StringOrDefault(tt.args.str, tt.args.defaultTo); got != tt.want {
+				t.Errorf("StringOrDefault() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/resources/strings_test.go
+++ b/pkg/resources/strings_test.go
@@ -75,7 +75,7 @@ func TestStringOrDefault(t *testing.T) {
 	}{
 		{
 			name: "test default is returned",
-			args:args{
+			args: args{
 				str:       "",
 				defaultTo: "def",
 			},
@@ -83,7 +83,7 @@ func TestStringOrDefault(t *testing.T) {
 		},
 		{
 			name: "test value is returned",
-			args:args{
+			args: args{
 				str:       "test",
 				defaultTo: "def",
 			},

--- a/test/e2e/cro_test.go
+++ b/test/e2e/cro_test.go
@@ -13,6 +13,7 @@ const (
 	postgresName    = "example-postgres"
 	redisName       = "example-redis"
 	blobstorageName = "example-blobstorage"
+	smtpName        = "example-smtp"
 )
 
 var (
@@ -56,6 +57,10 @@ func TestCRO(t *testing.T) {
 
 	t.Run("cro-openshift-blobstorage-test", func(t *testing.T) {
 		t.Run("Cluster", OpenshiftBlobstorageTestCluster)
+	})
+
+	t.Run("cro-openshift-smtp-test", func(t *testing.T) {
+		t.Run("Cluster", OpenshiftSMTPTestCluster)
 	})
 
 }
@@ -174,6 +179,24 @@ func OpenshiftBlobstorageTestCluster(t *testing.T) {
 
 	// run blobstorage test
 	if err = OpenshiftBlobstorageBasicTest(t, f, *ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func OpenshiftSMTPTestCluster(t *testing.T) {
+	t.Parallel()
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup()
+	err := ctx.InitializeClusterResources(getCleanupOptions(t))
+	if err != nil {
+		t.Fatalf("failed to initialize cluster resources: %v", err)
+	}
+	t.Log("initialized cluster resources")
+
+	f := framework.Global
+
+	// run smtp test
+	if err = OpenshiftSMTPBasicTest(t, f, *ctx); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/test/e2e/openshift_blobstorage_test.go
+++ b/test/e2e/openshift_blobstorage_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -74,7 +75,7 @@ func blobstorageCreateTest(t *testing.T, f *framework.Framework, testBlobstorage
 		}
 	}
 
-	t.Logf("%s secrete created successfully", bcr.Status.SecretRef.Name)
+	t.Logf("%s secret created successfully", bcr.Status.SecretRef.Name)
 	return nil
 }
 
@@ -83,6 +84,14 @@ func blobstorageDeleteTest(t *testing.T, f *framework.Framework, testBlobstorage
 	// delete blobstorage resource
 	if err := f.Client.Delete(goctx.TODO(), testBlobstorage); err != nil {
 		return errorUtil.Wrapf(err, "failed to delete example blobstorage")
+	}
+
+	sec := v1.Secret{}
+	if err := f.Client.Get(goctx.TODO(), types.NamespacedName{Namespace: namespace, Name: testBlobstorage.Spec.SecretRef.Name}, &sec); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return errorUtil.Wrapf(err, "could not get secret")
 	}
 	t.Logf("%s custom resource deleted", testBlobstorage.Name)
 

--- a/test/e2e/openshift_blobstorage_test.go
+++ b/test/e2e/openshift_blobstorage_test.go
@@ -1,0 +1,112 @@
+package e2e
+
+import (
+	goctx "context"
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+
+	errorUtil "github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func OpenshiftBlobstorageBasicTest(t *testing.T, f *framework.Framework, ctx framework.TestCtx) error {
+	testBlobstorage, namespace, err := getBasicBlobstorage(ctx)
+	if err != nil {
+		return errorUtil.Wrapf(err, "failed to get blobstorage")
+	}
+
+	// verify blobstorage create
+	if err := blobstorageCreateTest(t, f, testBlobstorage, namespace); err != nil {
+		return errorUtil.Wrapf(err, "create blobstorage test failure")
+	}
+
+	// verify blobstorage delete
+	if err := blobstorageDeleteTest(t, f, testBlobstorage, namespace); err != nil {
+		return errorUtil.Wrapf(err, "delete blobstorage test failure")
+	}
+
+	t.Logf("blobstorage basic test pass")
+	return nil
+}
+
+// creates blobstorage resource, verifies everything is as expected
+func blobstorageCreateTest(t *testing.T, f *framework.Framework, testBlobstorage *v1alpha1.BlobStorage, namespace string) error {
+	// create blobstorage resource
+	if err := f.Client.Create(goctx.TODO(), testBlobstorage, getCleanupOptions(t)); err != nil {
+		return errorUtil.Wrapf(err, "could not create example blobstorage")
+	}
+	t.Logf("created %s resource", testBlobstorage.Name)
+
+	// poll cr for complete status phase
+	bcr := &v1alpha1.BlobStorage{}
+	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		if err := f.Client.Get(goctx.TODO(), types.NamespacedName{Namespace: namespace, Name: blobstorageName}, bcr); err != nil {
+			return true, errorUtil.Wrapf(err, "could not get blobstorage cr")
+		}
+		if bcr.Status.Phase == v1alpha1.StatusPhase("complete") {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+	t.Logf("blobstorage status phase %s", bcr.Status.Phase)
+
+	// get created secret
+	sec := v1.Secret{}
+	if err := f.Client.Get(goctx.TODO(), types.NamespacedName{Namespace: bcr.Status.SecretRef.Namespace, Name: bcr.Status.SecretRef.Name}, &sec); err != nil {
+		return errorUtil.Wrapf(err, "could not get secret")
+	}
+
+	// check for expected key values
+	for _, k := range []string{"bucketName", "bucketRegion", "credentialKeyID", "credentialSecretKey"} {
+		if sec.Data[k] == nil {
+			return errorUtil.New(fmt.Sprintf("secret %s value not found", k))
+		}
+	}
+
+	t.Logf("%s secrete created successfully", bcr.Status.SecretRef.Name)
+	return nil
+}
+
+// removes blobstorage resource and verifies all components have been cleaned up
+func blobstorageDeleteTest(t *testing.T, f *framework.Framework, testBlobstorage *v1alpha1.BlobStorage, namespace string) error {
+	// delete blobstorage resource
+	if err := f.Client.Delete(goctx.TODO(), testBlobstorage); err != nil {
+		return errorUtil.Wrapf(err, "failed to delete example blobstorage")
+	}
+	t.Logf("%s custom resource deleted", testBlobstorage.Name)
+
+	return nil
+}
+
+func getBasicBlobstorage(ctx framework.TestCtx) (*v1alpha1.BlobStorage, string, error) {
+	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		return nil, "", errorUtil.Wrapf(err, "could not get namespace")
+	}
+
+	return &v1alpha1.BlobStorage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      blobstorageName,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.BlobStorageSpec{
+			SecretRef: &v1alpha1.SecretRef{
+				Name:      "example-blobstorage-sec",
+				Namespace: namespace,
+			},
+			Tier: "development",
+			Type: "workshop",
+		},
+	}, namespace, nil
+}

--- a/test/e2e/openshift_smtp_test.go
+++ b/test/e2e/openshift_smtp_test.go
@@ -1,0 +1,122 @@
+package e2e
+
+import (
+	goctx "context"
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+
+	errorUtil "github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func OpenshiftSMTPBasicTest(t *testing.T, f *framework.Framework, ctx framework.TestCtx) error {
+	testSMTP, namespace, err := getBasicSMTP(ctx)
+	if err != nil {
+		return errorUtil.Wrapf(err, "failed to get smtp")
+	}
+
+	// verify smtp create
+	if err := smtpCreateTest(t, f, testSMTP, namespace); err != nil {
+		return errorUtil.Wrapf(err, "create smtp test failure")
+	}
+
+	// verify smtp delete
+	if err := smtpDeleteTest(t, f, testSMTP, namespace); err != nil {
+		return errorUtil.Wrapf(err, "delete smtp test failure")
+	}
+
+	t.Logf("smtp basic test pass")
+	return nil
+}
+
+// creates smtp resource, verifies everything is as expected
+func smtpCreateTest(t *testing.T, f *framework.Framework, testSMTP *v1alpha1.SMTPCredentialSet, namespace string) error {
+	// create smtp resource
+	if err := f.Client.Create(goctx.TODO(), testSMTP, getCleanupOptions(t)); err != nil {
+		return errorUtil.Wrapf(err, "could not create example smtp")
+	}
+	t.Logf("created %s resource", testSMTP.Name)
+
+	// poll cr for complete status phase
+	scr := &v1alpha1.SMTPCredentialSet{}
+	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		if err := f.Client.Get(goctx.TODO(), types.NamespacedName{Namespace: namespace, Name: smtpName}, scr); err != nil {
+			return true, errorUtil.Wrapf(err, "could not get smtp cr")
+		}
+		if scr.Status.Phase == v1alpha1.StatusPhase("complete") {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+	t.Logf("smtp status phase %s", scr.Status.Phase)
+
+	// get created secret
+	sec := v1.Secret{}
+	if err := f.Client.Get(goctx.TODO(), types.NamespacedName{Namespace: scr.Status.SecretRef.Namespace, Name: scr.Status.SecretRef.Name}, &sec); err != nil {
+		return errorUtil.Wrapf(err, "could not get secret")
+	}
+
+	// check for expected key values
+	for _, k := range []string{"username", "password", "port", "host", "tls"} {
+		if sec.Data[k] == nil {
+			return errorUtil.New(fmt.Sprintf("secret %s value not found", k))
+		}
+	}
+
+	t.Logf("%s secret created successfully", scr.Status.SecretRef.Name)
+	return nil
+}
+
+// removes smtp resource and verifies all components have been cleaned up
+func smtpDeleteTest(t *testing.T, f *framework.Framework, testSMTP *v1alpha1.SMTPCredentialSet, namespace string) error {
+	// delete smtp resource
+	if err := f.Client.Delete(goctx.TODO(), testSMTP); err != nil {
+		return errorUtil.Wrapf(err, "failed to delete example smtp")
+	}
+	t.Logf("%s custom resource deleted", testSMTP.Name)
+
+	sec := v1.Secret{}
+	if err := f.Client.Get(goctx.TODO(), types.NamespacedName{Namespace: namespace, Name: testSMTP.Spec.SecretRef.Name}, &sec); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return errorUtil.Wrapf(err, "could not get secret")
+	}
+	t.Logf("")
+	return nil
+}
+
+func getBasicSMTP(ctx framework.TestCtx) (*v1alpha1.SMTPCredentialSet, string, error) {
+	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		return nil, "", errorUtil.Wrapf(err, "could not get namespace")
+	}
+
+	return &v1alpha1.SMTPCredentialSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      smtpName,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.SMTPCredentialSetSpec{
+			SecretRef: &v1alpha1.SecretRef{
+				Name:      "example-smtp-sec",
+				Namespace: namespace,
+			},
+			Tier: "development",
+			Type: "workshop",
+		},
+	}, namespace, nil
+}


### PR DESCRIPTION
## Overview

Currently we do support Openshift installs of blobstorage and smtp resources. This change adds the support and e2e 

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make run`
- Provision smtp and blobstorage workshops
- Ensure secrets are created
- Run `make cluster/clean`
- Run `make test/e2e/local`
- Ensure tests pass