### PR TITLE
INTLY-3968 added tags to elasticache

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,22 @@ spec:
   type: managed
 ```
 
+## Resource tagging
+Postgres, Redis and Blobstorage resources are tagged with the following key value pairs
+
+```bash
+integreatly.org/clusterId: #clusterid
+integreatly.org/product-name: #rhmi component product name
+integreatly.org/resource-type: #managed/workshop 
+integreatly.org/resource-name: #postgres/redis/blobsorage
+```
+
+AWS resources can be queried via the aws cli with the cluster id as in the following example
+```bash
+# clusterid aucunnin-ch5dc
+aws resourcegroupstaggingapi get-resources --tag-filters Key=integreatly.org/clusterId,Values=aucunnin-ch5dc | jq
+```
+
 ## Development
 
 ### Contributing

--- a/deploy/crds/integreatly_v1alpha1_blobstorage_crd.yaml
+++ b/deploy/crds/integreatly_v1alpha1_blobstorage_crd.yaml
@@ -29,6 +29,23 @@ spec:
           type: object
         spec:
           properties:
+            env:
+              properties:
+                name:
+                  type: string
+                value:
+                  type: string
+              required:
+              - name
+              - value
+              type: object
+            labels:
+              properties:
+                productname:
+                  type: string
+              required:
+              - productname
+              type: object
             secretRef:
               properties:
                 name:
@@ -46,6 +63,8 @@ spec:
           - type
           - tier
           - secretRef
+          - env
+          - labels
           type: object
         status:
           properties:

--- a/deploy/crds/integreatly_v1alpha1_postgres_crd.yaml
+++ b/deploy/crds/integreatly_v1alpha1_postgres_crd.yaml
@@ -29,6 +29,23 @@ spec:
           type: object
         spec:
           properties:
+            env:
+              properties:
+                name:
+                  type: string
+                value:
+                  type: string
+              required:
+              - name
+              - value
+              type: object
+            labels:
+              properties:
+                productname:
+                  type: string
+              required:
+              - productname
+              type: object
             secretRef:
               properties:
                 name:
@@ -46,6 +63,8 @@ spec:
           - type
           - tier
           - secretRef
+          - env
+          - labels
           type: object
         status:
           properties:

--- a/deploy/crds/integreatly_v1alpha1_redis_cr.yaml
+++ b/deploy/crds/integreatly_v1alpha1_redis_cr.yaml
@@ -10,4 +10,10 @@ spec:
   # i want a redis storage of a development-level tier
   tier: development
   # i want a redis storage for the type workshop
-  type: workshop
+  type: managed
+  labels:
+    # label for the product we are installing , subject to change
+    productname: productNameHere
+  env:
+    name: DEFAULT_ORGANIZATION_TAG
+    value: integreatly.org/

--- a/deploy/crds/integreatly_v1alpha1_redis_crd.yaml
+++ b/deploy/crds/integreatly_v1alpha1_redis_crd.yaml
@@ -29,6 +29,23 @@ spec:
           type: object
         spec:
           properties:
+            env:
+              properties:
+                name:
+                  type: string
+                value:
+                  type: string
+              required:
+              - name
+              - value
+              type: object
+            labels:
+              properties:
+                productname:
+                  type: string
+              required:
+              - productname
+              type: object
             secretRef:
               properties:
                 name:
@@ -46,6 +63,8 @@ spec:
           - type
           - tier
           - secretRef
+          - env
+          - labels
           type: object
         status:
           properties:

--- a/deploy/crds/integreatly_v1alpha1_smtpcredentialset_crd.yaml
+++ b/deploy/crds/integreatly_v1alpha1_smtpcredentialset_crd.yaml
@@ -29,6 +29,23 @@ spec:
           type: object
         spec:
           properties:
+            env:
+              properties:
+                name:
+                  type: string
+                value:
+                  type: string
+              required:
+              - name
+              - value
+              type: object
+            labels:
+              properties:
+                productname:
+                  type: string
+              required:
+              - productname
+              type: object
             secretRef:
               properties:
                 name:
@@ -46,6 +63,8 @@ spec:
           - type
           - tier
           - secretRef
+          - env
+          - labels
           type: object
         status:
           properties:

--- a/pkg/apis/integreatly/v1alpha1/types/types.go
+++ b/pkg/apis/integreatly/v1alpha1/types/types.go
@@ -18,12 +18,23 @@ type SecretRef struct {
 	Namespace string `json:"namespace,omitempty"`
 }
 
+type Env struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type Labels struct {
+	ProductName string `json:"productname"`
+}
+
 // ResourceTypeSpec Represents the basic information required to provision a resource type
 // +k8s:openapi-gen=true
 type ResourceTypeSpec struct {
 	Type      string     `json:"type"`
 	Tier      string     `json:"tier"`
 	SecretRef *SecretRef `json:"secretRef"`
+	Env       *Env       `json:"env"`
+	Labels    *Labels    `json:"labels"`
 }
 
 type StatusPhase string

--- a/pkg/apis/integreatly/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/integreatly/v1alpha1/zz_generated.deepcopy.go
@@ -78,6 +78,16 @@ func (in *BlobStorageSpec) DeepCopyInto(out *BlobStorageSpec) {
 		*out = new(types.SecretRef)
 		**out = **in
 	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = new(types.Env)
+		**out = **in
+	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = new(types.Labels)
+		**out = **in
+	}
 	return
 }
 
@@ -179,6 +189,16 @@ func (in *PostgresSpec) DeepCopyInto(out *PostgresSpec) {
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
 		*out = new(types.SecretRef)
+		**out = **in
+	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = new(types.Env)
+		**out = **in
+	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = new(types.Labels)
 		**out = **in
 	}
 	return
@@ -284,6 +304,16 @@ func (in *RedisSpec) DeepCopyInto(out *RedisSpec) {
 		*out = new(types.SecretRef)
 		**out = **in
 	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = new(types.Env)
+		**out = **in
+	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = new(types.Labels)
+		**out = **in
+	}
 	return
 }
 
@@ -385,6 +415,16 @@ func (in *SMTPCredentialSetSpec) DeepCopyInto(out *SMTPCredentialSetSpec) {
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
 		*out = new(types.SecretRef)
+		**out = **in
+	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = new(types.Env)
+		**out = **in
+	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = new(types.Labels)
 		**out = **in
 	}
 	return

--- a/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
@@ -11,18 +11,18 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorage":             schema_pkg_apis_integreatly_v1alpha1_BlobStorage(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorageSpec":         schema_pkg_apis_integreatly_v1alpha1_BlobStorageSpec(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorageStatus":       schema_pkg_apis_integreatly_v1alpha1_BlobStorageStatus(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.Postgres":                schema_pkg_apis_integreatly_v1alpha1_Postgres(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.PostgresSpec":            schema_pkg_apis_integreatly_v1alpha1_PostgresSpec(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.PostgresStatus":          schema_pkg_apis_integreatly_v1alpha1_PostgresStatus(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.Redis":                   schema_pkg_apis_integreatly_v1alpha1_Redis(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.RedisSpec":               schema_pkg_apis_integreatly_v1alpha1_RedisSpec(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.RedisStatus":             schema_pkg_apis_integreatly_v1alpha1_RedisStatus(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSet":       schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSet(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSetSpec":   schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSetSpec(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSetStatus": schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSetStatus(ref),
+		"./pkg/apis/integreatly/v1alpha1.BlobStorage":             schema_pkg_apis_integreatly_v1alpha1_BlobStorage(ref),
+		"./pkg/apis/integreatly/v1alpha1.BlobStorageSpec":         schema_pkg_apis_integreatly_v1alpha1_BlobStorageSpec(ref),
+		"./pkg/apis/integreatly/v1alpha1.BlobStorageStatus":       schema_pkg_apis_integreatly_v1alpha1_BlobStorageStatus(ref),
+		"./pkg/apis/integreatly/v1alpha1.Postgres":                schema_pkg_apis_integreatly_v1alpha1_Postgres(ref),
+		"./pkg/apis/integreatly/v1alpha1.PostgresSpec":            schema_pkg_apis_integreatly_v1alpha1_PostgresSpec(ref),
+		"./pkg/apis/integreatly/v1alpha1.PostgresStatus":          schema_pkg_apis_integreatly_v1alpha1_PostgresStatus(ref),
+		"./pkg/apis/integreatly/v1alpha1.Redis":                   schema_pkg_apis_integreatly_v1alpha1_Redis(ref),
+		"./pkg/apis/integreatly/v1alpha1.RedisSpec":               schema_pkg_apis_integreatly_v1alpha1_RedisSpec(ref),
+		"./pkg/apis/integreatly/v1alpha1.RedisStatus":             schema_pkg_apis_integreatly_v1alpha1_RedisStatus(ref),
+		"./pkg/apis/integreatly/v1alpha1.SMTPCredentialSet":       schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSet(ref),
+		"./pkg/apis/integreatly/v1alpha1.SMTPCredentialSetSpec":   schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSetSpec(ref),
+		"./pkg/apis/integreatly/v1alpha1.SMTPCredentialSetStatus": schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSetStatus(ref),
 	}
 }
 
@@ -53,19 +53,19 @@ func schema_pkg_apis_integreatly_v1alpha1_BlobStorage(ref common.ReferenceCallba
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorageSpec"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.BlobStorageSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorageStatus"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.BlobStorageStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorageSpec", "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorageStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./pkg/apis/integreatly/v1alpha1.BlobStorageSpec", "./pkg/apis/integreatly/v1alpha1.BlobStorageStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -92,12 +92,22 @@ func schema_pkg_apis_integreatly_v1alpha1_BlobStorageSpec(ref common.ReferenceCa
 							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.SecretRef"),
 						},
 					},
+					"env": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.Env"),
+						},
+					},
+					"labels": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.Labels"),
+						},
+					},
 				},
-				Required: []string{"type", "tier", "secretRef"},
+				Required: []string{"type", "tier", "secretRef", "env", "labels"},
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.SecretRef"},
+			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.Env", "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.Labels", "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.SecretRef"},
 	}
 }
 
@@ -171,19 +181,19 @@ func schema_pkg_apis_integreatly_v1alpha1_Postgres(ref common.ReferenceCallback)
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.PostgresSpec"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.PostgresSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.PostgresStatus"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.PostgresStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.PostgresSpec", "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.PostgresStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./pkg/apis/integreatly/v1alpha1.PostgresSpec", "./pkg/apis/integreatly/v1alpha1.PostgresStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -210,12 +220,22 @@ func schema_pkg_apis_integreatly_v1alpha1_PostgresSpec(ref common.ReferenceCallb
 							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.SecretRef"),
 						},
 					},
+					"env": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.Env"),
+						},
+					},
+					"labels": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.Labels"),
+						},
+					},
 				},
-				Required: []string{"type", "tier", "secretRef"},
+				Required: []string{"type", "tier", "secretRef", "env", "labels"},
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.SecretRef"},
+			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.Env", "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.Labels", "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.SecretRef"},
 	}
 }
 
@@ -289,19 +309,19 @@ func schema_pkg_apis_integreatly_v1alpha1_Redis(ref common.ReferenceCallback) co
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.RedisSpec"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.RedisSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.RedisStatus"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.RedisStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.RedisSpec", "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.RedisStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./pkg/apis/integreatly/v1alpha1.RedisSpec", "./pkg/apis/integreatly/v1alpha1.RedisStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -328,12 +348,22 @@ func schema_pkg_apis_integreatly_v1alpha1_RedisSpec(ref common.ReferenceCallback
 							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.SecretRef"),
 						},
 					},
+					"env": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.Env"),
+						},
+					},
+					"labels": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.Labels"),
+						},
+					},
 				},
-				Required: []string{"type", "tier", "secretRef"},
+				Required: []string{"type", "tier", "secretRef", "env", "labels"},
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.SecretRef"},
+			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.Env", "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.Labels", "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.SecretRef"},
 	}
 }
 
@@ -407,19 +437,19 @@ func schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSet(ref common.Reference
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSetSpec"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.SMTPCredentialSetSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSetStatus"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.SMTPCredentialSetStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSetSpec", "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSetStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./pkg/apis/integreatly/v1alpha1.SMTPCredentialSetSpec", "./pkg/apis/integreatly/v1alpha1.SMTPCredentialSetStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -446,12 +476,22 @@ func schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSetSpec(ref common.Refer
 							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.SecretRef"),
 						},
 					},
+					"env": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.Env"),
+						},
+					},
+					"labels": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.Labels"),
+						},
+					},
 				},
-				Required: []string{"type", "tier", "secretRef"},
+				Required: []string{"type", "tier", "secretRef", "env", "labels"},
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.SecretRef"},
+			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.Env", "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.Labels", "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types.SecretRef"},
 	}
 }
 

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -69,6 +69,16 @@ func buildTestRedisCR() *v1alpha1.Redis {
 			Name:      "test",
 			Namespace: "test",
 		},
+		Spec: v1alpha1.RedisSpec{
+			Tier: "test",
+			Env: &types.Env{
+				Name:  "test",
+				Value: "test",
+			},
+			Labels: &types.Labels{
+				ProductName: "test",
+			},
+		},
 	}
 }
 
@@ -120,6 +130,7 @@ func Test_createRedisCluster(t *testing.T) {
 		r           *v1alpha1.Redis
 		cacheSvc    elasticacheiface.ElastiCacheAPI
 		redisConfig *elasticache.CreateReplicationGroupInput
+		stratCfg    *StrategyConfig
 	}
 	type fields struct {
 		Client            client.Client
@@ -141,6 +152,7 @@ func Test_createRedisCluster(t *testing.T) {
 				cacheSvc:    &mockElasticacheClient{replicationGroups: []*elasticache.ReplicationGroup{}},
 				r:           buildTestRedisCR(),
 				redisConfig: &elasticache.CreateReplicationGroupInput{},
+				stratCfg:    &StrategyConfig{Region: "test"},
 			},
 			fields: fields{
 				ConfigManager:     nil,
@@ -158,6 +170,7 @@ func Test_createRedisCluster(t *testing.T) {
 				cacheSvc:    &mockElasticacheClient{replicationGroups: buildReplicationGroupPending()},
 				r:           buildTestRedisCR(),
 				redisConfig: &elasticache.CreateReplicationGroupInput{ReplicationGroupId: aws.String("test-id")},
+				stratCfg:    &StrategyConfig{Region: "test"},
 			},
 			fields: fields{
 				ConfigManager:     nil,
@@ -175,6 +188,7 @@ func Test_createRedisCluster(t *testing.T) {
 				cacheSvc:    &mockElasticacheClient{replicationGroups: buildReplicationGroupReady()},
 				r:           buildTestRedisCR(),
 				redisConfig: &elasticache.CreateReplicationGroupInput{ReplicationGroupId: aws.String("test-id")},
+				stratCfg:    &StrategyConfig{Region: "test"},
 			},
 			fields: fields{
 				ConfigManager:     nil,
@@ -196,6 +210,7 @@ func Test_createRedisCluster(t *testing.T) {
 					CacheNodeType:          aws.String("test"),
 					SnapshotRetentionLimit: aws.Int64(20),
 				},
+				stratCfg: &StrategyConfig{Region: "test"},
 			},
 			fields: fields{
 				ConfigManager:     nil,
@@ -215,7 +230,7 @@ func Test_createRedisCluster(t *testing.T) {
 				CredentialManager: tt.fields.CredentialManager,
 				ConfigManager:     tt.fields.ConfigManager,
 			}
-			got, _, err := p.createElasticacheCluster(tt.args.ctx, tt.args.r, tt.args.cacheSvc, tt.args.redisConfig)
+			got, _, err := p.createElasticacheCluster(tt.args.ctx, tt.args.r, tt.args.cacheSvc, tt.args.redisConfig, tt.args.stratCfg)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createElasticacheCluster() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/test/e2e/openshift_blobstorage_test.go
+++ b/test/e2e/openshift_blobstorage_test.go
@@ -118,6 +118,13 @@ func getBasicBlobstorage(ctx framework.TestCtx) (*v1alpha1.BlobStorage, string, 
 			},
 			Tier: "development",
 			Type: "workshop",
+			Env: &t1.Env{
+				Name:  "DEFAULT_ORGANIZATION_TAG",
+				Value: "integreatly.org/",
+			},
+			Labels: &t1.Labels{
+				ProductName: "productname",
+			},
 		},
 	}, namespace, nil
 }

--- a/test/e2e/openshift_postgres_test.go
+++ b/test/e2e/openshift_postgres_test.go
@@ -407,6 +407,13 @@ func getBasicTestPostgres(ctx framework.TestCtx) (*v1alpha1.Postgres, string, er
 			},
 			Tier: "development",
 			Type: "workshop",
+			Env: &types2.Env{
+				Name:  "DEFAULT_ORGANIZATION_TAG",
+				Value: "integreatly.org/",
+			},
+			Labels: &types2.Labels{
+				ProductName: "productname",
+			},
 		},
 	}, namespace, nil
 }

--- a/test/e2e/openshift_redis_test.go
+++ b/test/e2e/openshift_redis_test.go
@@ -341,6 +341,13 @@ func getBasicTestRedis(ctx framework.TestCtx) (*v1alpha1.Redis, string, error) {
 			},
 			Tier: "development",
 			Type: "workshop",
+			Env: &types2.Env{
+				Name:  "DEFAULT_ORGANIZATION_TAG",
+				Value: "integreatly.org/",
+			},
+			Labels: &types2.Labels{
+				ProductName: "productname",
+			},
 		},
 	}, namespace, nil
 }

--- a/test/e2e/openshift_smtp_test.go
+++ b/test/e2e/openshift_smtp_test.go
@@ -119,6 +119,13 @@ func getBasicSMTP(ctx framework.TestCtx) (*v1alpha1.SMTPCredentialSet, string, e
 			},
 			Tier: "development",
 			Type: "workshop",
+			Env: &t1.Env{
+				Name:  "DEFAULT_ORGANIZATION_TAG",
+				Value: "integreatly.org/",
+			},
+			Labels: &t1.Labels{
+				ProductName: "productname",
+			},
 		},
 	}, namespace, nil
 }


### PR DESCRIPTION
## Overview

Jira: https://issues.jboss.org/browse/INTLY-3968

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Add the following cr to the cloud-resources-operator namespace
```yaml
apiVersion: integreatly.org/v1alpha1
kind: Redis
metadata:
  # name must be between 1-40 characters
  name: example-redis
spec:
  # i want my redis storage information output in a secret named example-redis-sec
  secretRef:
    name: example-redis-sec
  # i want a redis storage of a development-level tier
  tier: development
  # i want a redis storage for the type workshop
  type: managed
  labels:
    # label for the product we are installing , subject to change
    productname: productNameHere
  env:
    name: DEFAULT_ORGANIZATION_TAG
    value: integreatly.org/
```

- Run `make run`
- Ensure Tags are added to the Redis instance