### PR TITLE
fix region reconciliation in aws service providers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/lib/pq v1.2.0
 	github.com/onsi/ginkgo v1.10.1 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
-	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible
 	github.com/openshift/cloud-credential-operator v0.0.0-20190812222907-ec6f38d73a79
 	github.com/operator-framework/operator-sdk v0.12.1-0.20191112211508-82fc57de5e5b
@@ -29,9 +28,7 @@ require (
 	golang.org/x/net v0.0.0-20191003171128-d98b1b443823 // indirect
 	golang.org/x/sys v0.0.0-20200113162924-86b910548bc1 // indirect
 	google.golang.org/appengine v1.6.2 // indirect
-	google.golang.org/genproto v0.0.0-20181016170114-94acd270e44e // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v12.0.0+incompatible

--- a/pkg/controller/postgressnapshot/postgressnapshot_controller.go
+++ b/pkg/controller/postgressnapshot/postgressnapshot_controller.go
@@ -143,7 +143,7 @@ func (r *ReconcilePostgresSnapshot) Reconcile(request reconcile.Request) (reconc
 		return reconcile.Result{Requeue: true, RequeueAfter: resources.ErrorReconcileTime}, err
 	}
 
-	defRegion, err := croAws.GetDefaultRegion(ctx, r.client)
+	defRegion, err := croAws.GetRegionFromStrategyOrDefault(ctx, r.client, stratCfg)
 	if err != nil {
 		return reconcile.Result{Requeue: true, RequeueAfter: resources.ErrorReconcileTime}, err
 	}

--- a/pkg/controller/redissnapshot/redissnapshot_controller.go
+++ b/pkg/controller/redissnapshot/redissnapshot_controller.go
@@ -144,7 +144,7 @@ func (r *ReconcileRedisSnapshot) Reconcile(request reconcile.Request) (reconcile
 		return reconcile.Result{Requeue: true, RequeueAfter: resources.ErrorReconcileTime}, err
 	}
 
-	defRegion, err := croAws.GetDefaultRegion(ctx, r.client)
+	defRegion, err := croAws.GetRegionFromStrategyOrDefault(ctx, r.client, stratCfg)
 	if err != nil {
 		return reconcile.Result{Requeue: true, RequeueAfter: resources.ErrorReconcileTime}, err
 	}

--- a/pkg/providers/aws/credentials.go
+++ b/pkg/providers/aws/credentials.go
@@ -70,6 +70,7 @@ var (
 				"rds:CreateDBSubnetGroup",
 				"rds:DescribeDBSubnetGroups",
 				"sts:GetCallerIdentity",
+				"iam:CreateServiceLinkedRole",
 			},
 			Resource: "*",
 		},

--- a/pkg/providers/aws/provider_smtpcredentialset.go
+++ b/pkg/providers/aws/provider_smtpcredentialset.go
@@ -108,7 +108,7 @@ func (p *SMTPCredentialProvider) CreateSMTPCredentials(ctx context.Context, smtp
 	}
 
 	awsRegion := stratCfg.Region
-	defRegion, err := GetDefaultRegion(ctx, p.Client)
+	defRegion, err := GetRegionFromStrategyOrDefault(ctx, p.Client, stratCfg)
 	if err != nil {
 		errMsg := "failed to get default region"
 		return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)

--- a/pkg/providers/aws/provider_smtpcredentialset_test.go
+++ b/pkg/providers/aws/provider_smtpcredentialset_test.go
@@ -67,6 +67,7 @@ func buildTestInfrastructure() *crov1.Infrastructure {
 			InfrastructureName: "test",
 			Platform:           crov1.AWSPlatformType,
 			PlatformStatus: &crov1.PlatformStatus{
+				Type: crov1.AWSPlatformType,
 				AWS: &crov1.AWSPlatformStatus{
 					Region: "test",
 				},

--- a/pkg/resources/cluster.go
+++ b/pkg/resources/cluster.go
@@ -32,7 +32,7 @@ func GetAWSRegion(ctx context.Context, c client.Client) (string, error) {
 	if err := c.Get(ctx, types.NamespacedName{Name: "cluster"}, infra); err != nil {
 		return "", errorUtil.Wrap(err, "failed to retrieve cluster infrastructure")
 	}
-	if infra.Status.Platform == v1.AWSPlatformType {
+	if infra.Status.PlatformStatus.Type == v1.AWSPlatformType {
 		return infra.Status.PlatformStatus.AWS.Region, nil
 	}
 	return "", errorUtil.New("infrastructure does not container aws region")


### PR DESCRIPTION
currently aws regions are not being set in a way which would
benefit rhmi, instead defaulting to eu-west-1 for aws deploys.

this change sets a priority to different ways of retrieving the
aws region in aws providers:
- try from the configmap strategy 'region' key
- try from the 'cluster' infrastructure cr in openshift
- error

this results in there being no more hardcoded region in the
operator, which was used heavily during development. and ensures
that, unless explicitly overridden with a configmap, rhmi services
will attempt to be provisioned in the same region as the openshift
cluster that the operator is running in.

verification:
- run the operator against a non-eu-west-1 region cluster
- ensure services come up as expected
