### PR TITLE
Targetting exported_namespace in metric alerts

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -143,10 +143,15 @@ func main() {
 		log.Info("Could not create metrics Service", "error", err.Error())
 	}
 
+	// Retrieve the namespace the operator is running in
+	operatorNs, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		log.Error(err, "Failed to get operator namespace")
+	}
 	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
 	// necessary to configure Prometheus to scrape metrics from this operator.
 	services := []*v1.Service{service}
-	_, err = metrics.CreateServiceMonitors(cfg, namespace, services, addMonitoringKeyLabelToOperatorServiceMonitor)
+	_, err = metrics.CreateServiceMonitors(cfg, operatorNs, services, addMonitoringKeyLabelToOperatorServiceMonitor)
 	if err != nil {
 		log.Info("Could not create ServiceMonitor object", "error", err.Error())
 		// If this operator is deployed to a cluster without the prometheus-operator running, it will return

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -704,7 +704,7 @@ func (p *PostgresProvider) CreateRDSAvailabilityAlert(ctx context.Context, cr *v
 	ruleName := fmt.Sprintf("availability-rule-%s", instanceID)
 	alertRuleName := "RDSInstanceUnavailable"
 	alertExp := intstr.FromString(
-		fmt.Sprintf("absent(cro_aws_rds_available{namespace='%s',instanceID='%s',clusterID='%s',resourceID='%s'} == 1)",
+		fmt.Sprintf("absent(cro_aws_rds_available{exported_namespace='%s',instanceID='%s',clusterID='%s',resourceID='%s'} == 1)",
 			cr.Namespace, instanceID, clusterID, cr.Name),
 	)
 	alertDescription := fmt.Sprintf("RDS instance: %s on cluster: %s for product: %s is unavailable", instanceID, clusterID, cr.Labels["productName"])

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -620,7 +620,7 @@ func (p *RedisProvider) CreateElastiCacheAvailabilityAlert(ctx context.Context, 
 	ruleName := fmt.Sprintf("availability-rule-%s", instanceID)
 	alertRuleName := "ElastiCacheInstanceUnavailable"
 	alertExp := intstr.FromString(
-		fmt.Sprintf("absent(cro_aws_elasticache_available{namespace='%s',instanceID='%s',clusterID='%s',resourceID='%s'} == 1)",
+		fmt.Sprintf("absent(cro_aws_elasticache_available{exported_namespace='%s',instanceID='%s',clusterID='%s',resourceID='%s'} == 1)",
 			cr.Namespace, instanceID, clusterID, cr.Name),
 	)
 	alertDescription := fmt.Sprintf("ElastiCache instance: %s on cluster: %s for product: %s is unavailable", instanceID, clusterID, cr.Labels["productName"])


### PR DESCRIPTION
Fixed issue with creating servicemonitors in the namespace the operaor is running in
Targetting exported_namespace in metric alerts

## Overview
The servicemonitor is now being created for the operator metrics service when the watch namespace is different to the namespace in which the CRO is running.
The alerts which are created for availability now correctly target `exported_namespace` rather than `namespace`

## Verification

- Clone this branch
- `oc create namespace "namespace-a"`
- `oc create namespace "namespace-b"`
- Run `make cluster/prepare`
- Update the deployment for the CRO, change the:
```
env:
  - name: WATCH_NAMESPACE
    value: "namespace-b"
```
- `oc apply -f deploy/operator.yaml --namespace "namespace-a"`
- Ensure that a servicemonitor is created in the namespace where the CRO is running