### PR TITLE
add skip create logic to aws redis and postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ Currently AWS resources are deployed into a separate Virtual Private Cloud (VPC)
 
 The two VPCs should now be able to communicate with each other. 
 
+## Skip Create
+The cloud resource operator continuously reconciles using the strat-config as a source of truth for the current state of the provisioned resources. Should these resources alter from the expected the state the operator will update the resources to match the expected state.  
+
+There can be circumstances where a provisioned resource would need to be altered. If this is the case, add `skipCreate: true` to the resources CR `spec`. This will cause the operator to skip creating or updating the resource. 
+
 ## Via the Operator Catalog
 
 ***In development***

--- a/deploy/crds/integreatly_v1alpha1_blobstorage_crd.yaml
+++ b/deploy/crds/integreatly_v1alpha1_blobstorage_crd.yaml
@@ -38,6 +38,8 @@ spec:
               required:
               - name
               type: object
+            skipCreate:
+              type: boolean
             tier:
               type: string
             type:

--- a/deploy/crds/integreatly_v1alpha1_postgres_crd.yaml
+++ b/deploy/crds/integreatly_v1alpha1_postgres_crd.yaml
@@ -38,6 +38,8 @@ spec:
               required:
               - name
               type: object
+            skipCreate:
+              type: boolean
             tier:
               type: string
             type:

--- a/deploy/crds/integreatly_v1alpha1_redis_crd.yaml
+++ b/deploy/crds/integreatly_v1alpha1_redis_crd.yaml
@@ -38,6 +38,8 @@ spec:
               required:
               - name
               type: object
+            skipCreate:
+              type: boolean
             tier:
               type: string
             type:

--- a/deploy/crds/integreatly_v1alpha1_smtpcredentialset_crd.yaml
+++ b/deploy/crds/integreatly_v1alpha1_smtpcredentialset_crd.yaml
@@ -38,6 +38,8 @@ spec:
               required:
               - name
               type: object
+            skipCreate:
+              type: boolean
             tier:
               type: string
             type:

--- a/pkg/apis/integreatly/v1alpha1/types/types.go
+++ b/pkg/apis/integreatly/v1alpha1/types/types.go
@@ -6,10 +6,12 @@ var (
 	PhaseInProgress                StatusPhase   = "in progress"
 	PhaseDeleteInProgress          StatusPhase   = "deletion in progress"
 	PhaseComplete                  StatusPhase   = "complete"
+	PhasePaused                    StatusPhase   = "paused"
 	PhaseFailed                    StatusPhase   = "failed"
 	StatusEmpty                    StatusMessage = ""
 	StatusUnsupportedType          StatusMessage = "unsupported deployment type"
 	StatusDeploymentConfigNotFound StatusMessage = "deployment configuration not found"
+	StatusSkipCreate               StatusMessage = "skipping create or update for maintenance"
 )
 
 // SecretRef Represents a namespace-scoped Secret
@@ -21,9 +23,10 @@ type SecretRef struct {
 // ResourceTypeSpec Represents the basic information required to provision a resource type
 // +k8s:openapi-gen=true
 type ResourceTypeSpec struct {
-	Type      string     `json:"type"`
-	Tier      string     `json:"tier"`
-	SecretRef *SecretRef `json:"secretRef"`
+	Type       string     `json:"type"`
+	Tier       string     `json:"tier"`
+	SkipCreate bool       `json:"skipCreate,omitempty"`
+	SecretRef  *SecretRef `json:"secretRef"`
 }
 
 type StatusPhase string

--- a/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
@@ -11,18 +11,18 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorage":             schema_pkg_apis_integreatly_v1alpha1_BlobStorage(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorageSpec":         schema_pkg_apis_integreatly_v1alpha1_BlobStorageSpec(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorageStatus":       schema_pkg_apis_integreatly_v1alpha1_BlobStorageStatus(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.Postgres":                schema_pkg_apis_integreatly_v1alpha1_Postgres(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.PostgresSpec":            schema_pkg_apis_integreatly_v1alpha1_PostgresSpec(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.PostgresStatus":          schema_pkg_apis_integreatly_v1alpha1_PostgresStatus(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.Redis":                   schema_pkg_apis_integreatly_v1alpha1_Redis(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.RedisSpec":               schema_pkg_apis_integreatly_v1alpha1_RedisSpec(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.RedisStatus":             schema_pkg_apis_integreatly_v1alpha1_RedisStatus(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSet":       schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSet(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSetSpec":   schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSetSpec(ref),
-		"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSetStatus": schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSetStatus(ref),
+		"./pkg/apis/integreatly/v1alpha1.BlobStorage":             schema_pkg_apis_integreatly_v1alpha1_BlobStorage(ref),
+		"./pkg/apis/integreatly/v1alpha1.BlobStorageSpec":         schema_pkg_apis_integreatly_v1alpha1_BlobStorageSpec(ref),
+		"./pkg/apis/integreatly/v1alpha1.BlobStorageStatus":       schema_pkg_apis_integreatly_v1alpha1_BlobStorageStatus(ref),
+		"./pkg/apis/integreatly/v1alpha1.Postgres":                schema_pkg_apis_integreatly_v1alpha1_Postgres(ref),
+		"./pkg/apis/integreatly/v1alpha1.PostgresSpec":            schema_pkg_apis_integreatly_v1alpha1_PostgresSpec(ref),
+		"./pkg/apis/integreatly/v1alpha1.PostgresStatus":          schema_pkg_apis_integreatly_v1alpha1_PostgresStatus(ref),
+		"./pkg/apis/integreatly/v1alpha1.Redis":                   schema_pkg_apis_integreatly_v1alpha1_Redis(ref),
+		"./pkg/apis/integreatly/v1alpha1.RedisSpec":               schema_pkg_apis_integreatly_v1alpha1_RedisSpec(ref),
+		"./pkg/apis/integreatly/v1alpha1.RedisStatus":             schema_pkg_apis_integreatly_v1alpha1_RedisStatus(ref),
+		"./pkg/apis/integreatly/v1alpha1.SMTPCredentialSet":       schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSet(ref),
+		"./pkg/apis/integreatly/v1alpha1.SMTPCredentialSetSpec":   schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSetSpec(ref),
+		"./pkg/apis/integreatly/v1alpha1.SMTPCredentialSetStatus": schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSetStatus(ref),
 	}
 }
 
@@ -53,19 +53,19 @@ func schema_pkg_apis_integreatly_v1alpha1_BlobStorage(ref common.ReferenceCallba
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorageSpec"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.BlobStorageSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorageStatus"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.BlobStorageStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorageSpec", "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.BlobStorageStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./pkg/apis/integreatly/v1alpha1.BlobStorageSpec", "./pkg/apis/integreatly/v1alpha1.BlobStorageStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -84,6 +84,12 @@ func schema_pkg_apis_integreatly_v1alpha1_BlobStorageSpec(ref common.ReferenceCa
 					"tier": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"skipCreate": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},
@@ -171,19 +177,19 @@ func schema_pkg_apis_integreatly_v1alpha1_Postgres(ref common.ReferenceCallback)
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.PostgresSpec"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.PostgresSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.PostgresStatus"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.PostgresStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.PostgresSpec", "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.PostgresStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./pkg/apis/integreatly/v1alpha1.PostgresSpec", "./pkg/apis/integreatly/v1alpha1.PostgresStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -202,6 +208,12 @@ func schema_pkg_apis_integreatly_v1alpha1_PostgresSpec(ref common.ReferenceCallb
 					"tier": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"skipCreate": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},
@@ -289,19 +301,19 @@ func schema_pkg_apis_integreatly_v1alpha1_Redis(ref common.ReferenceCallback) co
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.RedisSpec"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.RedisSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.RedisStatus"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.RedisStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.RedisSpec", "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.RedisStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./pkg/apis/integreatly/v1alpha1.RedisSpec", "./pkg/apis/integreatly/v1alpha1.RedisStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -320,6 +332,12 @@ func schema_pkg_apis_integreatly_v1alpha1_RedisSpec(ref common.ReferenceCallback
 					"tier": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"skipCreate": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},
@@ -407,19 +425,19 @@ func schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSet(ref common.Reference
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSetSpec"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.SMTPCredentialSetSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSetStatus"),
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.SMTPCredentialSetStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSetSpec", "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1.SMTPCredentialSetStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./pkg/apis/integreatly/v1alpha1.SMTPCredentialSetSpec", "./pkg/apis/integreatly/v1alpha1.SMTPCredentialSetStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -438,6 +456,12 @@ func schema_pkg_apis_integreatly_v1alpha1_SMTPCredentialSetSpec(ref common.Refer
 					"tier": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"skipCreate": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},

--- a/pkg/controller/blobstorage/blobstorage_controller.go
+++ b/pkg/controller/blobstorage/blobstorage_controller.go
@@ -81,7 +81,7 @@ type ReconcileBlobStorage struct {
 }
 
 func (r *ReconcileBlobStorage) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	r.logger.Info("Reconciling BlobStorage")
+	r.logger.Info("reconciling BlobStorage")
 	ctx := context.TODO()
 	cfgMgr := providers.NewConfigManager(providers.DefaultProviderConfigMapName, request.Namespace, r.client)
 
@@ -121,7 +121,7 @@ func (r *ReconcileBlobStorage) Reconcile(request reconcile.Request) (reconcile.R
 				return reconcile.Result{}, errorUtil.Wrapf(err, "failed to perform provider-specific storage deletion")
 			}
 
-			r.logger.Info("Waiting on blob storage to successfully delete")
+			r.logger.Info("waiting on blob storage to successfully delete")
 			if err = resources.UpdatePhase(ctx, r.client, instance, types.PhaseDeleteInProgress, msg.WrapError(err)); err != nil {
 				return reconcile.Result{}, err
 			}
@@ -137,7 +137,7 @@ func (r *ReconcileBlobStorage) Reconcile(request reconcile.Request) (reconcile.R
 			return reconcile.Result{}, err
 		}
 		if bsi == nil {
-			r.logger.Info("Secret data is still reconciling, blob storage is nil")
+			r.logger.Info("secret data is still reconciling, blob storage is nil")
 			instance.Status.SecretRef = &types.SecretRef{}
 			if err = resources.UpdatePhase(ctx, r.client, instance, types.PhaseInProgress, msg); err != nil {
 				return reconcile.Result{}, err

--- a/pkg/controller/smtpcredentialset/smtpcredentialset_controller.go
+++ b/pkg/controller/smtpcredentialset/smtpcredentialset_controller.go
@@ -82,7 +82,7 @@ type ReconcileSMTPCredentialSet struct {
 // Reconcile reads that state of the cluster for a SMTPCredentials object and makes changes based on the state read
 // and what is in the SMTPCredentials.Spec
 func (r *ReconcileSMTPCredentialSet) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	r.logger.Info("Reconciling SMTPCredentials")
+	r.logger.Info("reconciling SMTPCredentials")
 	ctx := context.TODO()
 	cfgMgr := providers.NewConfigManager(providers.DefaultProviderConfigMapName, request.Namespace, r.client)
 
@@ -125,7 +125,7 @@ func (r *ReconcileSMTPCredentialSet) Reconcile(request reconcile.Request) (recon
 				return reconcile.Result{}, errorUtil.Wrapf(err, "failed to run delete handler for smtp credentials instance %s", instance.Name)
 			}
 
-			r.logger.Infof("Waiting for SMTP credentials to successfully delete")
+			r.logger.Infof("waiting for SMTP credentials to successfully delete")
 			if updateErr := resources.UpdatePhase(ctx, r.client, instance, types.PhaseDeleteInProgress, msg); updateErr != nil {
 				return reconcile.Result{}, updateErr
 			}

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 	"time"
+
+	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 
 	"github.com/aws/aws-sdk-go/service/elasticache/elasticacheiface"
 	"github.com/sirupsen/logrus"
@@ -28,12 +29,11 @@ import (
 const (
 	redisProviderName = "aws-elasticache"
 	// default create params
-	defaultCacheNodeType      = "cache.t2.micro"
-	defaultEngineVersion      = "3.2.10"
-	defaultDescription        = "A Redis replication group"
-	defaultNumCacheClusters   = 2
-	defaultSnapshotRetention  = 30
-	NoFinalSnapshotIdentifier = ""
+	defaultCacheNodeType     = "cache.t2.micro"
+	defaultEngineVersion     = "3.2.10"
+	defaultDescription       = "A Redis replication group"
+	defaultNumCacheClusters  = 2
+	defaultSnapshotRetention = 30
 )
 
 var _ providers.RedisProvider = (*AWSRedisProvider)(nil)


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/INTLY-4345

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Seed the cluster with the following
```
apiVersion: integreatly.org/v1alpha1
kind: Redis
metadata:
  name: example-redis
spec:
  secretRef:
    name: example-redis-sec
  tier: development
  type: managed
  skipCreate: true
```
```
apiVersion: integreatly.org/v1alpha1
kind: Postgres
metadata:
  name: example-postgres
spec:
  secretRef:
    name: example-postgres-sec
  tier: development
  type: managed
  skipCreate: true
```
- Run `make run`
- Ensure both Postgres and Redis creation has not begun in AWS and the `Status` is updated to `paused`
- Remove `skipCreate: true` from CR's or set `skipCreate:false`
- Ensure both Postgres and Redis creation starts in AWS and the `Status` changed to reflect that.