### PR TITLE
Intly 6232 - Ensure CRO metrics are always exposed

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -38,7 +38,7 @@ import (
 // Change below variables to serve metrics on different host or port.
 var (
 	metricsHost               = "0.0.0.0"
-	metricsPort         int32 = 8384
+	metricsPort         int32 = 8383
 	operatorMetricsPort int32 = 8686
 )
 var log = logf.Log.WithName("cmd")

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -38,7 +38,7 @@ import (
 // Change below variables to serve metrics on different host or port.
 var (
 	metricsHost               = "0.0.0.0"
-	metricsPort         int32 = 8383
+	metricsPort         int32 = 8384
 	operatorMetricsPort int32 = 8686
 )
 var log = logf.Log.WithName("cmd")


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/INTLY-6232

## Verification

- Run `make cluster/prepare`
- Run `make cluster/seed/managed/postgres cluster/seed/managed/redis`
- Run `make run`
- Run `curl localhost:8384/metrics | grep aws`
- Ensure the following metrics are there `cro_postgres_available, cro_postgres_connection, cro_postgres_info, cro_redis_available, cro_redis_connection`
- Once resources created, add `skipCreate: true` to the resources CR
- Log into AWS console, delete resources
- Remove `skipCreate: true` from CR
- Verify the resource is not recreated
- Verify the metrics are still exposed and the correct metric value

**Note :** The connection value will always be `0` if running locally