### PR TITLE
fix credentials secret name clash

### DIFF
--- a/pkg/providers/openshift/provider_postgres.go
+++ b/pkg/providers/openshift/provider_postgres.go
@@ -179,81 +179,71 @@ func (p *OpenShiftPostgresProvider) CreatePostgres(ctx context.Context, ps *v1al
 }
 
 func (p *OpenShiftPostgresProvider) DeletePostgres(ctx context.Context, ps *v1alpha1.Postgres) (types2.StatusMessage, error) {
-	// check deployment status
-	dpl := &appsv1.Deployment{}
-	err := p.Client.Get(ctx, types.NamespacedName{Name: ps.Name, Namespace: ps.Namespace}, dpl)
-	if err != nil {
-		if k8serr.IsNotFound(err) {
-			return types2.StatusEmpty, nil
-		}
-		errMsg := "failed to get postgres deployment"
+	// delete service
+	p.Logger.Info("Deleting postgres service")
+	svc := &v1.Service{
+		ObjectMeta: controllerruntime.ObjectMeta{
+			Name:      ps.Name,
+			Namespace: ps.Namespace,
+		},
+	}
+	err := p.Client.Delete(ctx, svc)
+	if err != nil && !k8serr.IsNotFound(err) {
+		errMsg := "failed to delete postgres service"
 		return types2.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
 	}
 
-	for _, s := range dpl.Status.Conditions {
-		if s.Type == appsv1.DeploymentAvailable && s.Status == "True" {
-			// delete service
-			p.Logger.Info("Deleting postgres service")
-			svc := &v1.Service{
-				ObjectMeta: controllerruntime.ObjectMeta{
-					Name:      ps.Name,
-					Namespace: ps.Namespace,
-				},
-			}
-			err = p.Client.Delete(ctx, svc)
-			if err != nil && !k8serr.IsNotFound(err) {
-				errMsg := "failed to delete postgres service"
-				return types2.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
-			}
-
-			// delete pvc
-			p.Logger.Info("Deleting postgres persistent volume claim")
-			pvc := &v1.PersistentVolumeClaim{
-				ObjectMeta: controllerruntime.ObjectMeta{
-					Name:      ps.Name,
-					Namespace: ps.Namespace,
-				},
-			}
-			err = p.Client.Delete(ctx, pvc)
-			if err != nil && !k8serr.IsNotFound(err) {
-				errMsg := "failed to delete postgres persistent volume claim"
-				return types2.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
-			}
-
-			// delete secret
-			p.Logger.Info("Deleting postgres secret")
-			sec := &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      defaultCredentialsSec,
-					Namespace: ps.Namespace,
-				},
-			}
-			err = p.Client.Delete(ctx, sec)
-			if err != nil && !k8serr.IsNotFound(err) {
-				errMsg := "failed to deleted postgres secrets"
-				return types2.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
-			}
-
-			// clean up objects
-			p.Logger.Info("Deleting postgres deployment")
-			err = p.Client.Delete(ctx, dpl)
-			if err != nil && !k8serr.IsNotFound(err) {
-				errMsg := "failed to delete postgres deployment"
-				return types2.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
-			}
-
-			// remove the finalizer added by the provider
-			p.Logger.Info("Removing postgres finalizer")
-			resources.RemoveFinalizer(&ps.ObjectMeta, DefaultFinalizer)
-			if err := p.Client.Update(ctx, ps); err != nil {
-				errMsg := "failed to update instance as part of the postgres finalizer reconcile"
-				return types2.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
-			}
-
-			p.Logger.Infof("deletion handler for postgres %s in namespace %s finished successfully", ps.Name, ps.Namespace)
-		}
+	// delete pvc
+	p.Logger.Info("Deleting postgres persistent volume claim")
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: controllerruntime.ObjectMeta{
+			Name:      ps.Name,
+			Namespace: ps.Namespace,
+		},
+	}
+	err = p.Client.Delete(ctx, pvc)
+	if err != nil && !k8serr.IsNotFound(err) {
+		errMsg := "failed to delete postgres persistent volume claim"
+		return types2.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
 	}
 
+	// delete secret
+	p.Logger.Info("Deleting postgres secret")
+	sec := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultCredentialsSec,
+			Namespace: ps.Namespace,
+		},
+	}
+	err = p.Client.Delete(ctx, sec)
+	if err != nil && !k8serr.IsNotFound(err) {
+		errMsg := "failed to deleted postgres secrets"
+		return types2.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
+	}
+
+	// clean up objects
+	p.Logger.Info("Deleting postgres deployment")
+	dpl := &appsv1.Deployment{
+		ObjectMeta: controllerruntime.ObjectMeta{
+			Name:      ps.Name,
+			Namespace: ps.Namespace,
+		},
+	}
+	err = p.Client.Delete(ctx, dpl)
+	if err != nil && !k8serr.IsNotFound(err) {
+		errMsg := "failed to delete postgres deployment"
+		return types2.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
+	}
+
+	// remove the finalizer added by the provider
+	p.Logger.Info("Removing postgres finalizer")
+	resources.RemoveFinalizer(&ps.ObjectMeta, DefaultFinalizer)
+	if err := p.Client.Update(ctx, ps); err != nil {
+		errMsg := "failed to update instance as part of the postgres finalizer reconcile"
+		return types2.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
+	}
+
+	p.Logger.Infof("deletion handler for postgres %s in namespace %s finished successfully", ps.Name, ps.Namespace)
 	return "deletion in progress", nil
 }
 

--- a/pkg/providers/openshift/provider_postgres_test.go
+++ b/pkg/providers/openshift/provider_postgres_test.go
@@ -3,10 +3,11 @@ package openshift
 import (
 	"context"
 	"fmt"
-	types2 "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 	"reflect"
 	"testing"
 	"time"
+
+	types2 "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
 
@@ -105,7 +106,7 @@ func buildTestCredsSecret() *v1.Secret {
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      defaultCredentialsSec,
+			Name:      fmt.Sprintf("%s-%s", testPostgresName, defaultCredentialsSec),
 			Namespace: testPostgresNamespace,
 		},
 		Data: map[string][]byte{
@@ -354,7 +355,7 @@ func TestOpenShiftPostgresProvider_overrideDefaults(t *testing.T) {
 			},
 			getTestableSpec: func(ctx context.Context, c client.Client) (interface{}, error) {
 				sec := &v1.Secret{}
-				err := c.Get(ctx, types.NamespacedName{Name: defaultCredentialsSec, Namespace: testPostgresNamespace}, sec)
+				err := c.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-%s", testPostgresName, defaultCredentialsSec), Namespace: testPostgresNamespace}, sec)
 				return sec.StringData, err
 			},
 			wantErr: false,


### PR DESCRIPTION
## Overview
Fixes secret naming clashes when multiple postgres instances are deployed in the same namespace

## Verification with Integreatly
- Update the cluster service version for the `cloud-resources` manifest in the integreatly repo to point to my quay.io: `quay.io/dimitra/cloud-resource-operator:test` 
- Run the operator locally
```
make cluster/prepare/local
make code/run/service_account 
```
- Verify that codeready comes up successfully 
- Verify that there are 2 `<installation-name>-postgres-credentials` secrets in the integreatly namespace, 1 for 3scale and 1 for codeready

## Verification

- Run cro from this branch
- Create 2 postgres instances in the same namespace
- Ensure both instances run correctly and 2 separate credential secrets are created 