### PR TITLE
Postgres/Redis connection metric function refactor

### DIFF
--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -197,10 +197,13 @@ func (p *PostgresProvider) createRDSInstance(ctx context.Context, cr *v1alpha1.P
 	}
 
 	// expose pending maintenance metric
-	p.setPostgresServiceMaintenanceMetric(ctx, cr, rdsSvc, foundInstance)
+	defer p.setPostgresServiceMaintenanceMetric(ctx, cr, rdsSvc, foundInstance)
 
 	// set status metric
-	p.exposePostgresMetrics(ctx, cr, foundInstance)
+	defer p.exposePostgresMetrics(ctx, cr, foundInstance)
+
+	// create connection metric
+	defer p.createRDSConnectionMetric(ctx, cr, foundInstance)
 
 	// check rds instance phase
 	if *foundInstance.DBInstanceStatus != "available" {
@@ -230,9 +233,6 @@ func (p *PostgresProvider) createRDSInstance(ctx context.Context, cr *v1alpha1.P
 		Database: *foundInstance.DBName,
 		Port:     int(*foundInstance.Endpoint.Port),
 	}
-
-	// create connection metric
-	p.createRDSConnectionMetric(ctx, cr, foundInstance, pdd)
 
 	// return secret information
 	return &providers.PostgresInstance{DeploymentDetails: pdd}, croType.StatusMessage(fmt.Sprintf("%s, aws rds status is %s", msg, *foundInstance.DBInstanceStatus)), nil
@@ -766,9 +766,9 @@ func (p *PostgresProvider) setPostgresServiceMaintenanceMetric(ctx context.Conte
 }
 
 // tests to see if a simple tcp connection can be made to rds and creates a metric based on this
-func (p *PostgresProvider) createRDSConnectionMetric(ctx context.Context, cr *v1alpha1.Postgres, instance *rds.DBInstance, postgresInstance *providers.PostgresDeploymentDetails) {
+func (p *PostgresProvider) createRDSConnectionMetric(ctx context.Context, cr *v1alpha1.Postgres, instance *rds.DBInstance) {
 	// return cluster id needed for metric labels
-	logrus.Info(fmt.Sprintf("testing and exposing postgres connection metric for: %s", *instance.DBInstanceIdentifier))
+	logrus.Infof("testing and exposing postgres connection metric for: %s", *instance.DBInstanceIdentifier)
 	clusterID, err := resources.GetClusterID(ctx, p.Client)
 	if err != nil {
 		logrus.Error(fmt.Sprintf("failed to get cluster id while exposing connection metric for %s", *instance.DBInstanceIdentifier))
@@ -778,8 +778,15 @@ func (p *PostgresProvider) createRDSConnectionMetric(ctx context.Context, cr *v1
 	// build generic labels to be added to metric
 	genericLabels := buildPostgresGenericMetricLabels(cr, instance, clusterID)
 
+	// check if the endpoint is available
+	if instance.Endpoint == nil {
+		logrus.Infof("instance endpoint not yet available for: %s", *instance.DBInstanceIdentifier)
+		resources.SetMetric(resources.DefaultPostgresConnectionMetricName, genericLabels, 0)
+		return
+	}
+
 	// test the connection
-	conn := p.TCPPinger.TCPConnection(postgresInstance.Host, postgresInstance.Port)
+	conn := p.TCPPinger.TCPConnection(*instance.Endpoint.Address, int(*instance.Endpoint.Port))
 	if !conn {
 		// create failed connection metric
 		resources.SetMetric(resources.DefaultPostgresConnectionMetricName, genericLabels, 0)

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -157,10 +157,13 @@ func (p *RedisProvider) createElasticacheCluster(ctx context.Context, r *v1alpha
 	}
 
 	// expose elasticache maintenance metric
-	p.setRedisServiceMaintenanceMetric(ctx, r, cacheSvc, foundCache)
+	defer p.setRedisServiceMaintenanceMetric(ctx, r, cacheSvc, foundCache)
 
 	// expose status metrics
-	p.exposeRedisMetrics(ctx, r, foundCache)
+	defer p.exposeRedisMetrics(ctx, r, foundCache)
+
+	// expose a connection metric
+	defer p.createElasticacheConnectionMetric(ctx, r, foundCache)
 
 	// check elasticache phase
 	if *foundCache.Status != "available" {
@@ -197,9 +200,6 @@ func (p *RedisProvider) createElasticacheCluster(ctx context.Context, r *v1alpha
 		URI:  *primaryEndpoint.Address,
 		Port: *primaryEndpoint.Port,
 	}
-
-	// expose a connection metric
-	p.createElasticacheConnectionMetric(ctx, r, foundCache, rdd)
 
 	// return secret information
 	return &providers.RedisCluster{DeploymentDetails: rdd}, croType.StatusMessage(fmt.Sprintf("successfully created and tagged, aws elasticache status is %s", *foundCache.Status)), nil
@@ -667,9 +667,9 @@ func (p *RedisProvider) setRedisServiceMaintenanceMetric(ctx context.Context, cr
 	}
 }
 
-func (p *RedisProvider) createElasticacheConnectionMetric(ctx context.Context, cr *v1alpha1.Redis, cache *elasticache.ReplicationGroup, elasticacheGroup *providers.RedisDeploymentDetails) {
+func (p *RedisProvider) createElasticacheConnectionMetric(ctx context.Context, cr *v1alpha1.Redis, cache *elasticache.ReplicationGroup) {
 	// return cluster id needed for metric labels
-	logrus.Info(fmt.Sprintf("testing and exposing redis connection metric for: %s", *cache.ReplicationGroupId))
+	logrus.Infof("testing and exposing redis connection metric for: %s", *cache.ReplicationGroupId)
 	clusterID, err := resources.GetClusterID(ctx, p.Client)
 	if err != nil {
 		logrus.Error(fmt.Sprintf("failed to get cluster id while exposing connection metric for %s", *cache.ReplicationGroupId))
@@ -678,8 +678,15 @@ func (p *RedisProvider) createElasticacheConnectionMetric(ctx context.Context, c
 	// build generic labels to be added to metric
 	genericLabels := buildRedisGenericMetricLabels(cr, cache, clusterID)
 
+	// check if the node group is available
+	if cache.NodeGroups == nil {
+		resources.SetMetric(resources.DefaultRedisConnectionMetricName, genericLabels, 0)
+		logrus.Infof("node group not yet available for: %s", *cache.ReplicationGroupId)
+		return
+	}
+
 	// test the connection
-	conn := p.TCPPinger.TCPConnection(elasticacheGroup.URI, int(elasticacheGroup.Port))
+	conn := p.TCPPinger.TCPConnection(*cache.NodeGroups[0].PrimaryEndpoint.Address, int(*cache.NodeGroups[0].PrimaryEndpoint.Port))
 	if !conn {
 		// create failed connection metric
 		resources.SetMetric(resources.DefaultRedisConnectionMetricName, genericLabels, 0)


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/INTLY-5213

## Verification

- Clone this branch
- Login to your cluster via `oc`
- `make cluster/prepare`
- `make cluster/prepare cluster/seed/managed/redis cluster/seed/managed/postgres`
- `make run`
- Once the resources have been created and with the operator running locally: `curl localhost:8383/metrics | grep -i cro`
- Verify that both the `cro_redis_connection` and `cro_postgres_connection` metrics are displayed. As the operator is running locally, they will show a `0` value.
