### PR TITLE
fix handle modify aws instance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/lib/pq v1.3.0
 	github.com/onsi/ginkgo v1.10.1 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
-	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible
 	github.com/openshift/cloud-credential-operator v0.0.0-20190812222907-ec6f38d73a79
 	github.com/operator-framework/operator-sdk v0.12.1-0.20191112211508-82fc57de5e5b
@@ -29,9 +28,7 @@ require (
 	golang.org/x/net v0.0.0-20191003171128-d98b1b443823 // indirect
 	golang.org/x/sys v0.0.0-20200113162924-86b910548bc1 // indirect
 	google.golang.org/appengine v1.6.2 // indirect
-	google.golang.org/genproto v0.0.0-20181016170114-94acd270e44e // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v12.0.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/lib/pq v1.3.0
 	github.com/onsi/ginkgo v1.10.1 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
+	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible
 	github.com/openshift/cloud-credential-operator v0.0.0-20190812222907-ec6f38d73a79
 	github.com/operator-framework/operator-sdk v0.12.1-0.20191112211508-82fc57de5e5b
@@ -28,7 +29,9 @@ require (
 	golang.org/x/net v0.0.0-20191003171128-d98b1b443823 // indirect
 	golang.org/x/sys v0.0.0-20200113162924-86b910548bc1 // indirect
 	google.golang.org/appengine v1.6.2 // indirect
+	google.golang.org/genproto v0.0.0-20181016170114-94acd270e44e // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v12.0.0+incompatible

--- a/pkg/providers/aws/config.go
+++ b/pkg/providers/aws/config.go
@@ -27,7 +27,7 @@ const (
 
 	DefaultFinalizer = "finalizers.cloud-resources-operator.integreatly.org"
 
-	defaultReconcileTime = time.Second * 300
+	defaultReconcileTime = time.Second * 30
 
 	regionUSEast1 = "us-east-1"
 	regionUSWest2 = "us-west-2"

--- a/pkg/providers/aws/credentials.go
+++ b/pkg/providers/aws/credentials.go
@@ -59,6 +59,7 @@ var (
 				"elasticache:DescribeCacheClusters",
 				"elasticache:DescribeCacheSubnetGroups",
 				"elasticache:CreateCacheSubnetGroup",
+				"elasticache:ModifyReplicationGroup",
 				"rds:DescribeDBInstances",
 				"rds:CreateDBInstance",
 				"rds:DeleteDBInstance",

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -473,15 +473,15 @@ func buildRDSUpdateStrategy(rdsConfig *rds.CreateDBInstanceInput, foundConfig *r
 		mi.DeletionProtection = rdsConfig.DeletionProtection
 		updateFound = true
 	}
-	if *rdsConfig.Port != *foundConfig.Endpoint.Port && *foundConfig.PendingModifiedValues.Port != *rdsConfig.Port {
+	if *rdsConfig.Port != *foundConfig.Endpoint.Port {
 		mi.DBPortNumber = rdsConfig.Port
 		updateFound = true
 	}
-	if *rdsConfig.BackupRetentionPeriod != *foundConfig.BackupRetentionPeriod && *foundConfig.PendingModifiedValues.BackupRetentionPeriod != *rdsConfig.BackupRetentionPeriod {
+	if *rdsConfig.BackupRetentionPeriod != *foundConfig.BackupRetentionPeriod {
 		mi.BackupRetentionPeriod = rdsConfig.BackupRetentionPeriod
 		updateFound = true
 	}
-	if *rdsConfig.DBInstanceClass != *foundConfig.DBInstanceClass && *foundConfig.PendingModifiedValues.DBInstanceClass != *rdsConfig.DBInstanceClass {
+	if *rdsConfig.DBInstanceClass != *foundConfig.DBInstanceClass {
 		mi.DBInstanceClass = rdsConfig.DBInstanceClass
 		updateFound = true
 	}
@@ -489,22 +489,61 @@ func buildRDSUpdateStrategy(rdsConfig *rds.CreateDBInstanceInput, foundConfig *r
 		mi.PubliclyAccessible = rdsConfig.PubliclyAccessible
 		updateFound = true
 	}
-	if *rdsConfig.AllocatedStorage != *foundConfig.AllocatedStorage && *foundConfig.PendingModifiedValues.AllocatedStorage != *rdsConfig.AllocatedStorage {
+	if *rdsConfig.AllocatedStorage != *foundConfig.AllocatedStorage {
 		mi.AllocatedStorage = rdsConfig.AllocatedStorage
 		updateFound = true
 	}
-	if *rdsConfig.EngineVersion != *foundConfig.EngineVersion && *foundConfig.PendingModifiedValues.EngineVersion != *rdsConfig.EngineVersion {
+	if *rdsConfig.EngineVersion != *foundConfig.EngineVersion {
 		mi.EngineVersion = rdsConfig.EngineVersion
 		updateFound = true
 	}
-	if *rdsConfig.MultiAZ != *foundConfig.MultiAZ && *foundConfig.PendingModifiedValues.MultiAZ != *rdsConfig.MultiAZ {
+	if *rdsConfig.MultiAZ != *foundConfig.MultiAZ {
 		mi.MultiAZ = rdsConfig.MultiAZ
 		updateFound = true
 	}
-	if !updateFound {
+	if !updateFound || !verifyPendingModification(mi, foundConfig.PendingModifiedValues) {
 		return nil
 	}
 	return mi
+}
+
+// returns true if modify input is not pending
+func verifyPendingModification(mi *rds.ModifyDBInstanceInput, pm *rds.PendingModifiedValues) bool {
+	pendingModifications := true
+	if pm == nil {
+		return pendingModifications
+	}
+	if mi.DBPortNumber != nil && pm.Port != nil {
+		if *mi.DBPortNumber == *pm.Port {
+			pendingModifications = false
+		}
+	}
+	if mi.BackupRetentionPeriod != nil && pm.BackupRetentionPeriod != nil {
+		if *mi.BackupRetentionPeriod == *pm.BackupRetentionPeriod {
+			pendingModifications = false
+		}
+	}
+	if mi.DBInstanceClass != nil && pm.DBInstanceClass != nil {
+		if *mi.DBInstanceClass == *pm.DBInstanceClass {
+			pendingModifications = false
+		}
+	}
+	if mi.AllocatedStorage != nil && pm.AllocatedStorage != nil {
+		if *mi.AllocatedStorage == *pm.AllocatedStorage {
+			pendingModifications = false
+		}
+	}
+	if mi.EngineVersion != nil && pm.EngineVersion != nil {
+		if *mi.EngineVersion == *pm.EngineVersion {
+			pendingModifications = false
+		}
+	}
+	if mi.MultiAZ != nil && pm.MultiAZ != nil {
+		if *mi.MultiAZ == *pm.MultiAZ {
+			pendingModifications = false
+		}
+	}
+	return pendingModifications
 }
 
 // verify postgres create config

--- a/pkg/providers/aws/provider_postgres_test.go
+++ b/pkg/providers/aws/provider_postgres_test.go
@@ -237,6 +237,15 @@ func buildAvailableDBInstance(testID string) []*rds.DBInstance {
 	}
 }
 
+func buildPendingDBInstance(testID string) []*rds.DBInstance {
+	return []*rds.DBInstance{
+		{
+			DBInstanceIdentifier: aws.String(testID),
+			DBInstanceStatus:     aws.String("pending"),
+		},
+	}
+}
+
 func buildAvailableCreateInput(testID string) *rds.CreateDBInstanceInput {
 	return &rds.CreateDBInstanceInput{
 		DBInstanceIdentifier:  aws.String(testID),
@@ -388,7 +397,7 @@ func TestAWSPostgresProvider_createPostgresInstance(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "test rds is created",
+			name: "test rds CreateReplicationGroup is called",
 			args: args{
 				rdsSvc:      &mockRdsClient{dbInstances: []*rds.DBInstance{}},
 				ec2Svc:      &mockEc2Client{vpcs: buildVpcs(), subnets: buildSubnets(), secGroups: buildSecurityGroups(secName), azs: buildAZ()},
@@ -431,6 +440,27 @@ func TestAWSPostgresProvider_createPostgresInstance(t *testing.T) {
 				Database: defaultAwsEngine,
 				Port:     defaultAwsPostgresPort,
 			}},
+			wantErr: false,
+		},
+		{
+			name: "test rds is exists and is not available",
+			args: args{
+				rdsSvc: &mockRdsClient{dbInstances: buildPendingDBInstance(testIdentifier)},
+				ec2Svc: &mockEc2Client{vpcs: buildVpcs(), subnets: buildSubnets(), secGroups: buildSecurityGroups(secName), azs: buildAZ()},
+				ctx:    context.TODO(),
+				cr:     buildTestPostgresCR(),
+				postgresCfg: &rds.CreateDBInstanceInput{
+					DBInstanceIdentifier: aws.String(testIdentifier),
+				},
+			},
+			fields: fields{
+				Client:            fake.NewFakeClientWithScheme(scheme, buildTestPostgresCR(), builtTestCredSecret(), buildTestInfra()),
+				Logger:            testLogger,
+				CredentialManager: nil,
+				ConfigManager:     nil,
+				TCPPinger:         buildMockConnectionTester(),
+			},
+			want:    nil,
 			wantErr: false,
 		},
 		{

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -282,7 +282,7 @@ func Test_createRedisCluster(t *testing.T) {
 				TCPPinger:         buildMockConnectionTester(),
 				Client:            fake.NewFakeClientWithScheme(scheme, buildTestRedisCR(), builtTestCredSecret(), buildTestInfra(), buildTestPrometheusRule()),
 			},
-			want:    nil,
+			want:    buildTestRedisCluster(),
 			wantErr: false,
 		},
 		{

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -244,6 +244,27 @@ func Test_createRedisCluster(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "test elasticache already exists and status is available",
+			args: args{
+				ctx:         context.TODO(),
+				cacheSvc:    &mockElasticacheClient{replicationGroups: buildReplicationGroupReady()},
+				ec2Svc:      &mockEc2Client{vpcs: buildVpcs(), subnets: buildSubnets(), secGroups: buildSecurityGroups(secName)},
+				r:           buildTestRedisCR(),
+				stsSvc:      &mockStsClient{},
+				redisConfig: &elasticache.CreateReplicationGroupInput{ReplicationGroupId: aws.String("test-id")},
+				stratCfg:    &StrategyConfig{Region: "test"},
+			},
+			fields: fields{
+				ConfigManager:     nil,
+				CredentialManager: nil,
+				Logger:            testLogger,
+				TCPPinger:         buildMockConnectionTester(),
+				Client:            fake.NewFakeClientWithScheme(scheme, buildTestRedisCR(), builtTestCredSecret(), buildTestInfra(), buildTestPrometheusRule()),
+			},
+			want:    buildTestRedisCluster(),
+			wantErr: false,
+		},
+		{
 			name: "test elasticache already exists and status is not available",
 			args: args{
 				ctx:         context.TODO(),

--- a/pkg/resources/configmaps.go
+++ b/pkg/resources/configmaps.go
@@ -2,6 +2,8 @@ package resources
 
 import (
 	"context"
+	"fmt"
+	"github.com/sirupsen/logrus"
 
 	errorUtil "github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -14,6 +16,7 @@ func GetConfigMapOrDefault(ctx context.Context, c client.Client, name types.Name
 	cm := &v1.ConfigMap{}
 	if err := c.Get(ctx, name, cm); err != nil {
 		if errors.IsNotFound(err) {
+			logrus.Debug(fmt.Sprintf("%s config not found in ns ( %s ) falling back to default strategy", name.Name, name.Namespace))
 			return def, nil
 		}
 		return nil, errorUtil.Wrap(err, "failed to get config map, not returning default")


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/INTLY-5467

Currently how we handled the modify of aws resources meant the status of a CR got stuck in `pending` until the next maintenance window. This change ensures a continuous happy path over applying modifications to resources.  

## Verification

- Clone this branch
- Run `make cluster/prepare cluster/seed/managed/redis cluster/seed/managed/postgres`
- Run `make run`
- Once resources are created, via the aws console bump the instance size of both `elasticache` and `rds`. Ensure you select apply immediately. When AWS successfully changes the instance size and CRO reconciles on these changes it will try to modify the instances to their original size. 
- Via the AWS console you can view pending modifications. Ensure these modifications are present 
- Ensure the operator continues to run, note the logs informing of any pending modifications
- Ensure the CR status reflects the AWS instance status

## Note
Currently for `postgres` we check to see if the modifications we are going to apply will be applied in the next maintenance window. If not they are added. Due to limitation in the AWS elasticache SDK we can not do this for Redis. Resulting in the `modify` function being called every reconcile until the maintenance window 