### PR TITLE
Refactor metric and alert names 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/lib/pq v1.2.0
 	github.com/onsi/ginkgo v1.10.1 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
-	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible
 	github.com/openshift/cloud-credential-operator v0.0.0-20190812222907-ec6f38d73a79
 	github.com/operator-framework/operator-sdk v0.12.1-0.20191112211508-82fc57de5e5b
@@ -29,9 +28,7 @@ require (
 	golang.org/x/net v0.0.0-20191003171128-d98b1b443823 // indirect
 	golang.org/x/sys v0.0.0-20200113162924-86b910548bc1 // indirect
 	google.golang.org/appengine v1.6.2 // indirect
-	google.golang.org/genproto v0.0.0-20181016170114-94acd270e44e // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v12.0.0+incompatible

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -42,7 +42,6 @@ import (
 const (
 	defaultPostgresMaintenanceMetricName = "cro_postgres_service_maintenance"
 	defaultPostgresInfoMetricName        = "cro_postgres_info"
-	defaultPostgresAvailMetricName       = "cro_postgres_available"
 	postgresProviderName                 = "aws-rds"
 	DefaultAwsIdentifierLength           = 40
 	defaultAwsMultiAZ                    = true
@@ -744,12 +743,12 @@ func (p *PostgresProvider) exposePostgresMetrics(ctx context.Context, cr *v1alph
 
 	// set available metric
 	if *instance.DBInstanceStatus != "available" {
-		if err := resources.SetMetric(defaultPostgresAvailMetricName, genericLabels, 0); err != nil {
+		if err := resources.SetMetric(resources.DefaultPostgresAvailMetricName, genericLabels, 0); err != nil {
 			return err
 		}
 		return nil
 	}
-	if err := resources.SetMetric(defaultPostgresAvailMetricName, genericLabels, 1); err != nil {
+	if err := resources.SetMetric(resources.DefaultPostgresAvailMetricName, genericLabels, 1); err != nil {
 		return err
 	}
 

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 
-	prometheusv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	croType "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 	croResources "github.com/integr8ly/cloud-resource-operator/pkg/resources"
 
@@ -21,7 +20,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -42,9 +40,9 @@ import (
 )
 
 const (
-	defaultPostgresMaintenanceMetricName = "cro_aws_rds_service_maintenance"
-	defaultPostgresInfoMetricName        = "cro_aws_rds_info"
-	defaultPostgresAvailMetricName       = "cro_aws_rds_available"
+	defaultPostgresMaintenanceMetricName = "cro_postgres_service_maintenance"
+	defaultPostgresInfoMetricName        = "cro_postgres_info"
+	defaultPostgresAvailMetricName       = "cro_postgres_available"
 	postgresProviderName                 = "aws-rds"
 	DefaultAwsIdentifierLength           = 40
 	defaultAwsMultiAZ                    = true
@@ -215,7 +213,7 @@ func (p *PostgresProvider) createRDSInstance(ctx context.Context, cr *v1alpha1.P
 
 	// set status metric
 	if err := p.exposePostgresMetrics(ctx, cr, foundInstance); err != nil {
-		return nil, croType.StatusMessage(fmt.Sprintf("error seting metric %s", err)), err
+		return nil, croType.StatusMessage(fmt.Sprintf("error setting metric %s", err)), err
 	}
 
 	// check rds instance phase
@@ -223,15 +221,10 @@ func (p *PostgresProvider) createRDSInstance(ctx context.Context, cr *v1alpha1.P
 		return nil, croType.StatusMessage(fmt.Sprintf("createRDSInstance() in progress, current aws rds resource status is %s", *foundInstance.DBInstanceStatus)), nil
 	}
 
-	clusterID, err := resources.GetClusterID(ctx, p.Client)
+	// create the PrometheusRule alert to watch for the availability of this rds instance
+	_, err = resources.CreatePostgresAvailabilityAlert(ctx, p.Client, cr)
 	if err != nil {
-		errMsg := "failed to retrieve cluster identifier"
-		return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
-	}
-	// Create the PrometheusRule alert to watch for the availability of this ElastiCache instance we are provisioning
-	err = p.CreateRDSAvailabilityAlert(ctx, cr, *foundInstance.DBInstanceIdentifier, clusterID)
-	if err != nil {
-		errMsg := "error creating the elasticache prometheus rule"
+		errMsg := "error creating rds prometheus rule"
 		return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
 	}
 
@@ -261,7 +254,7 @@ func (p *PostgresProvider) createRDSInstance(ctx context.Context, cr *v1alpha1.P
 	}}, croType.StatusMessage(fmt.Sprintf("%s, aws rds status is %s", msg, *foundInstance.DBInstanceStatus)), nil
 }
 
-//TagRDSPostgres Tags RDS resources
+// TagRDSPostgres Tags RDS resources
 func (p *PostgresProvider) TagRDSPostgres(ctx context.Context, cr *v1alpha1.Postgres, rdsSvc rdsiface.RDSAPI, foundInstance *rds.DBInstance) (croType.StatusMessage, error) {
 	logrus.Infof("adding tags to rds instance %s", *foundInstance.DBInstanceIdentifier)
 	// get the environment from the CR
@@ -400,7 +393,7 @@ func (p *PostgresProvider) deleteRDSInstance(ctx context.Context, pg *v1alpha1.P
 
 	// set status metric
 	if err := p.exposePostgresMetrics(ctx, pg, foundInstance); err != nil {
-		return croType.StatusMessage(fmt.Sprintf("error seting metric %s", err)), err
+		return croType.StatusMessage(fmt.Sprintf("error setting metric %s", err)), err
 	}
 
 	// return if rds instance is not available
@@ -429,9 +422,9 @@ func (p *PostgresProvider) deleteRDSInstance(ctx context.Context, pg *v1alpha1.P
 		return croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
 	}
 
-	// Delete the PrometheusRule alert which watches the availability of this RDS instance we provisioned
-	if err := p.DeleteRDSAvailabilityAlert(ctx, pg.Namespace, *foundInstance.DBInstanceIdentifier); err != nil {
-		errMsg := fmt.Sprintf("failed to delete rds alert : %s", err)
+	// delete the alert which watches the availability of the rds instance
+	if err := resources.DeletePostgresAvailabilityAlert(ctx, p.Client, pg); err != nil {
+		errMsg := fmt.Sprintf("failed to delete rds alert: %s", err)
 		return croType.StatusMessage(errMsg), errorUtil.Wrapf(err, errMsg)
 	}
 
@@ -727,6 +720,7 @@ func buildPostgresGenericMetricLabels(cr *v1alpha1.Postgres, instance *rds.DBIns
 	labels["namespace"] = cr.Namespace
 	labels["instanceID"] = *instance.DBInstanceIdentifier
 	labels["productName"] = cr.Labels["productName"]
+	labels["strategy"] = postgresProviderName
 	return labels
 }
 
@@ -798,65 +792,5 @@ func (p *PostgresProvider) setPostgresServiceMaintenanceMetric(ctx context.Conte
 		}
 	}
 
-	return nil
-}
-
-// CreateRDSAvailabilityAlert Call this when we create the ElastiCache instance to create an
-// alert to watch for the availability of the instance
-func (p *PostgresProvider) CreateRDSAvailabilityAlert(ctx context.Context, cr *v1alpha1.Postgres, instanceID string, clusterID string) error {
-	ruleName := fmt.Sprintf("availability-rule-%s", instanceID)
-	alertRuleName := "RDSInstanceUnavailable"
-	alertExp := intstr.FromString(
-		fmt.Sprintf("absent(cro_aws_rds_available{exported_namespace='%s',instanceID='%s',clusterID='%s',resourceID='%s'} == 1)",
-			cr.Namespace, instanceID, clusterID, cr.Name),
-	)
-	alertDescription := fmt.Sprintf("RDS instance: %s on cluster: %s for product: %s is unavailable", instanceID, clusterID, cr.Labels["productName"])
-	labels := map[string]string{
-		"severity":    "warning",
-		"productName": cr.Labels["productName"],
-	}
-
-	pr, err := croResources.CreatePrometheusRule(ruleName, cr.Namespace, alertRuleName, alertDescription, alertExp, labels)
-	if err != nil {
-		return err
-	}
-
-	// Unless it already exists, call the kubernetes api and create this PrometheusRule
-	// Replace this with CreateOrUpdate if we can figure it out
-	err = p.Client.Create(ctx, pr)
-	if err != nil {
-		if !k8serr.IsAlreadyExists(err) {
-			return errorUtil.Wrap(err, fmt.Sprintf("exception calling Create prometheus rule: %s", alertRuleName))
-		}
-	}
-	p.Logger.Info(fmt.Sprintf("prometheus rule: %s reconcilced successfully.", pr.Name))
-	return nil
-}
-
-// DeleteRDSAvailabilityAlert We call this when we delete an ElastiCache instance,
-// it removes the prometheusrule alert which watches for the availability of the instance.
-func (p *PostgresProvider) DeleteRDSAvailabilityAlert(ctx context.Context, namespace string, instanceID string) error {
-	// query the kubernetes api to find the object we're looking for
-	ruleName := fmt.Sprintf("availability-rule-%s", instanceID)
-
-	pr := &prometheusv1.PrometheusRule{}
-	selector := client.ObjectKey{
-		Namespace: namespace,
-		Name:      ruleName,
-	}
-
-	if err := p.Client.Get(ctx, selector, pr); err != nil {
-		if k8serr.IsNotFound(err) {
-			logrus.Info(fmt.Sprintf("prometheus rule %s not found", ruleName))
-			return nil
-		}
-		return errorUtil.Wrapf(err, "exception calling DeleteRDSAvailabilityAlert: %s", ruleName)
-	}
-
-	// call delete on that object
-	if err := p.Client.Delete(ctx, pr); err != nil {
-		return errorUtil.Wrapf(err, "exception calling DeleteRDSAvailabilityAlert: %s", ruleName)
-	}
-	p.Logger.Info(fmt.Sprintf("prometheus rule: %s deleted.", pr.Name))
 	return nil
 }

--- a/pkg/providers/aws/provider_postgres_test.go
+++ b/pkg/providers/aws/provider_postgres_test.go
@@ -132,7 +132,7 @@ func (m *mockEc2Client) DescribeAvailabilityZones(*ec2.DescribeAvailabilityZones
 func buildTestPostgresqlPrometheusRule() *monitoringv1.PrometheusRule {
 	return &monitoringv1.PrometheusRule{
 		ObjectMeta: controllerruntime.ObjectMeta{
-			Name:      "availability-rule-test-id",
+			Name:      "availability-rule-test",
 			Namespace: "test",
 		},
 	}

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 
-	prometheusv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringclient "github.com/coreos/prometheus-operator/pkg/client/versioned/typed/monitoring/v1"
 	croType "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 	croResources "github.com/integr8ly/cloud-resource-operator/pkg/resources"
@@ -29,20 +28,18 @@ import (
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers"
 
 	errorUtil "github.com/pkg/errors"
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	defaultRedisMaintenanceMetricName = "cro_aws_elasticache_service_maintenance"
-	defaultRedisInfoMetricName        = "cro_aws_elasticache_info"
-	defaultRedisAvailMetricName       = "cro_aws_elasticache_available"
+	defaultRedisMaintenanceMetricName = "cro_redis_elasticache_service_maintenance"
+	defaultRedisInfoMetricName        = "cro_redis_info"
+	defaultRedisAvailMetricName       = "cro_redis_available"
 	redisProviderName                 = "aws-elasticache"
 	// default create params
 	defaultCacheNodeType     = "cache.t2.micro"
@@ -188,15 +185,10 @@ func (p *RedisProvider) createElasticacheCluster(ctx context.Context, r *v1alpha
 		return nil, croType.StatusMessage(fmt.Sprintf("createReplicationGroup() in progress, current aws elasticache status is %s", *foundCache.Status)), nil
 	}
 
-	clusterID, err := resources.GetClusterID(ctx, p.Client)
+	// create the PrometheusRule alert to watch for the availability of the elasticache instance
+	_, err = resources.CreateRedisAvailabilityAlert(ctx, p.Client, r)
 	if err != nil {
-		errMsg := "failed to retrieve cluster identifier"
-		return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
-	}
-	// Create the PrometheusRule alert to watch for the availability of this ElastiCache instance we are provisioning
-	err = p.CreateElastiCacheAvailabilityAlert(ctx, r, *foundCache.ReplicationGroupId, clusterID)
-	if err != nil {
-		errMsg := "error creating the elasticache prometheus rule"
+		errMsg := "error creating elasticache prometheus rule"
 		return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
 	}
 
@@ -233,7 +225,7 @@ func (p *RedisProvider) createElasticacheCluster(ctx context.Context, r *v1alpha
 	}}, croType.StatusMessage(fmt.Sprintf("successfully created and tagged, aws elasticache status is %s", *foundCache.Status)), nil
 }
 
-//TagElasticacheNode Add Tags to AWS Elasticache
+// TagElasticacheNode Add Tags to AWS Elasticache
 func (p *RedisProvider) TagElasticacheNode(ctx context.Context, cacheSvc elasticacheiface.ElastiCacheAPI, stsSvc stsiface.STSAPI, r *v1alpha1.Redis, stratCfg StrategyConfig, cache *elasticache.NodeGroupMember) (types.StatusMessage, error) {
 	logrus.Info("creating or updating tags on elasticache nodes and snapshots")
 
@@ -410,9 +402,9 @@ func (p *RedisProvider) deleteElasticacheCluster(ctx context.Context, cacheSvc e
 		return croType.StatusMessage(errMsg), errorUtil.Wrapf(err, errMsg)
 	}
 
-	// Delete the PrometheusRule alert which watches the availability of this ElastiCache instance we provisioned
-	if err := p.DeleteElastiCacheAvailabilityAlert(ctx, r.Namespace, *foundCache.ReplicationGroupId); err != nil {
-		errMsg := fmt.Sprintf("failed to delete elasticache alert : %s", err)
+	// delete the alert which watches the availability of the elasticache instance
+	if err := resources.DeleteRedisAvailabilityAlert(ctx, p.Client, r); err != nil {
+		errMsg := fmt.Sprintf("failed to delete elasticache alert: %s", err)
 		return croType.StatusMessage(errMsg), errorUtil.Wrapf(err, errMsg)
 	}
 
@@ -623,7 +615,7 @@ func buildRedisGenericMetricLabels(r *v1alpha1.Redis, cache *elasticache.Replica
 	labels["namespace"] = r.Namespace
 	labels["instanceID"] = *cache.ReplicationGroupId
 	labels["productName"] = r.Labels["productName"]
-
+	labels["strategy"] = redisProviderName
 	return labels
 }
 
@@ -705,66 +697,5 @@ func (p *RedisProvider) setRedisServiceMaintenanceMetric(ctx context.Context, cr
 			return errorUtil.Wrap(err, msg)
 		}
 	}
-	return nil
-}
-
-// CreateElastiCacheAvailabilityAlert Call this when we create the ElastiCache instance to create an
-// alert to watch for the availability of the instance
-func (p *RedisProvider) CreateElastiCacheAvailabilityAlert(ctx context.Context, cr *v1alpha1.Redis, instanceID string, clusterID string) error {
-	ruleName := fmt.Sprintf("availability-rule-%s", instanceID)
-	alertRuleName := "ElastiCacheInstanceUnavailable"
-	alertExp := intstr.FromString(
-		fmt.Sprintf("absent(cro_aws_elasticache_available{exported_namespace='%s',instanceID='%s',clusterID='%s',resourceID='%s'} == 1)",
-			cr.Namespace, instanceID, clusterID, cr.Name),
-	)
-	alertDescription := fmt.Sprintf("ElastiCache instance: %s on cluster: %s for product: %s is unavailable", instanceID, clusterID, cr.Labels["productName"])
-	labels := map[string]string{
-		"severity":    "warning",
-		"productName": cr.Labels["productName"],
-	}
-
-	pr, err := croResources.CreatePrometheusRule(ruleName, cr.Namespace, alertRuleName, alertDescription, alertExp, labels)
-	if err != nil {
-		return err
-	}
-
-	// Unless it already exists, call the kubernetes api and create this PrometheusRule
-	// Replace this with CreateOrUpdate if we can figure it out
-	err = p.Client.Create(ctx, pr)
-	if err != nil {
-		if !k8serr.IsAlreadyExists(err) {
-			return errorUtil.Wrap(err, fmt.Sprintf("exception calling create metric name: %s", alertRuleName))
-		}
-	}
-	p.Logger.Info(fmt.Sprintf("prometheus rule: %s reconcilced successfully.", pr.Name))
-	return nil
-}
-
-// DeleteElastiCacheAvailabilityAlert We call this when we delete an ElastiCache instance,
-// it removes the prometheusrule alert which watches for the availability of the instance.
-func (p *RedisProvider) DeleteElastiCacheAvailabilityAlert(ctx context.Context, namespace string, instanceID string) error {
-	// query the kubernetes api to find the object we're looking for
-	ruleName := fmt.Sprintf("availability-rule-%s", instanceID)
-
-	pr := &prometheusv1.PrometheusRule{}
-	selector := client.ObjectKey{
-		Namespace: namespace,
-		Name:      ruleName,
-	}
-
-	if err := p.Client.Get(ctx, selector, pr); err != nil {
-		if k8serr.IsNotFound(err) {
-			logrus.Info(fmt.Sprintf("prometheus rule %s not found", ruleName))
-			return nil
-		}
-		return nil
-	}
-
-	// call delete on that object
-	if err := p.Client.Delete(ctx, pr); err != nil {
-		msg := fmt.Sprintf("exception calling DeleteElastiCacheAvailabilityAlert: %s", ruleName)
-		return errorUtil.Wrap(err, msg)
-	}
-	p.Logger.Info(fmt.Sprintf("prometheus rule: %s deleted.", pr.Name))
 	return nil
 }

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -39,7 +39,6 @@ import (
 const (
 	defaultRedisMaintenanceMetricName = "cro_redis_elasticache_service_maintenance"
 	defaultRedisInfoMetricName        = "cro_redis_info"
-	defaultRedisAvailMetricName       = "cro_redis_available"
 	redisProviderName                 = "aws-elasticache"
 	// default create params
 	defaultCacheNodeType     = "cache.t2.micro"
@@ -645,12 +644,12 @@ func (p *RedisProvider) exposeRedisMetrics(ctx context.Context, cr *v1alpha1.Red
 
 	// set available metric
 	if *instance.Status != "available" {
-		if err := resources.SetMetric(defaultRedisAvailMetricName, genericLabels, 0); err != nil {
+		if err := resources.SetMetric(resources.DefaultRedisAvailMetricName, genericLabels, 0); err != nil {
 			return err
 		}
 		return nil
 	}
-	if err := resources.SetMetric(defaultRedisAvailMetricName, genericLabels, 1); err != nil {
+	if err := resources.SetMetric(resources.DefaultRedisAvailMetricName, genericLabels, 1); err != nil {
 		return err
 	}
 

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -135,7 +135,7 @@ func (m *mockStsClient) GetCallerIdentity(*sts.GetCallerIdentityInput) (*sts.Get
 func buildTestPrometheusRule() *monitoringv1.PrometheusRule {
 	return &monitoringv1.PrometheusRule{
 		ObjectMeta: controllerruntime.ObjectMeta{
-			Name:      "availability-rule-test-id",
+			Name:      "availability-rule-test",
 			Namespace: "test",
 		},
 	}

--- a/pkg/resources/custom_metrics.go
+++ b/pkg/resources/custom_metrics.go
@@ -155,7 +155,7 @@ func CreatePostgresAvailabilityAlert(ctx context.Context, client client.Client, 
 		fmt.Sprintf("absent(%s{exported_namespace='%s',resourceID='%s'} == 1)",
 			DefaultPostgresAvailMetricName, cr.Namespace, cr.Name),
 	)
-	alertDescription := fmt.Sprintf("Postgres instance: %s on cluster: %s for product: %s is unavailable", cr.Name, clusterID, cr.Labels["productName"])
+	alertDescription := fmt.Sprintf("Postgres instance: %s on cluster: %s for product: %s (strategy: %s) is unavailable", cr.Name, clusterID, cr.Labels["productName"], cr.Status.Strategy)
 	labels := map[string]string{
 		"severity":    "critical",
 		"productName": cr.Labels["productName"],
@@ -187,7 +187,7 @@ func CreateRedisAvailabilityAlert(ctx context.Context, client client.Client, cr 
 		fmt.Sprintf("absent(%s{exported_namespace='%s',resourceID='%s'} == 1)",
 			DefaultRedisAvailMetricName, cr.Namespace, cr.Name),
 	)
-	alertDescription := fmt.Sprintf("Redis cache: %s on cluster: %s for product: %s is unavailable", cr.Name, clusterID, cr.Labels["productName"])
+	alertDescription := fmt.Sprintf("Redis cache: %s on cluster: %s for product: %s (strategy: %s) is unavailable", cr.Name, clusterID, cr.Labels["productName"], cr.Status.Strategy)
 	labels := map[string]string{
 		"severity":    "critical",
 		"productName": cr.Labels["productName"],

--- a/pkg/resources/custom_metrics.go
+++ b/pkg/resources/custom_metrics.go
@@ -1,9 +1,17 @@
 package resources
 
 import (
+	"context"
+	"fmt"
 	"time"
 
+	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
 	prometheusv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/pkg/errors"
 	errorUtil "github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -13,11 +21,13 @@ import (
 )
 
 const (
-	sleepytime = 3600
+	sleepytime                     = 3600
+	DefaultPostgresAvailMetricName = "cro_postgres_available"
+	DefaultRedisAvailMetricName    = "cro_redis_available"
 )
 
 var (
-	//MetricVecs create the map of vectors
+	// MetricVecs create the map of vectors
 	MetricVecs map[string]prometheus.GaugeVec
 	logger     *logrus.Entry
 )
@@ -26,7 +36,7 @@ func init() {
 	StartGaugeVector()
 }
 
-//StartGaugeVector periodic loop that is wiping all known vectors.
+// StartGaugeVector periodic loop that is wiping all known vectors.
 func StartGaugeVector() {
 	MetricVecs = map[string]prometheus.GaugeVec{}
 	logger = logrus.WithFields(logrus.Fields{"custom_metrics": "StartGaugeVector"})
@@ -42,7 +52,7 @@ func StartGaugeVector() {
 	}()
 }
 
-//SetMetric Set exports a Prometheus Gauge
+// SetMetric Set exports a Prometheus Gauge
 func SetMetric(name string, labels map[string]string, value float64) error {
 	// set vector value
 	gv, ok := MetricVecs[name]
@@ -65,7 +75,7 @@ func SetMetric(name string, labels map[string]string, value float64) error {
 	return nil
 }
 
-//SetMetricCurrentTime Set current time wraps set metric
+// SetMetricCurrentTime Set current time wraps set metric
 func SetMetricCurrentTime(name string, labels map[string]string) error {
 	if err := SetMetric(name, labels, float64(time.Now().UnixNano())/1e9); err != nil {
 		return errorUtil.Wrap(err, "unable to set current time gauge vector")
@@ -73,11 +83,29 @@ func SetMetricCurrentTime(name string, labels map[string]string) error {
 	return nil
 }
 
-func createPrometheusRuleObject(ruleName string, namespace string, groups []prometheusv1.RuleGroup) *prometheusv1.PrometheusRule {
-	return &prometheusv1.PrometheusRule{
+// CreatePrometheusRule will create a PrometheusRule object
+func ReconcilePrometheusRule(ctx context.Context, client client.Client, ruleName, ns, alertName, desc string, alertExp intstr.IntOrString, labels map[string]string) (*prometheusv1.PrometheusRule, error) {
+	alertGroupName := alertName + "Group"
+	groups := []prometheusv1.RuleGroup{
+		{
+			Name: alertGroupName,
+			Rules: []prometheusv1.Rule{
+				{
+					Alert:  alertName,
+					Expr:   alertExp,
+					Labels: labels,
+					Annotations: map[string]string{
+						"description": desc,
+					},
+				},
+			},
+		},
+	}
+
+	rule := &prometheusv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ruleName,
-			Namespace: namespace,
+			Namespace: ns,
 			Labels: map[string]string{
 				"monitoring-key": "middleware",
 			},
@@ -86,27 +114,95 @@ func createPrometheusRuleObject(ruleName string, namespace string, groups []prom
 			Groups: groups,
 		},
 	}
+
+	// create or update the resource
+	_, err := controllerutil.CreateOrUpdate(ctx, client, rule, func() error {
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to reconcile prometheus rule request for %s", ruleName)
+	}
+
+	return rule, nil
 }
 
-// CreatePrometheusRule will create a PrometheusRule object
-func CreatePrometheusRule(ruleName string, namespace string, alertRuleName string, description string, alertExp intstr.IntOrString, labels map[string]string) (*prometheusv1.PrometheusRule, error) {
-	alertGroupName := alertRuleName + "Group"
-
-	groups := []prometheusv1.RuleGroup{
-		{
-			Name: alertGroupName,
-			Rules: []prometheusv1.Rule{
-				{
-					Alert:  alertRuleName,
-					Expr:   alertExp,
-					Labels: labels,
-					Annotations: map[string]string{
-						"description": description,
-					},
-				},
-			},
+// DeletePrometheusRule will delete a prometheus rule object
+func DeletePrometheusRule(ctx context.Context, client client.Client, ruleName, ns string) error {
+	rule := &prometheusv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      ruleName,
 		},
 	}
 
-	return createPrometheusRuleObject(ruleName, namespace, groups), nil
+	// call delete on that object
+	if err := client.Delete(ctx, rule); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreatePostgresAvailabilityAlert creates an alert for the availability of a postgres instance
+func CreatePostgresAvailabilityAlert(ctx context.Context, client client.Client, cr *v1alpha1.Postgres) (*prometheusv1.PrometheusRule, error) {
+	clusterID, err := GetClusterID(ctx, client)
+	if err != nil {
+		return nil, errorUtil.Wrap(err, "failed to retrieve cluster identifier")
+	}
+	ruleName := fmt.Sprintf("availability-rule-%s", cr.Name)
+	alertRuleName := "PostgresInstanceUnavailable"
+	alertExp := intstr.FromString(
+		fmt.Sprintf("absent(%s{exported_namespace='%s',resourceID='%s'} == 1)",
+			DefaultPostgresAvailMetricName, cr.Namespace, cr.Name),
+	)
+	alertDescription := fmt.Sprintf("Postgres instance: %s on cluster: %s for product: %s is unavailable", cr.Name, clusterID, cr.Labels["productName"])
+	labels := map[string]string{
+		"severity":    "critical",
+		"productName": cr.Labels["productName"],
+	}
+
+	// create the rule
+	pr, err := ReconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertRuleName, alertDescription, alertExp, labels)
+	if err != nil {
+		return nil, err
+	}
+	return pr, nil
+}
+
+// DeletePostgresAvailabilityAlert deletes the postgres availability alert
+func DeletePostgresAvailabilityAlert(ctx context.Context, client client.Client, cr *v1alpha1.Postgres) error {
+	ruleName := fmt.Sprintf("availability-rule-%s", cr.Name)
+	return DeletePrometheusRule(ctx, client, ruleName, cr.Namespace)
+}
+
+// CreateRedisAvailabilityAlert creates an alert for the availability of a redis cache
+func CreateRedisAvailabilityAlert(ctx context.Context, client client.Client, cr *v1alpha1.Redis) (*prometheusv1.PrometheusRule, error) {
+	clusterID, err := GetClusterID(ctx, client)
+	if err != nil {
+		return nil, errorUtil.Wrap(err, "failed to retrieve cluster identifier")
+	}
+	ruleName := fmt.Sprintf("availability-rule-%s", cr.Name)
+	alertRuleName := "RedisInstanceUnavailable"
+	alertExp := intstr.FromString(
+		fmt.Sprintf("absent(%s{exported_namespace='%s',resourceID='%s'} == 1)",
+			DefaultRedisAvailMetricName, cr.Namespace, cr.Name),
+	)
+	alertDescription := fmt.Sprintf("Redis cache: %s on cluster: %s for product: %s is unavailable", cr.Name, clusterID, cr.Labels["productName"])
+	labels := map[string]string{
+		"severity":    "critical",
+		"productName": cr.Labels["productName"],
+	}
+
+	// create the rule
+	pr, err := ReconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertRuleName, alertDescription, alertExp, labels)
+	if err != nil {
+		return nil, err
+	}
+	return pr, nil
+}
+
+// DeleteRedisAvailabilityAlert deletes the redis availability alert
+func DeleteRedisAvailabilityAlert(ctx context.Context, client client.Client, cr *v1alpha1.Redis) error {
+	ruleName := fmt.Sprintf("availability-rule-%s", cr.Name)
+	return DeletePrometheusRule(ctx, client, ruleName, cr.Namespace)
 }


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/INTLY-5109

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make run`
- Create a managed postgres instance and a managed redis instance:
```
make cluster/seed/managed/redis
make cluster/seed/managed/postgres
```
- Ensure the metrics `cro_redis_available` and `cro_postgres_available` are being exposed
- Ensure that the promethus rules are getting created and 
- Ensure that alert names, descriptions, etc do not contain provider specific terminology (eg should be Postgres over RDS) 