### PR TITLE
add conditions to not except changes in cloud-resource-config in an existing install

### DIFF
--- a/pkg/controller/redis/redis_controller.go
+++ b/pkg/controller/redis/redis_controller.go
@@ -119,9 +119,25 @@ func (r *ReconcileRedis) Reconcile(request reconcile.Request) (reconcile.Result,
 		return reconcile.Result{}, errorUtil.Wrapf(err, "failed to read deployment type config for deployment %s", instance.Spec.Type)
 	}
 
+	// Check the CR for existing Strategy
+	strategyToUse := stratMap.Redis
+	if instance.Status.Strategy != "" {
+		strategyToUse = instance.Status.Strategy
+		if strategyToUse != stratMap.Redis {
+			r.logger.Infof("strategy and provider already set, changing of cloud-resource-config config maps not allowed in existing installation. the existing strategy is '%s' , cloud-resource-config is now set to '%s'. operator will continue to use existing strategy", strategyToUse, stratMap.Redis)
+		}
+	}
+
 	for _, p := range r.providerList {
-		if !p.SupportsStrategy(stratMap.Redis) {
+		if !p.SupportsStrategy(strategyToUse) {
 			continue
+		}
+		instance.Status.Strategy = strategyToUse
+		instance.Status.Provider = p.GetName()
+		if instance.Status.Strategy != strategyToUse || instance.Status.Provider != p.GetName() {
+			if err = r.client.Status().Update(ctx, instance); err != nil {
+				return reconcile.Result{}, errorUtil.Wrapf(err, "failed to update instance %s in namespace %s", instance.Name, instance.Namespace)
+			}
 		}
 
 		// handle deletion of redis and remove any finalizers added
@@ -177,7 +193,7 @@ func (r *ReconcileRedis) Reconcile(request reconcile.Request) (reconcile.Result,
 		instance.Status.Phase = croType.PhaseComplete
 		instance.Status.Message = msg
 		instance.Status.SecretRef = instance.Spec.SecretRef
-		instance.Status.Strategy = stratMap.Redis
+		instance.Status.Strategy = strategyToUse
 		instance.Status.Provider = p.GetName()
 		if err = r.client.Status().Update(ctx, instance); err != nil {
 			return reconcile.Result{}, errorUtil.Wrapf(err, "failed to update instance %s in namespace %s", instance.Name, instance.Namespace)


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/INTLY-5447

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make run`
- Run `make seed/managed/postgres`
- edit the cloud-resource-config configmap on the cluster and change the managed section to point to openshift as follows
```yaml
data:
  managed: >
    {"blobstorage":"aws", "smtpcredentials":"aws", "redis":"aws",
    "postgres":"openshift"}
```
- you should get the following warning in the operator logs
```bash
INFO[0007] Strategy and Provider already set, changing of cloud-resource-config config maps not allowed in existing installation. The existing Strategy is 'aws' , cloud-resource-config is now set to 'openshift'. Operator will continue to use existing Strategy  controller=controller_postgres
```
- The Postgres cr example-postgres status should continue to point at aws for strategy and provider as follows
```bash
oc get postgres example-postgres -o yaml -w
```
```yaml
...
status:
  message: successfully created and tagged, aws rds status is available
  phase: complete
  provider: aws-rds
  secretRef:
    name: example-postgres-sec
  strategy: aws

```

Repeat above steps for Redis, Smtpcredentials and blogstorage.