### PR TITLE
bump postgres version to 10

### DIFF
--- a/pkg/providers/openshift/provider_postgres.go
+++ b/pkg/providers/openshift/provider_postgres.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	types2 "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 	"strings"
 	"time"
+
+	types2 "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 
 	"k8s.io/client-go/kubernetes"
 
@@ -443,7 +444,7 @@ func buildDefaultPostgresPodContainers(ps *v1alpha1.Postgres) []v1.Container {
 	return []v1.Container{
 		{
 			Name:  ps.Name,
-			Image: "registry.redhat.io/rhscl/postgresql-96-rhel7",
+			Image: "registry.redhat.io/rhscl/postgresql-10-rhel7",
 			Ports: []v1.ContainerPort{
 				{
 					ContainerPort: int32(defaultPostgresPort),

--- a/pkg/providers/openshift/provider_redis.go
+++ b/pkg/providers/openshift/provider_redis.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	types2 "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 	"strings"
 	"time"
+
+	types2 "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 
 	controllerruntime "sigs.k8s.io/controller-runtime"
 
@@ -329,7 +330,7 @@ func buildDefaultRedisDeployment(r *v1alpha1.Redis) *appsv1.Deployment {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"deployment": redisDCSelectorName,
+						"deployment": r.Name,
 					},
 				},
 			},
@@ -338,7 +339,7 @@ func buildDefaultRedisDeployment(r *v1alpha1.Redis) *appsv1.Deployment {
 			},
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"deployment": redisDCSelectorName,
+					"deployment": r.Name,
 				},
 			},
 			Replicas: int32Ptr(1),
@@ -457,7 +458,7 @@ func buildDefaultRedisService(r *v1alpha1.Redis) *apiv1.Service {
 				},
 			},
 			Selector: map[string]string{
-				"deployment": redisDCSelectorName,
+				"deployment": r.Name,
 			},
 		},
 	}


### PR DESCRIPTION
## Overview
- Bump postgres version 
- Update redis deployment selectors to match the installation name 

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make run`
- Create an in-cluster postgres cr
- Ensure that the postgres comes up as expected and can be connected to