### PR TITLE
Allow RDS backup and maintenance windows to be modified through CRO ConfigMaps

### DIFF
--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -4,9 +4,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Created is a string that can be used as an annotation
-const Created string = "created"
-
 // Add makes sure that the provided key/value are set as an annotation
 func Add(instance metav1.Object, key, value string) {
 	annotations := instance.GetAnnotations()

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -515,6 +515,14 @@ func buildRDSUpdateStrategy(rdsConfig *rds.CreateDBInstanceInput, foundConfig *r
 		mi.MultiAZ = rdsConfig.MultiAZ
 		updateFound = true
 	}
+	if rdsConfig.PreferredBackupWindow != nil && *rdsConfig.PreferredBackupWindow != *foundConfig.PreferredBackupWindow {
+		mi.PreferredBackupWindow = rdsConfig.PreferredBackupWindow
+		updateFound = true
+	}
+	if rdsConfig.PreferredMaintenanceWindow != nil && *rdsConfig.PreferredMaintenanceWindow != *foundConfig.PreferredMaintenanceWindow {
+		mi.PreferredMaintenanceWindow = rdsConfig.PreferredMaintenanceWindow
+		updateFound = true
+	}
 	if !updateFound || !verifyPendingModification(mi, foundConfig.PendingModifiedValues) {
 		return nil
 	}

--- a/pkg/providers/aws/provider_postgres_test.go
+++ b/pkg/providers/aws/provider_postgres_test.go
@@ -29,6 +29,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const (
+	testPreferredBackupWindow = "02:40-03:10"
+	testPreferredMaintenanceWindow = "mon:00:29-mon:00:59"
+)
 type mockRdsClient struct {
 	rdsiface.RDSAPI
 	wantErrList   bool
@@ -195,6 +199,8 @@ func buildDbInstanceGroupAvailable() []*rds.DBInstance {
 			DBInstanceIdentifier: aws.String("test-id"),
 			DBInstanceStatus:     aws.String("available"),
 			AvailabilityZone:     aws.String("test-availabilityZone"),
+			PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
+			PreferredBackupWindow: aws.String(testPreferredBackupWindow),
 			DeletionProtection:   aws.Bool(false),
 		},
 	}
@@ -227,6 +233,8 @@ func buildAvailableDBInstance(testID string) []*rds.DBInstance {
 			AllocatedStorage:      aws.Int64(defaultAwsAllocatedStorage),
 			EngineVersion:         aws.String(defaultAwsEngineVersion),
 			Engine:                aws.String(defaultAwsEngine),
+			PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
+			PreferredBackupWindow: aws.String(testPreferredBackupWindow),
 			MultiAZ:               aws.Bool(true),
 			Endpoint: &rds.Endpoint{
 				Address:      aws.String("blob"),
@@ -256,6 +264,8 @@ func buildAvailableCreateInput(testID string) *rds.CreateDBInstanceInput {
 		PubliclyAccessible:    aws.Bool(defaultAwsPubliclyAccessible),
 		AllocatedStorage:      aws.Int64(defaultAwsAllocatedStorage),
 		EngineVersion:         aws.String(defaultAwsEngineVersion),
+		PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
+		PreferredBackupWindow: aws.String(testPreferredBackupWindow),
 		MultiAZ:               aws.Bool(true),
 	}
 }
@@ -270,6 +280,8 @@ func buildRequiresModificationsCreateInput(testID string) *rds.CreateDBInstanceI
 		PubliclyAccessible:    aws.Bool(defaultAwsPubliclyAccessible),
 		AllocatedStorage:      aws.Int64(defaultAwsAllocatedStorage),
 		EngineVersion:         aws.String(defaultAwsEngineVersion),
+		PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
+		PreferredBackupWindow: aws.String(testPreferredBackupWindow),
 		MultiAZ:               aws.Bool(true),
 	}
 }
@@ -284,6 +296,8 @@ func buildNewRequiresModificationsCreateInput(testID string) *rds.CreateDBInstan
 		PubliclyAccessible:    aws.Bool(defaultAwsPubliclyAccessible),
 		AllocatedStorage:      aws.Int64(defaultAwsAllocatedStorage),
 		EngineVersion:         aws.String(defaultAwsEngineVersion),
+		PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
+		PreferredBackupWindow: aws.String(testPreferredBackupWindow),
 		MultiAZ:               aws.Bool(true),
 	}
 }
@@ -304,6 +318,8 @@ func buildPendingModifiedDBInstance(testID string) []*rds.DBInstance {
 			AllocatedStorage:      aws.Int64(defaultAwsAllocatedStorage),
 			EngineVersion:         aws.String(defaultAwsEngineVersion),
 			Engine:                aws.String(defaultAwsEngine),
+			PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
+			PreferredBackupWindow: aws.String(testPreferredBackupWindow),
 			MultiAZ:               aws.Bool(true),
 			Endpoint: &rds.Endpoint{
 				Address:      aws.String("blob"),


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/INTLY-7203

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make cluster/seed/managed/postgres`
- Run `make run`
- Ensure postgres is installed correctly, note the maintenance and backup window
- Update `cloud-resources-aws-strategies` config map in the `cloud-resources-operator` namespace, Ensure the `PreferredBackupWindow` and `PreferredMaintenanceWindow` in the update differs from the current windows for the instance : 
```
data:
  blobstorage: >
    {"development": { "region": "eu-west-1", "createStrategy": {},
    "deleteStrategy": {} }}
  postgres: >
    {"development": { "region": "eu-west-1", "createStrategy":
    {"PreferredBackupWindow":"02:40-03:10",
    "PreferredMaintenanceWindow":"mon:00:29-mon:00:59"}, "deleteStrategy": {} }}
  redis: >
    {"development": { "region": "eu-west-1", "createStrategy": {},
    "deleteStrategy": {} }}
```
- Ensure the operator reconciles on this config map (No debug log saying config map not found)
- Ensure the Backup and Maintenance window is updated to match