### PR TITLE
Adding cluster role permissions to CRO to manage PrometheusRules

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -19,3 +19,9 @@ rules:
       - configmaps
     verbs:
       - "*"
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - '*'

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -417,9 +417,8 @@ func (p *PostgresProvider) deleteRDSInstance(ctx context.Context, pg *v1alpha1.P
 	}
 
 	// Delete the PrometheusRule alert which watches the availability of this RDS instance we provisioned
-	err = p.DeleteRDSAvailabilityAlert(ctx, pg.Namespace, *foundInstance.DBInstanceIdentifier)
-	if err != nil {
-		errMsg := fmt.Sprintf("failed to delete RDS alert : %s", err)
+	if err :=  p.DeleteRDSAvailabilityAlert(ctx, pg.Namespace, *foundInstance.DBInstanceIdentifier); err != nil {
+		errMsg := fmt.Sprintf("failed to delete rds alert : %s", err)
 		return croType.StatusMessage(errMsg), errorUtil.Wrapf(err, errMsg)
 	}
 
@@ -727,7 +726,7 @@ func (p *PostgresProvider) CreateRDSAvailabilityAlert(ctx context.Context, cr *v
 			return errorUtil.Wrap(err, fmt.Sprintf("exception calling Create prometheusrule: %s", alertRuleName))
 		}
 	}
-	p.Logger.Info(fmt.Sprintf("PrometheusRule: %s reconciled successfully.", pr.Name))
+	p.Logger.Info(fmt.Sprintf("prometheusrule: %s reconciled successfully.", pr.Name))
 	return nil
 }
 

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -396,8 +396,7 @@ func (p *RedisProvider) deleteElasticacheCluster(ctx context.Context, cacheSvc e
 	}
 
 	// Delete the PrometheusRule alert which watches the availability of this ElastiCache instance we provisioned
-	err = p.DeleteElastiCacheAvailabilityAlert(ctx, r.Namespace, *foundCache.ReplicationGroupId)
-	if err != nil {
+	if err := p.DeleteElastiCacheAvailabilityAlert(ctx, r.Namespace, *foundCache.ReplicationGroupId); err != nil{
 		errMsg := fmt.Sprintf("failed to delete elasticache alert : %s", err)
 		return croType.StatusMessage(errMsg), errorUtil.Wrapf(err, errMsg)
 	}
@@ -643,7 +642,7 @@ func (p *RedisProvider) CreateElastiCacheAvailabilityAlert(ctx context.Context, 
 			return errorUtil.Wrap(err, fmt.Sprintf("exception calling Create metricName: %s", alertRuleName))
 		}
 	}
-	p.Logger.Info(fmt.Sprintf("PrometheusRule: %s reconciled successfully.", pr.Name))
+	p.Logger.Info(fmt.Sprintf("prometheusrule: %s reconciled successfully.", pr.Name))
 	return nil
 }
 

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -387,13 +387,6 @@ func (p *RedisProvider) deleteElasticacheCluster(ctx context.Context, cacheSvc e
 		return croType.StatusMessage(fmt.Sprintf("delete detected, deleteReplicationGroup() in progress, current aws elasticache status is %s", *foundCache.Status)), nil
 	}
 
-	// Delete the PrometheusRule alert which watches the availability of this ElastiCache instance we provisioned
-	err = p.DeleteElastiCacheAvailabilityAlert(ctx, r.Namespace, *foundCache.ReplicationGroupId)
-	if err != nil {
-		errMsg := fmt.Sprintf("failed to delete elasticache alert : %s", err)
-		return croType.StatusMessage(errMsg), errorUtil.Wrapf(err, errMsg)
-	}
-
 	// delete elasticache cluster
 	_, err = cacheSvc.DeleteReplicationGroup(elasticacheDeleteConfig)
 	elasticacheErr, isAwsErr := err.(awserr.Error)
@@ -401,6 +394,14 @@ func (p *RedisProvider) deleteElasticacheCluster(ctx context.Context, cacheSvc e
 		errMsg := fmt.Sprintf("failed to delete elasticache cluster : %s", err)
 		return croType.StatusMessage(errMsg), errorUtil.Wrapf(err, errMsg)
 	}
+
+	// Delete the PrometheusRule alert which watches the availability of this ElastiCache instance we provisioned
+	err = p.DeleteElastiCacheAvailabilityAlert(ctx, r.Namespace, *foundCache.ReplicationGroupId)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to delete elasticache alert : %s", err)
+		return croType.StatusMessage(errMsg), errorUtil.Wrapf(err, errMsg)
+	}
+
 	return "delete detected, deleteReplicationGroup started", nil
 }
 
@@ -642,7 +643,7 @@ func (p *RedisProvider) CreateElastiCacheAvailabilityAlert(ctx context.Context, 
 			return errorUtil.Wrap(err, fmt.Sprintf("exception calling Create metricName: %s", alertRuleName))
 		}
 	}
-	p.Logger.Info(fmt.Sprintf("PrometheusRule: %s reconcilced successfully.", pr.Name))
+	p.Logger.Info(fmt.Sprintf("PrometheusRule: %s reconciled successfully.", pr.Name))
 	return nil
 }
 


### PR DESCRIPTION
Altered ordering for when PromtheusRules are deleted for RDS/ElastiCache resources

## Overview

Jira: https://issues.redhat.com/browse/INTLY-5109

## Verification

- Clone this branch
- Run `oc create namespace "namespace-a"`
- Run `oc create namespace "namespace-b"`
- Run `oc project namespace-a`
- Run `make image/build`
- Run `docker tag <image>:0.8.1 <image-with-your-name>:v0.8.1`
- Run `docker push <image-with-your-name>:v0.8.1`
- Update the image in the `deploy/operator.yaml`
- Update the deployment for the CRO, change the:
```
env:
  - name: WATCH_NAMESPACE
    value: "namespace-b"
```
- Run `make cluster/prepare`
- `oc apply -f deploy/operator.yaml --namespace "namespace-a"`
- Create a Redis/Postgresql CR in `namespace-b`
- Ensure that a ServiceMonitor is created in the `namespace-a` where the CRO is running
- Ensure that a PrometheusRule is created in the namespace-b where the Redis/Postgresql CR is