### PR TITLE
intly-6233 Final snapshots for RDS and Elasticache do not contain tags for teardown

### DIFF
--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -52,6 +52,7 @@ const (
 	defaultAwsEngineVersion              = "10.6"
 	defaultAwsPubliclyAccessible         = false
 	defaultAwsSkipFinalSnapshot          = false
+	defaultAWSCopyTagsToSnapshot         = true
 	defaultAwsDeleteAutomatedBackups     = true
 	defaultCredSecSuffix                 = "-aws-rds-credentials"
 	defaultPostgresUserKey               = "user"
@@ -627,6 +628,9 @@ func (p *PostgresProvider) buildRDSCreateStrategy(ctx context.Context, pg *v1alp
 		rdsCreateConfig.VpcSecurityGroupIds = []*string{
 			aws.String(*foundSecGroup.GroupId),
 		}
+	}
+	if rdsCreateConfig.CopyTagsToSnapshot == nil {
+		rdsCreateConfig.CopyTagsToSnapshot = aws.Bool(defaultAWSCopyTagsToSnapshot)
 	}
 	return nil
 }

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -33,9 +33,7 @@ import (
 )
 
 const (
-	defaultRedisMaintenanceMetricName = "cro_redis_elasticache_service_maintenance"
-	defaultRedisInfoMetricName        = "cro_redis_info"
-	redisProviderName                 = "aws-elasticache"
+	redisProviderName = "aws-elasticache"
 	// default create params
 	defaultCacheNodeType = "cache.t2.micro"
 	// required for at rest encryption, see https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/at-rest-encryption.html
@@ -548,7 +546,7 @@ func (p *RedisProvider) buildElasticacheDeleteConfig(ctx context.Context, r v1al
 	if err != nil {
 		return errorUtil.Wrapf(err, "failed to retrieve rds config")
 	}
-	if elasticacheDeleteConfig.FinalSnapshotIdentifier != nil && *elasticacheDeleteConfig.FinalSnapshotIdentifier == "" {
+	if elasticacheDeleteConfig.FinalSnapshotIdentifier == nil {
 		elasticacheDeleteConfig.FinalSnapshotIdentifier = aws.String(snapshotIdentifier)
 	}
 	return nil


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/INTLY-6233 

## Verification

- Clone this branch
- Run `make cluster/prepare cluster/seed/managed/postgres cluster/seed/managed/redis`
- Run `make run`
- Delete CR's when resource is created
- Ensure snapshot of redis is created
- Ensure tags are added to postgres snapshot