### PR TITLE
Update seed targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,21 +79,38 @@ cluster/prepare:
 	oc create -f ./deploy/role_binding.yaml -n $(NAMESPACE)
 	oc create -f ./deploy/examples/ -n $(NAMESPACE)
 
-.PHONY: cluster/seed/smtp
-cluster/seed/smtp:
-	oc apply -f ./deploy/crds/integreatly_v1alpha1_smtpcredentialset_cr.yaml -n $(NAMESPACE)
+.PHONY: cluster/seed/workshop/smtp
+cluster/seed/workshop/smtp:
+	@cat deploy/crds/integreatly_v1alpha1_smtpcredentialset_cr.yaml | sed "s/type: REPLACE_ME/type: workshop/g" | oc apply -f - -n $(NAMESPACE)
 
-.PHONY: cluster/seed/blobstorage
-cluster/seed/blobstorage:
-	oc apply -f ./deploy/crds/integreatly_v1alpha1_blobstorage_cr.yaml -n $(NAMESPACE)
+.PHONY: cluster/seed/managed/smtp
+cluster/seed/managed/smtp:
+	@cat deploy/crds/integreatly_v1alpha1_smtpcredentialset_cr.yaml | sed "s/type: REPLACE_ME/type: managed/g" | oc apply -f - -n $(NAMESPACE)
 
-.PHONY: cluster/seed/redis
-cluster/seed/redis:
-	oc apply -f ./deploy/crds/integreatly_v1alpha1_redis_cr.yaml -n $(NAMESPACE)
+.PHONY: cluster/seed/workshop/blobstorage
+cluster/seed/workshop/blobstorage:
+	@cat deploy/crds/integreatly_v1alpha1_blobstorage_cr.yaml | sed "s/type: REPLACE_ME/type: workshop/g" | oc apply -f - -n $(NAMESPACE)
 
-.PHONY: cluster/seed/postgres
-cluster/seed/postgres:
-	oc apply -f ./deploy/crds/integreatly_v1alpha1_postgres_cr.yaml -n $(NAMESPACE)
+.PHONY: cluster/seed/managed/blobstorage
+cluster/seed/managed/blobstorage:
+	@cat deploy/crds/integreatly_v1alpha1_blobstorage_cr.yaml | sed "s/type: REPLACE_ME/type: managed/g" | oc apply -f - -n $(NAMESPACE)
+
+.PHONY: cluster/seed/workshop/redis
+cluster/seed/workshop/redis:
+	@cat deploy/crds/integreatly_v1alpha1_redis_cr.yaml | sed "s/type: REPLACE_ME/type: workshop/g" | oc apply -f - -n $(NAMESPACE)
+
+.PHONY: cluster/seed/managed/redis
+cluster/seed/managed/redis:
+	@cat deploy/crds/integreatly_v1alpha1_redis_cr.yaml | sed "s/type: REPLACE_ME/type: managed/g" | oc apply -f - -n $(NAMESPACE)
+
+.PHONY: cluster/seed/workshop/postgres
+cluster/seed/workshop/postgres:
+	@cat deploy/crds/integreatly_v1alpha1_postgres_cr.yaml | sed "s/type: REPLACE_ME/type: workshop/g" | oc apply -f - -n $(NAMESPACE)
+
+.PHONY: cluster/seed/managed/postgres
+cluster/seed/managed/postgres:
+	@cat deploy/crds/integreatly_v1alpha1_postgres_cr.yaml | sed "s/type: REPLACE_ME/type: managed/g" | oc apply -f - -n $(NAMESPACE)
+
 
 .PHONY: cluster/clean
 cluster/clean:

--- a/deploy/crds/integreatly_v1alpha1_blobstorage_cr.yaml
+++ b/deploy/crds/integreatly_v1alpha1_blobstorage_cr.yaml
@@ -9,5 +9,5 @@ spec:
     name: example-blobstorage-sec
   # i want a blob storage of a development-level tier
   tier: development
-  # i want a blob storage for the type managed
-  type: managed
+  # the type i want for a blob storage
+  type: REPLACE_ME

--- a/deploy/crds/integreatly_v1alpha1_postgres_cr.yaml
+++ b/deploy/crds/integreatly_v1alpha1_postgres_cr.yaml
@@ -9,5 +9,5 @@ spec:
     name: example-postgres-sec
   # i want a postgres storage of a development-level tier
   tier: development
-  # i want a postgres storage for the type workshop
-  type: workshop
+  # the type i want for a postgres storage
+  type: REPLACE_ME

--- a/deploy/crds/integreatly_v1alpha1_redis_cr.yaml
+++ b/deploy/crds/integreatly_v1alpha1_redis_cr.yaml
@@ -9,5 +9,5 @@ spec:
     name: example-redis-sec
   # i want a redis storage of a development-level tier
   tier: development
-  # i want a redis storage for the type workshop
-  type: workshop
+  # the type i want for a redis storage
+  type: REPLACE_ME

--- a/deploy/crds/integreatly_v1alpha1_smtpcredentialset_cr.yaml
+++ b/deploy/crds/integreatly_v1alpha1_smtpcredentialset_cr.yaml
@@ -9,5 +9,5 @@ spec:
     name: example-smtpcredentialset-sec
   # i want an smtp cred set of a development-level tier
   tier: development
-  # i want an smpt cred set for the type managed
-  type: managed
+  # the type i want for an smpt cred
+  type: REPLACE_ME


### PR DESCRIPTION
## Overview

During development we often have to switch between provisioning managed and workshop types. To help speed up this process this change allows you to seed the `type` you want

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run make seed targets
- Ensure CR's are created as expected