### PR TITLE
INTLY-7205 added logic for updating redis maintenance/snapshot windows

### DIFF
--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -4,9 +4,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Created is a string that can be used as an annotation
-const Created string = "created"
-
 // Add makes sure that the provided key/value are set as an annotation
 func Add(instance metav1.Object, key, value string) {
 	annotations := instance.GetAnnotations()

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -515,6 +515,14 @@ func buildRDSUpdateStrategy(rdsConfig *rds.CreateDBInstanceInput, foundConfig *r
 		mi.MultiAZ = rdsConfig.MultiAZ
 		updateFound = true
 	}
+	if rdsConfig.PreferredBackupWindow != nil && *rdsConfig.PreferredBackupWindow != *foundConfig.PreferredBackupWindow {
+		mi.PreferredBackupWindow = rdsConfig.PreferredBackupWindow
+		updateFound = true
+	}
+	if rdsConfig.PreferredMaintenanceWindow != nil && *rdsConfig.PreferredMaintenanceWindow != *foundConfig.PreferredMaintenanceWindow {
+		mi.PreferredMaintenanceWindow = rdsConfig.PreferredMaintenanceWindow
+		updateFound = true
+	}
 	if !updateFound || !verifyPendingModification(mi, foundConfig.PendingModifiedValues) {
 		return nil
 	}

--- a/pkg/providers/aws/provider_postgres_test.go
+++ b/pkg/providers/aws/provider_postgres_test.go
@@ -29,6 +29,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const (
+	testPreferredBackupWindow      = "02:40-03:10"
+	testPreferredMaintenanceWindow = "mon:00:29-mon:00:59"
+)
+
 type mockRdsClient struct {
 	rdsiface.RDSAPI
 	wantErrList   bool
@@ -192,10 +197,12 @@ func buildDbInstanceGroupPending() []*rds.DBInstance {
 func buildDbInstanceGroupAvailable() []*rds.DBInstance {
 	return []*rds.DBInstance{
 		{
-			DBInstanceIdentifier: aws.String("test-id"),
-			DBInstanceStatus:     aws.String("available"),
-			AvailabilityZone:     aws.String("test-availabilityZone"),
-			DeletionProtection:   aws.Bool(false),
+			DBInstanceIdentifier:       aws.String("test-id"),
+			DBInstanceStatus:           aws.String("available"),
+			AvailabilityZone:           aws.String("test-availabilityZone"),
+			PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
+			PreferredBackupWindow:      aws.String(testPreferredBackupWindow),
+			DeletionProtection:         aws.Bool(false),
 		},
 	}
 }
@@ -214,20 +221,22 @@ func buildDbInstanceDeletionProtection() []*rds.DBInstance {
 func buildAvailableDBInstance(testID string) []*rds.DBInstance {
 	return []*rds.DBInstance{
 		{
-			DBInstanceIdentifier:  aws.String(testID),
-			DBInstanceStatus:      aws.String("available"),
-			AvailabilityZone:      aws.String("test-availabilityZone"),
-			DBInstanceArn:         aws.String("arn-test"),
-			DeletionProtection:    aws.Bool(defaultAwsPostgresDeletionProtection),
-			MasterUsername:        aws.String(defaultAwsPostgresUser),
-			DBName:                aws.String(defaultAwsPostgresDatabase),
-			BackupRetentionPeriod: aws.Int64(defaultAwsBackupRetentionPeriod),
-			DBInstanceClass:       aws.String(defaultAwsDBInstanceClass),
-			PubliclyAccessible:    aws.Bool(defaultAwsPubliclyAccessible),
-			AllocatedStorage:      aws.Int64(defaultAwsAllocatedStorage),
-			EngineVersion:         aws.String(defaultAwsEngineVersion),
-			Engine:                aws.String(defaultAwsEngine),
-			MultiAZ:               aws.Bool(true),
+			DBInstanceIdentifier:       aws.String(testID),
+			DBInstanceStatus:           aws.String("available"),
+			AvailabilityZone:           aws.String("test-availabilityZone"),
+			DBInstanceArn:              aws.String("arn-test"),
+			DeletionProtection:         aws.Bool(defaultAwsPostgresDeletionProtection),
+			MasterUsername:             aws.String(defaultAwsPostgresUser),
+			DBName:                     aws.String(defaultAwsPostgresDatabase),
+			BackupRetentionPeriod:      aws.Int64(defaultAwsBackupRetentionPeriod),
+			DBInstanceClass:            aws.String(defaultAwsDBInstanceClass),
+			PubliclyAccessible:         aws.Bool(defaultAwsPubliclyAccessible),
+			AllocatedStorage:           aws.Int64(defaultAwsAllocatedStorage),
+			EngineVersion:              aws.String(defaultAwsEngineVersion),
+			Engine:                     aws.String(defaultAwsEngine),
+			PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
+			PreferredBackupWindow:      aws.String(testPreferredBackupWindow),
+			MultiAZ:                    aws.Bool(true),
 			Endpoint: &rds.Endpoint{
 				Address:      aws.String("blob"),
 				HostedZoneId: aws.String("blog"),
@@ -248,63 +257,71 @@ func buildPendingDBInstance(testID string) []*rds.DBInstance {
 
 func buildAvailableCreateInput(testID string) *rds.CreateDBInstanceInput {
 	return &rds.CreateDBInstanceInput{
-		DBInstanceIdentifier:  aws.String(testID),
-		DeletionProtection:    aws.Bool(defaultAwsPostgresDeletionProtection),
-		Port:                  aws.Int64(defaultAwsPostgresPort),
-		BackupRetentionPeriod: aws.Int64(defaultAwsBackupRetentionPeriod),
-		DBInstanceClass:       aws.String(defaultAwsDBInstanceClass),
-		PubliclyAccessible:    aws.Bool(defaultAwsPubliclyAccessible),
-		AllocatedStorage:      aws.Int64(defaultAwsAllocatedStorage),
-		EngineVersion:         aws.String(defaultAwsEngineVersion),
-		MultiAZ:               aws.Bool(true),
+		DBInstanceIdentifier:       aws.String(testID),
+		DeletionProtection:         aws.Bool(defaultAwsPostgresDeletionProtection),
+		Port:                       aws.Int64(defaultAwsPostgresPort),
+		BackupRetentionPeriod:      aws.Int64(defaultAwsBackupRetentionPeriod),
+		DBInstanceClass:            aws.String(defaultAwsDBInstanceClass),
+		PubliclyAccessible:         aws.Bool(defaultAwsPubliclyAccessible),
+		AllocatedStorage:           aws.Int64(defaultAwsAllocatedStorage),
+		EngineVersion:              aws.String(defaultAwsEngineVersion),
+		PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
+		PreferredBackupWindow:      aws.String(testPreferredBackupWindow),
+		MultiAZ:                    aws.Bool(true),
 	}
 }
 
 func buildRequiresModificationsCreateInput(testID string) *rds.CreateDBInstanceInput {
 	return &rds.CreateDBInstanceInput{
-		DBInstanceIdentifier:  aws.String(testID),
-		DeletionProtection:    aws.Bool(defaultAwsPostgresDeletionProtection),
-		Port:                  aws.Int64(123),
-		BackupRetentionPeriod: aws.Int64(defaultAwsBackupRetentionPeriod),
-		DBInstanceClass:       aws.String(defaultAwsDBInstanceClass),
-		PubliclyAccessible:    aws.Bool(defaultAwsPubliclyAccessible),
-		AllocatedStorage:      aws.Int64(defaultAwsAllocatedStorage),
-		EngineVersion:         aws.String(defaultAwsEngineVersion),
-		MultiAZ:               aws.Bool(true),
+		DBInstanceIdentifier:       aws.String(testID),
+		DeletionProtection:         aws.Bool(defaultAwsPostgresDeletionProtection),
+		Port:                       aws.Int64(123),
+		BackupRetentionPeriod:      aws.Int64(defaultAwsBackupRetentionPeriod),
+		DBInstanceClass:            aws.String(defaultAwsDBInstanceClass),
+		PubliclyAccessible:         aws.Bool(defaultAwsPubliclyAccessible),
+		AllocatedStorage:           aws.Int64(defaultAwsAllocatedStorage),
+		EngineVersion:              aws.String(defaultAwsEngineVersion),
+		PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
+		PreferredBackupWindow:      aws.String(testPreferredBackupWindow),
+		MultiAZ:                    aws.Bool(true),
 	}
 }
 
 func buildNewRequiresModificationsCreateInput(testID string) *rds.CreateDBInstanceInput {
 	return &rds.CreateDBInstanceInput{
-		DBInstanceIdentifier:  aws.String(testID),
-		DeletionProtection:    aws.Bool(defaultAwsPostgresDeletionProtection),
-		Port:                  aws.Int64(123),
-		BackupRetentionPeriod: aws.Int64(123),
-		DBInstanceClass:       aws.String(defaultAwsDBInstanceClass),
-		PubliclyAccessible:    aws.Bool(defaultAwsPubliclyAccessible),
-		AllocatedStorage:      aws.Int64(defaultAwsAllocatedStorage),
-		EngineVersion:         aws.String(defaultAwsEngineVersion),
-		MultiAZ:               aws.Bool(true),
+		DBInstanceIdentifier:       aws.String(testID),
+		DeletionProtection:         aws.Bool(defaultAwsPostgresDeletionProtection),
+		Port:                       aws.Int64(123),
+		BackupRetentionPeriod:      aws.Int64(123),
+		DBInstanceClass:            aws.String(defaultAwsDBInstanceClass),
+		PubliclyAccessible:         aws.Bool(defaultAwsPubliclyAccessible),
+		AllocatedStorage:           aws.Int64(defaultAwsAllocatedStorage),
+		EngineVersion:              aws.String(defaultAwsEngineVersion),
+		PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
+		PreferredBackupWindow:      aws.String(testPreferredBackupWindow),
+		MultiAZ:                    aws.Bool(true),
 	}
 }
 
 func buildPendingModifiedDBInstance(testID string) []*rds.DBInstance {
 	return []*rds.DBInstance{
 		{
-			DBInstanceIdentifier:  aws.String(testID),
-			DBInstanceStatus:      aws.String("available"),
-			AvailabilityZone:      aws.String("test-availabilityZone"),
-			DBInstanceArn:         aws.String("arn-test"),
-			DeletionProtection:    aws.Bool(defaultAwsPostgresDeletionProtection),
-			MasterUsername:        aws.String(defaultAwsPostgresUser),
-			DBName:                aws.String(defaultAwsPostgresDatabase),
-			BackupRetentionPeriod: aws.Int64(defaultAwsBackupRetentionPeriod),
-			DBInstanceClass:       aws.String(defaultAwsDBInstanceClass),
-			PubliclyAccessible:    aws.Bool(defaultAwsPubliclyAccessible),
-			AllocatedStorage:      aws.Int64(defaultAwsAllocatedStorage),
-			EngineVersion:         aws.String(defaultAwsEngineVersion),
-			Engine:                aws.String(defaultAwsEngine),
-			MultiAZ:               aws.Bool(true),
+			DBInstanceIdentifier:       aws.String(testID),
+			DBInstanceStatus:           aws.String("available"),
+			AvailabilityZone:           aws.String("test-availabilityZone"),
+			DBInstanceArn:              aws.String("arn-test"),
+			DeletionProtection:         aws.Bool(defaultAwsPostgresDeletionProtection),
+			MasterUsername:             aws.String(defaultAwsPostgresUser),
+			DBName:                     aws.String(defaultAwsPostgresDatabase),
+			BackupRetentionPeriod:      aws.Int64(defaultAwsBackupRetentionPeriod),
+			DBInstanceClass:            aws.String(defaultAwsDBInstanceClass),
+			PubliclyAccessible:         aws.Bool(defaultAwsPubliclyAccessible),
+			AllocatedStorage:           aws.Int64(defaultAwsAllocatedStorage),
+			EngineVersion:              aws.String(defaultAwsEngineVersion),
+			Engine:                     aws.String(defaultAwsEngine),
+			PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
+			PreferredBackupWindow:      aws.String(testPreferredBackupWindow),
+			MultiAZ:                    aws.Bool(true),
 			Endpoint: &rds.Endpoint{
 				Address:      aws.String("blob"),
 				HostedZoneId: aws.String("blog"),


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/INTLY-7205

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make cluster/seed/managed/redis`
- Run `make run`
- Ensure redis is installed correctly, note the maintenance and backup window using `aws elasticache describe-cache-clusters | grep "SnapshotWindow\|PreferredMaintenanceWindow"`
- Update the cloud-resources-aws-strategies config map in the cloud-resources-operator namespace
- Ensure the `SnapshotWindow` and `PreferredMaintenanceWindow` in the update differs from the current windows for the instance 

```
data:
  blobstorage: >
    {"development": { "region": "eu-west-1", "createStrategy": {},
    "deleteStrategy": {} }}
  postgres: >
    {"development": { "region": "eu-west-1", "createStrategy":
    {}, "deleteStrategy": {} }}
  redis: >
    {"development": { "region": "eu-west-1", "createStrategy": {"SnapshotWindow":"21:40-23:10",
    "PreferredMaintenanceWindow":"mon:00:00-mon:04:00"}, "deleteStrategy": {} }} 
```

- Ensure the operator reconciles on this config map (No debug log saying config map not found)
- Ensure the Backup and Maintenance window is updated to match the new values
