### PR TITLE
Fix CSV Formatting & Add Product Name to Util Function

### DIFF
--- a/deploy/olm-catalog/cloud-resources/0.6.0/cloud-resources.v0.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/cloud-resources/0.6.0/cloud-resources.v0.6.0.clusterserviceversion.yaml
@@ -6,6 +6,23 @@ metadata:
       [
         {
           "apiVersion": "integreatly.org/v1alpha1",
+          "kind": "BlobStorage",
+          "metadata": {
+            "labels": {
+              "productName": "ProductName"
+            },
+            "name": "example-blobstorage"
+          },
+          "spec": {
+            "secretRef": {
+              "name": "example-blobstorage-sec"
+            },
+            "tier": "development",
+            "type": "REPLACE_ME"
+          }
+        },
+        {
+          "apiVersion": "integreatly.org/v1alpha1",
           "kind": "Postgres",
           "metadata": {
             "labels": {
@@ -74,29 +91,12 @@ metadata:
             "tier": "development",
             "type": "REPLACE_ME"
           }
-        },
-        {
-          "apiVersion": "integreatly.org/v1alpha1",
-          "kind": "BlobStorage",
-          "metadata": {
-            "labels": {
-              "productName": "ProductName"
-            },
-            "name": "example-blobstorage"
-          },
-          "spec": {
-            "secretRef": {
-              "name": "example-blobstorage-sec"
-            },
-            "tier": "development",
-            "type": "REPLACE_ME"
-          }
         }
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
     certified: "false"
-    containerImage: quay.io/integreatly/cloud-resource-operator:0.5.0
+    containerImage: quay.io/integreatly/cloud-resource-operator:v0.6.0
     createdAt: "2019-10-07 12:34:56"
     description: Operator to provision cloud provider resources in an abstracted manner
     support: Integreatly
@@ -142,9 +142,15 @@ spec:
         displayName: Secret Reference
         path: secretRef
       version: v1alpha1
-    - kind: PostgresSnapshot
+    - description: Represents an instance of a Postgres Snapshot
+      displayName: Postgres Snapshot
+      kind: PostgresSnapshot
       name: postgressnapshots.integreatly.org
       version: v1alpha1
+      specDescriptors:
+        - description: The type of the resource to snapshot
+          displayName: ResourceName
+          path: resourceName
     - description: Represents an instance of a Redis cluster in a provider
       displayName: Redis
       kind: Redis
@@ -163,9 +169,15 @@ spec:
         displayName: Secret Reference
         path: secretRef
       version: v1alpha1
-    - kind: RedisSnapshot
+    - description: Represents an instance of Postgres Snapshot
+      displayName: Redis Snapshot
+      kind: RedisSnapshot
       name: redissnapshots.integreatly.org
       version: v1alpha1
+      specDescriptors:
+        - description: The type of the resource to snapshot
+          displayName: ResourceName
+          path: resourceName
     - description: Represents an instance of SMTP credentials in a provider
       displayName: SMTP Credentials
       kind: SMTPCredentialSet
@@ -239,7 +251,7 @@ spec:
                   value: cloud-resource-operator
                 - name: TAG_KEY_PREFIX
                   value: integreatly.org/
-                image: quay.io/integreatly/cloud-resource-operator:0.6.0
+                image: quay.io/integreatly/cloud-resource-operator:v0.6.0
                 imagePullPolicy: Always
                 name: cloud-resource-operator
                 resources: {}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/lib/pq v1.2.0
 	github.com/onsi/ginkgo v1.10.1 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
+	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/openshift/api v3.9.1-0.20191002160657-d92789481b05+incompatible
 	github.com/openshift/cloud-credential-operator v0.0.0-20190812222907-ec6f38d73a79
 	github.com/operator-framework/operator-sdk v0.12.1-0.20191112211508-82fc57de5e5b
@@ -28,7 +29,9 @@ require (
 	golang.org/x/net v0.0.0-20191003171128-d98b1b443823 // indirect
 	golang.org/x/sys v0.0.0-20200113162924-86b910548bc1 // indirect
 	google.golang.org/appengine v1.6.2 // indirect
+	google.golang.org/genproto v0.0.0-20181016170114-94acd270e44e // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v11.0.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/lib/pq v1.2.0
 	github.com/onsi/ginkgo v1.10.1 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
-	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/openshift/api v3.9.1-0.20191002160657-d92789481b05+incompatible
 	github.com/openshift/cloud-credential-operator v0.0.0-20190812222907-ec6f38d73a79
 	github.com/operator-framework/operator-sdk v0.12.1-0.20191112211508-82fc57de5e5b
@@ -29,9 +28,7 @@ require (
 	golang.org/x/net v0.0.0-20191003171128-d98b1b443823 // indirect
 	golang.org/x/sys v0.0.0-20200113162924-86b910548bc1 // indirect
 	google.golang.org/appengine v1.6.2 // indirect
-	google.golang.org/genproto v0.0.0-20181016170114-94acd270e44e // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v11.0.0+incompatible

--- a/pkg/resources/config.go
+++ b/pkg/resources/config.go
@@ -14,8 +14,8 @@ import (
 const (
 	EnvForceReconcileTimeout = "ENV_FORCE_RECONCILE_TIMEOUT"
 	DefaultTagKeyPrefix      = "integreatly.org/"
-	ErrorReconcileTime 		 = time.Second * 30
-	SuccessReconcileTime	 = time.Second * 60
+	ErrorReconcileTime       = time.Second * 30
+	SuccessReconcileTime     = time.Second * 60
 )
 
 // returns envar for reconcile time else returns default time

--- a/pkg/resources/util.go
+++ b/pkg/resources/util.go
@@ -15,13 +15,13 @@ import (
 type modifyResourceFunc func(cr metav1.Object) error
 
 // ReconcileBlobStorage creates or updates a blob storage custom resource
-func ReconcileBlobStorage(ctx context.Context, client client.Client, deploymentType, tier, name, ns, secretName, secretNs string, modifyFunc modifyResourceFunc) (*v1alpha1.BlobStorage, error) {
+func ReconcileBlobStorage(ctx context.Context, client client.Client, productName, deploymentType, tier, name, ns, secretName, secretNs string, modifyFunc modifyResourceFunc) (*v1alpha1.BlobStorage, error) {
 	bs := &v1alpha1.BlobStorage{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
 			Labels: map[string]string{
-				"productName": name,
+				"productName": productName,
 			},
 		},
 	}
@@ -58,9 +58,6 @@ func ReconcileSMTPCredentialSet(ctx context.Context, client client.Client, deplo
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
-			Labels: map[string]string{
-				"productName": name,
-			},
 		},
 	}
 
@@ -91,13 +88,13 @@ func ReconcileSMTPCredentialSet(ctx context.Context, client client.Client, deplo
 }
 
 // ReconcilePostgres creates or updates a postgres custom resource
-func ReconcilePostgres(ctx context.Context, client client.Client, deploymentType, tier, name, ns, secretName, secretNs string, modifyFunc modifyResourceFunc) (*v1alpha1.Postgres, error) {
+func ReconcilePostgres(ctx context.Context, client client.Client, productName, deploymentType, tier, name, ns, secretName, secretNs string, modifyFunc modifyResourceFunc) (*v1alpha1.Postgres, error) {
 	pg := &v1alpha1.Postgres{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
 			Labels: map[string]string{
-				"productName": name,
+				"productName": productName,
 			},
 		},
 	}
@@ -129,13 +126,13 @@ func ReconcilePostgres(ctx context.Context, client client.Client, deploymentType
 }
 
 // ReconcileRedis creates or updates a redis custom resource
-func ReconcileRedis(ctx context.Context, client client.Client, deploymentType, tier, name, ns, secretName, secretNs string, modifyFunc modifyResourceFunc) (*v1alpha1.Redis, error) {
+func ReconcileRedis(ctx context.Context, client client.Client, productName, deploymentType, tier, name, ns, secretName, secretNs string, modifyFunc modifyResourceFunc) (*v1alpha1.Redis, error) {
 	r := &v1alpha1.Redis{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
 			Labels: map[string]string{
-				"productName": name,
+				"productName": productName,
 			},
 		},
 	}

--- a/pkg/resources/util_test.go
+++ b/pkg/resources/util_test.go
@@ -36,6 +36,7 @@ func TestReconcileBlobStorage(t *testing.T) {
 	type args struct {
 		ctx            context.Context
 		client         client.Client
+		productName    string
 		deploymentType string
 		tier           string
 		name           string
@@ -57,6 +58,7 @@ func TestReconcileBlobStorage(t *testing.T) {
 				client:         fake.NewFakeClientWithScheme(scheme),
 				deploymentType: "managed",
 				tier:           "production",
+				productName:    "test",
 				name:           "test",
 				ns:             "test",
 				secretName:     "test",
@@ -90,6 +92,7 @@ func TestReconcileBlobStorage(t *testing.T) {
 				deploymentType: "managed",
 				tier:           "production",
 				name:           "test",
+				productName:    "test",
 				ns:             "test",
 				secretName:     "test",
 				secretNs:       "test",
@@ -127,6 +130,7 @@ func TestReconcileBlobStorage(t *testing.T) {
 				deploymentType: "workshop",
 				tier:           "development",
 				name:           "test",
+				productName:    "test",
 				ns:             "test",
 				secretName:     "test",
 				secretNs:       "test",
@@ -140,7 +144,7 @@ func TestReconcileBlobStorage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ReconcileBlobStorage(tt.args.ctx, tt.args.client, tt.args.deploymentType, tt.args.tier, tt.args.name, tt.args.ns, tt.args.secretName, tt.args.secretNs, tt.args.modifyFunc)
+			got, err := ReconcileBlobStorage(tt.args.ctx, tt.args.client, tt.args.productName, tt.args.deploymentType, tt.args.tier, tt.args.name, tt.args.ns, tt.args.secretName, tt.args.secretNs, tt.args.modifyFunc)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ReconcileBlobStorage() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -192,9 +196,6 @@ func TestReconcileSMTPCredentialSet(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "test",
 					Namespace: "test",
-					Labels: map[string]string{
-						"productName": "test",
-					},
 				},
 				Spec: v1alpha1.SMTPCredentialSetSpec{
 					Type: "managed",
@@ -206,61 +207,6 @@ func TestReconcileSMTPCredentialSet(t *testing.T) {
 				},
 			},
 			wantErr: false,
-		},
-		{
-			name: "test modification function",
-			args: args{
-				ctx:            context.TODO(),
-				client:         fake.NewFakeClientWithScheme(scheme),
-				deploymentType: "managed",
-				tier:           "production",
-				name:           "test",
-				ns:             "test",
-				secretName:     "test",
-				secretNs:       "test",
-				modifyFunc: func(cr v1.Object) error {
-					cr.SetLabels(map[string]string{
-						"cro": "test",
-					})
-					return nil
-				},
-			},
-			want: &v1alpha1.SMTPCredentialSet{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "test",
-					Namespace: "test",
-					Labels: map[string]string{
-						"cro": "test",
-					},
-				},
-				Spec: v1alpha1.SMTPCredentialSetSpec{
-					Type: "managed",
-					Tier: "production",
-					SecretRef: &types.SecretRef{
-						Name:      "test",
-						Namespace: "test",
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "test modification function error",
-			args: args{
-				ctx:            context.TODO(),
-				client:         fake.NewFakeClientWithScheme(scheme),
-				deploymentType: "workshop",
-				tier:           "development",
-				name:           "test",
-				ns:             "test",
-				secretName:     "test",
-				secretNs:       "test",
-				modifyFunc: func(cr v1.Object) error {
-					return errors.New("error executing function")
-				},
-			},
-			want:    nil,
-			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -287,6 +233,7 @@ func TestReconcilePostgres(t *testing.T) {
 		ctx            context.Context
 		client         client.Client
 		deploymentType string
+		productName    string
 		tier           string
 		name           string
 		ns             string
@@ -307,6 +254,7 @@ func TestReconcilePostgres(t *testing.T) {
 				client:         fake.NewFakeClientWithScheme(scheme),
 				deploymentType: "managed",
 				tier:           "production",
+				productName:    "test",
 				name:           "test",
 				ns:             "test",
 				secretName:     "test",
@@ -338,6 +286,7 @@ func TestReconcilePostgres(t *testing.T) {
 				ctx:            context.TODO(),
 				client:         fake.NewFakeClientWithScheme(scheme),
 				deploymentType: "managed",
+				productName:    "test",
 				tier:           "production",
 				name:           "test",
 				ns:             "test",
@@ -376,6 +325,7 @@ func TestReconcilePostgres(t *testing.T) {
 				client:         fake.NewFakeClientWithScheme(scheme),
 				deploymentType: "workshop",
 				tier:           "development",
+				productName:    "test",
 				name:           "test",
 				ns:             "test",
 				secretName:     "test",
@@ -390,7 +340,7 @@ func TestReconcilePostgres(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ReconcilePostgres(tt.args.ctx, tt.args.client, tt.args.deploymentType, tt.args.tier, tt.args.name, tt.args.ns, tt.args.secretName, tt.args.secretNs, tt.args.modifyFunc)
+			got, err := ReconcilePostgres(tt.args.ctx, tt.args.client, tt.args.productName, tt.args.deploymentType, tt.args.tier, tt.args.name, tt.args.ns, tt.args.secretName, tt.args.secretNs, tt.args.modifyFunc)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ReconcilePostgres() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -412,6 +362,7 @@ func TestReconcileRedis(t *testing.T) {
 		client         client.Client
 		deploymentType string
 		tier           string
+		productName    string
 		name           string
 		ns             string
 		secretName     string
@@ -431,6 +382,7 @@ func TestReconcileRedis(t *testing.T) {
 				client:         fake.NewFakeClientWithScheme(scheme),
 				deploymentType: "managed",
 				tier:           "production",
+				productName:    "test",
 				name:           "test",
 				ns:             "test",
 				secretName:     "test",
@@ -463,6 +415,7 @@ func TestReconcileRedis(t *testing.T) {
 				client:         fake.NewFakeClientWithScheme(scheme),
 				deploymentType: "managed",
 				tier:           "production",
+				productName:    "test",
 				name:           "test",
 				ns:             "test",
 				secretName:     "test",
@@ -500,6 +453,7 @@ func TestReconcileRedis(t *testing.T) {
 				client:         fake.NewFakeClientWithScheme(scheme),
 				deploymentType: "workshop",
 				tier:           "development",
+				productName:    "test",
 				name:           "test",
 				ns:             "test",
 				secretName:     "test",
@@ -514,7 +468,7 @@ func TestReconcileRedis(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ReconcileRedis(tt.args.ctx, tt.args.client, tt.args.deploymentType, tt.args.tier, tt.args.name, tt.args.ns, tt.args.secretName, tt.args.secretNs, tt.args.modifyFunc)
+			got, err := ReconcileRedis(tt.args.ctx, tt.args.client, tt.args.productName, tt.args.deploymentType, tt.args.tier, tt.args.name, tt.args.ns, tt.args.secretName, tt.args.secretNs, tt.args.modifyFunc)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ReconcileRedis() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
## Overview

Currently description and display name is not generated by the Operator SDK

This change adds both for the new crd`s in the csv

## Verify
- Update MakeFile to target your Quay
- Run `make image/push`
- Run `make manifest/push`
- Ensure you set the Quay Application and Repo to publc
- Create a new Operator Source pointing at your Quay
```
apiVersion: operators.coreos.com/v1
kind: OperatorSource
metadata:
  name: integreatly-operators
  namespace: openshift-marketplace
spec:
  authorizationToken: {}
  displayName: Integreatly Operators
  endpoint: 'https://quay.io/cnr'
  publisher: Integreatly Publisher
  registryNamespace: <<YOUR QUAY NAME>>
  type: appregistry
```
- Create a `Cloud Resource Operator` subscription from OLM
- Ensure the subscription is a success and the operator is installed