### PR TITLE
feat: Add monitoring label to operator service monitor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,12 +49,16 @@ code/audit:
 
 .PHONY: cluster/prepare
 cluster/prepare:
-	oc new-project $(NAMESPACE) || true
-	oc apply -f ./deploy/crds/integreatly_v1alpha1_blobstorage_crd.yaml
-	oc apply -f ./deploy/crds/integreatly_v1alpha1_smtpcredentialset_crd.yaml
-	oc apply -f ./deploy/crds/integreatly_v1alpha1_redis_crd.yaml
-	oc apply -f ./deploy/crds/integreatly_v1alpha1_postgres_crd.yaml
-	oc apply -f ./deploy/examples/
+	-oc new-project $(NAMESPACE) || true
+	-oc label namespace $(NAMESPACE) monitoring-key=middleware
+	oc create -f ./deploy/crds/integreatly_v1alpha1_blobstorage_crd.yaml -n $(NAMESPACE)
+	oc create -f ./deploy/crds/integreatly_v1alpha1_smtpcredentialset_crd.yaml -n $(NAMESPACE)
+	oc create -f ./deploy/crds/integreatly_v1alpha1_redis_crd.yaml -n $(NAMESPACE)
+	oc create -f ./deploy/crds/integreatly_v1alpha1_postgres_crd.yaml -n $(NAMESPACE)
+	oc create -f ./deploy/service_account.yaml -n $(NAMESPACE)
+	oc create -f ./deploy/role.yaml -n $(NAMESPACE)
+	oc create -f ./deploy/role_binding.yaml -n $(NAMESPACE)
+	oc create -f ./deploy/examples/ -n $(NAMESPACE)
 
 .PHONY: cluster/seed/smtp
 cluster/seed/smtp:
@@ -74,10 +78,14 @@ cluster/seed/postgres:
 
 .PHONY: cluster/clean
 cluster/clean:
-	oc project $(NAMESPACE)
-	oc delete -f ./deploy/crds/integreatly_v1alpha1_blobstorage_crd.yaml
-	oc delete -f ./deploy/crds/integreatly_v1alpha1_smtpcredentialset_crd.yaml
-	oc delete -f ./deploy/crds/integreatly_v1alpha1_redis_crd.yaml
+	oc delete -f ./deploy/crds/integreatly_v1alpha1_blobstorage_crd.yaml -n $(NAMESPACE)
+	oc delete -f ./deploy/crds/integreatly_v1alpha1_smtpcredentialset_crd.yaml -n $(NAMESPACE)
+	oc delete -f ./deploy/crds/integreatly_v1alpha1_redis_crd.yaml -n $(NAMESPACE)
+	oc delete -f ./deploy/crds/integreatly_v1alpha1_postgres_crd.yaml -n $(NAMESPACE)
+	oc delete -f ./deploy/service_account.yaml -n $(NAMESPACE)
+	oc delete -f ./deploy/role.yaml -n $(NAMESPACE)
+	oc delete -f ./deploy/role_binding.yaml -n $(NAMESPACE)
+	oc delete -f ./deploy/examples/ -n $(NAMESPACE)
 	oc delete project $(NAMESPACE)
 
 .PHONY: test/unit/setup

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/aws/aws-sdk-go v1.23.17
+	github.com/coreos/prometheus-operator v0.29.0
 	github.com/go-openapi/spec v0.19.0
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect


### PR DESCRIPTION
## Overview
None

Adding monitoring-key:middleware to the service monitor created by the operator itself so the metrics can be fed into the middleware monitoring prometheus.

## Verification

- Checkout this branch
- Run `make cluster/prepare`
- Modify `operator.yaml` image to  `quay.io/davidffrench/cloud-resource-operator:add_monitoring_label`
- Run `kubectl deploy -f deploy/operator.yaml`
- Check the service-monitor created by the operator in the same namespace has the correct `monitoring-key:middleware` label