### PR TITLE
add available metrics

### DIFF
--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -581,13 +581,13 @@ func buildDefaultRDSSecret(ps *v1alpha1.Postgres) *v1.Secret {
 	}
 }
 
-func buildPostgresInfoMetricLabels(cr *v1alpha1.Postgres, instance *rds.DBInstance, clusterId string) map[string]string {
-	labels := buildPostgresGenericMetricLabels(cr, instance, clusterId)
+func buildPostgresInfoMetricLabels(cr *v1alpha1.Postgres, instance *rds.DBInstance, clusterID string) map[string]string {
+	labels := buildPostgresGenericMetricLabels(cr, instance, clusterID)
 	labels["status"] = *instance.DBInstanceStatus
 	return labels
 }
 
-func buildPostgresGenericMetricLabels(cr *v1alpha1.Postgres, instance *rds.DBInstance, clusterId string) map[string]string {
+func buildPostgresGenericMetricLabels(cr *v1alpha1.Postgres, instance *rds.DBInstance, clusterID string) map[string]string {
 	labels := map[string]string{}
 	labels["clusterID"] = clusterID
 	labels["resourceID"] = cr.Name
@@ -605,9 +605,9 @@ func (p *AWSPostgresProvider) exposePostgresMetrics(ctx context.Context, cr *v1a
 	}
 
 	// build metric labels
-	infoLabels:= buildPostgresInfoMetricLabels(cr, instance, clusterId)
+	infoLabels:= buildPostgresInfoMetricLabels(cr, instance, clusterID)
 	// build available mertic labels
-	genericLabels := buildPostgresGenericMetricLabels(cr, instance, clusterId)
+	genericLabels := buildPostgresGenericMetricLabels(cr, instance, clusterID)
 
 	// set status gauge
 	if err := resources.SetMetricCurrentTime(defaultPostgresInfoMetricName, infoLabels); err != nil {

--- a/pkg/providers/aws/provider_postgres_test.go
+++ b/pkg/providers/aws/provider_postgres_test.go
@@ -58,6 +58,10 @@ func (m *mockRdsClient) DescribeDBSnapshots(input *rds.DescribeDBSnapshotsInput)
 	return &rds.DescribeDBSnapshotsOutput{}, nil
 }
 
+func (m *mockRdsClient) DescribePendingMaintenanceActions(*rds.DescribePendingMaintenanceActionsInput) (*rds.DescribePendingMaintenanceActionsOutput, error) {
+	return &rds.DescribePendingMaintenanceActionsOutput{}, nil
+}
+
 func buildTestPostgresCR() *v1alpha1.Postgres {
 	return &v1alpha1.Postgres{
 		ObjectMeta: controllerruntime.ObjectMeta{

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -520,8 +520,8 @@ func (p *AWSRedisProvider) setRedisInfoMetric(ctx context.Context, cr *v1alpha1.
 	}
 
 	// build metric labels
-	infoLabels := buildRedisInfoMetricLables(cr, instance, clusterId)
-	genericLabels := buildRedisGenericMetricLabels(cr, instance, clusterId)
+	infoLabels := buildRedisInfoMetricLables(cr, instance, clusterID)
+	genericLabels := buildRedisGenericMetricLabels(cr, instance, clusterID)
 
 	// set status gauge
 	if err := resources.SetMetricCurrentTime(defaultRedisInfoMetricName, infoLabels); err != nil {

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -35,7 +35,7 @@ import (
 const (
 	defaultRedisMaintenanceMetricName = "cro_aws_elasticache_service_maintenance"
 	defaultRedisInfoMetricName        = "cro_aws_elasticache_info"
-	defaultRedisAvailMetricName       = "cro_aws_elasticache_avail"
+	defaultRedisAvailMetricName       = "cro_aws_elasticache_available"
 	redisProviderName                 = "aws-elasticache"
 	// default create params
 	defaultCacheNodeType     = "cache.t2.micro"
@@ -104,12 +104,6 @@ func (p *AWSRedisProvider) CreateRedis(ctx context.Context, r *v1alpha1.Redis) (
 	// setup aws elasticache cluster sdk session
 	cacheSvc, stsSvc := createAWSService(stratCfg, providerCreds)
 
-	err = p.setRedisServiceMaintenanceMetric(ctx, r)
-	if err != nil {
-		errMsg := "error creating the elasticache service maintenance metrics"
-		return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
-	}
-
 	// create the aws elasticache cluster
 	return p.createElasticacheCluster(ctx, r, cacheSvc, stsSvc, elasticacheCreateConfig, stratCfg)
 }
@@ -158,8 +152,14 @@ func (p *AWSRedisProvider) createElasticacheCluster(ctx context.Context, r *v1al
 		return nil, "started elasticache provision", nil
 	}
 
+	err = p.setRedisServiceMaintenanceMetric(ctx, r, cacheSvc, foundCache)
+	if err != nil {
+		errMsg := "error creating the elasticache service maintenance metrics"
+		return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
+	}
+
 	// set status metric
-	if err := p.setRedisInfoMetric(ctx, r, foundCache); err != nil {
+	if err := p.exposeRedisMetrics(ctx, r, foundCache); err != nil {
 		return nil, "failed to set metric", err
 	}
 
@@ -361,7 +361,7 @@ func (p *AWSRedisProvider) deleteElasticacheCluster(cacheSvc elasticacheiface.El
 	}
 
 	// set status metric
-	if err := p.setRedisInfoMetric(ctx, r, foundCache); err != nil {
+	if err := p.exposeRedisMetrics(ctx, r, foundCache); err != nil {
 		return "failed to set metric", err
 	}
 
@@ -497,12 +497,7 @@ func (p *AWSRedisProvider) buildElasticacheDeleteConfig(ctx context.Context, r v
 	return nil
 }
 
-func buildRedisInfoMetricLables(r *v1alpha1.Redis, cache *elasticache.ReplicationGroup, clusterID string) map[string]string {
-	labels := buildRedisGenericMetricLabels(r, cache, clusterID)
-	labels["status"] = *cache.Status
-	return labels
-}
-
+// returns generic labels to be added to every metric
 func buildRedisGenericMetricLabels(r *v1alpha1.Redis, cache *elasticache.ReplicationGroup, clusterID string) map[string]string {
 	labels := map[string]string{}
 	labels["clusterID"] = clusterID
@@ -512,7 +507,15 @@ func buildRedisGenericMetricLabels(r *v1alpha1.Redis, cache *elasticache.Replica
 	return labels
 }
 
-func (p *AWSRedisProvider) setRedisInfoMetric(ctx context.Context, cr *v1alpha1.Redis, instance *elasticache.ReplicationGroup) error {
+// adds extra information to labels around resource
+func buildRedisInfoMetricLables(r *v1alpha1.Redis, cache *elasticache.ReplicationGroup, clusterID string) map[string]string {
+	labels := buildRedisGenericMetricLabels(r, cache, clusterID)
+	labels["status"] = *cache.Status
+	return labels
+}
+
+// used to expose an available and information metrics during reconcile
+func (p *AWSRedisProvider) exposeRedisMetrics(ctx context.Context, cr *v1alpha1.Redis, instance *elasticache.ReplicationGroup) error {
 	logrus.Info("setting redis information metric")
 	clusterID, err := resources.GetClusterID(ctx, p.Client)
 	if err != nil {
@@ -535,42 +538,32 @@ func (p *AWSRedisProvider) setRedisInfoMetric(ctx context.Context, cr *v1alpha1.
 		}
 		return nil
 	}
-	if err := resources.SetMetric(defaultRedisAvailMetricName, genericLabels, 0); err != nil {
+	if err := resources.SetMetric(defaultRedisAvailMetricName, genericLabels, 1); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (p *AWSRedisProvider) setRedisServiceMaintenanceMetric(ctx context.Context, cr *v1alpha1.Redis) error {
-
+// sets maintenance metric
+func (p *AWSRedisProvider) setRedisServiceMaintenanceMetric(ctx context.Context, cr *v1alpha1.Redis, cacheSvc elasticacheiface.ElastiCacheAPI, instance *elasticache.ReplicationGroup) error {
 	// info about the elasticache cluster to be created
-	_, _, stratCfg, err := p.getElasticacheConfig(ctx, cr)
+	logrus.Info("checking for pending redis service updates")
+	clusterID, err := resources.GetClusterID(ctx, p.Client)
 	if err != nil {
-		errMsg := fmt.Sprintf("failed to retrieve aws elasticache cluster config %s", cr.Name)
-		return errorUtil.Wrapf(err, errMsg)
+		return errorUtil.Wrap(err, "failed to get cluster id")
 	}
-
-	// create the credentials to be used by the aws resource providers, not to be used by end-user
-	providerCreds, err := p.CredentialManager.ReconcileProviderCredentials(ctx, cr.Namespace)
-	if err != nil {
-		msg := "failed to reconcile elasticache credentials"
-		return errorUtil.Wrap(err, msg)
-	}
-
-	cacheSvc, _ := createAWSService(stratCfg, providerCreds)
 
 	// Retrieve service maintenance updates, create and export Prometheus metrics
 	output, err := cacheSvc.DescribeServiceUpdates(&elasticache.DescribeServiceUpdatesInput{})
 	if err != nil {
-		msg := "elasticache serviceupdates error"
-		return errorUtil.Wrap(err, msg)
+		return errorUtil.Wrap(err, "elasticache serviceupdates error")
 	}
 
-	logrus.Info(fmt.Sprintf("there are elasticache serviceupdates: %d available", len(output.ServiceUpdates)))
-	metricName := defaultRedisMaintenanceMetricName
+	logrus.Info(fmt.Sprintf("there are elasticache service updates: %d available", len(output.ServiceUpdates)))
 	for _, su := range output.ServiceUpdates {
 		metricLabels := map[string]string{}
+		metricLabels["clusterID"] = clusterID
 
 		metricLabels["AutoUpdateAfterRecommendedApplyByDate"] = strconv.FormatBool(*su.AutoUpdateAfterRecommendedApplyByDate)
 		metricLabels["Engine"] = *su.Engine
@@ -586,9 +579,9 @@ func (p *AWSRedisProvider) setRedisServiceMaintenanceMetric(ctx context.Context,
 
 		metricEpochTimestamp := (*su.ServiceUpdateRecommendedApplyByDate).Unix()
 
-		err = croResources.SetMetric(metricName, metricLabels, float64(metricEpochTimestamp))
+		err = croResources.SetMetric(defaultRedisMaintenanceMetricName, metricLabels, float64(metricEpochTimestamp))
 		if err != nil {
-			msg := fmt.Sprintf("exception calling SetMetric with metricName: %s", metricName)
+			msg := fmt.Sprintf("exception calling SetMetric with metricName: %s", defaultRedisMaintenanceMetricName)
 			return errorUtil.Wrap(err, msg)
 		}
 	}

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -94,6 +94,10 @@ func (m *mockElasticacheClient) DescribeCacheClusters(*elasticache.DescribeCache
 	}, nil
 }
 
+func (m *mockElasticacheClient) DescribeServiceUpdates(*elasticache.DescribeServiceUpdatesInput) (*elasticache.DescribeServiceUpdatesOutput, error) {
+	return &elasticache.DescribeServiceUpdatesOutput{}, nil
+}
+
 // mock sts get caller identity
 func (m *mockStsClient) GetCallerIdentity(*sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error) {
 	return &sts.GetCallerIdentityOutput{


### PR DESCRIPTION
## Overview

In order to make a cleaner alert we decided on returning a value of `1` to represent an `available resource` and a value of `0` to represent an `unavailable resource`

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make cluster/seed/managed/postgres`
- Run `make cluster/seed/managed/redis`
- Run `make run`
- Run `curl localhost:8383/metrics | grep aws `
- Ensure `cro_aws_rds_available` and `cro_aws_elasticache_available` metric and the value represents the current state of the provisioning resource