### PR TITLE
INTLY-7205 added logic to allow updates to snapshot and maintenance windows for redis

### DIFF
--- a/pkg/providers/aws/provider_postgres_test.go
+++ b/pkg/providers/aws/provider_postgres_test.go
@@ -30,9 +30,10 @@ import (
 )
 
 const (
-	testPreferredBackupWindow = "02:40-03:10"
+	testPreferredBackupWindow      = "02:40-03:10"
 	testPreferredMaintenanceWindow = "mon:00:29-mon:00:59"
 )
+
 type mockRdsClient struct {
 	rdsiface.RDSAPI
 	wantErrList   bool
@@ -196,12 +197,12 @@ func buildDbInstanceGroupPending() []*rds.DBInstance {
 func buildDbInstanceGroupAvailable() []*rds.DBInstance {
 	return []*rds.DBInstance{
 		{
-			DBInstanceIdentifier: aws.String("test-id"),
-			DBInstanceStatus:     aws.String("available"),
-			AvailabilityZone:     aws.String("test-availabilityZone"),
+			DBInstanceIdentifier:       aws.String("test-id"),
+			DBInstanceStatus:           aws.String("available"),
+			AvailabilityZone:           aws.String("test-availabilityZone"),
 			PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
-			PreferredBackupWindow: aws.String(testPreferredBackupWindow),
-			DeletionProtection:   aws.Bool(false),
+			PreferredBackupWindow:      aws.String(testPreferredBackupWindow),
+			DeletionProtection:         aws.Bool(false),
 		},
 	}
 }
@@ -220,22 +221,22 @@ func buildDbInstanceDeletionProtection() []*rds.DBInstance {
 func buildAvailableDBInstance(testID string) []*rds.DBInstance {
 	return []*rds.DBInstance{
 		{
-			DBInstanceIdentifier:  aws.String(testID),
-			DBInstanceStatus:      aws.String("available"),
-			AvailabilityZone:      aws.String("test-availabilityZone"),
-			DBInstanceArn:         aws.String("arn-test"),
-			DeletionProtection:    aws.Bool(defaultAwsPostgresDeletionProtection),
-			MasterUsername:        aws.String(defaultAwsPostgresUser),
-			DBName:                aws.String(defaultAwsPostgresDatabase),
-			BackupRetentionPeriod: aws.Int64(defaultAwsBackupRetentionPeriod),
-			DBInstanceClass:       aws.String(defaultAwsDBInstanceClass),
-			PubliclyAccessible:    aws.Bool(defaultAwsPubliclyAccessible),
-			AllocatedStorage:      aws.Int64(defaultAwsAllocatedStorage),
-			EngineVersion:         aws.String(defaultAwsEngineVersion),
-			Engine:                aws.String(defaultAwsEngine),
+			DBInstanceIdentifier:       aws.String(testID),
+			DBInstanceStatus:           aws.String("available"),
+			AvailabilityZone:           aws.String("test-availabilityZone"),
+			DBInstanceArn:              aws.String("arn-test"),
+			DeletionProtection:         aws.Bool(defaultAwsPostgresDeletionProtection),
+			MasterUsername:             aws.String(defaultAwsPostgresUser),
+			DBName:                     aws.String(defaultAwsPostgresDatabase),
+			BackupRetentionPeriod:      aws.Int64(defaultAwsBackupRetentionPeriod),
+			DBInstanceClass:            aws.String(defaultAwsDBInstanceClass),
+			PubliclyAccessible:         aws.Bool(defaultAwsPubliclyAccessible),
+			AllocatedStorage:           aws.Int64(defaultAwsAllocatedStorage),
+			EngineVersion:              aws.String(defaultAwsEngineVersion),
+			Engine:                     aws.String(defaultAwsEngine),
 			PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
-			PreferredBackupWindow: aws.String(testPreferredBackupWindow),
-			MultiAZ:               aws.Bool(true),
+			PreferredBackupWindow:      aws.String(testPreferredBackupWindow),
+			MultiAZ:                    aws.Bool(true),
 			Endpoint: &rds.Endpoint{
 				Address:      aws.String("blob"),
 				HostedZoneId: aws.String("blog"),
@@ -256,71 +257,71 @@ func buildPendingDBInstance(testID string) []*rds.DBInstance {
 
 func buildAvailableCreateInput(testID string) *rds.CreateDBInstanceInput {
 	return &rds.CreateDBInstanceInput{
-		DBInstanceIdentifier:  aws.String(testID),
-		DeletionProtection:    aws.Bool(defaultAwsPostgresDeletionProtection),
-		Port:                  aws.Int64(defaultAwsPostgresPort),
-		BackupRetentionPeriod: aws.Int64(defaultAwsBackupRetentionPeriod),
-		DBInstanceClass:       aws.String(defaultAwsDBInstanceClass),
-		PubliclyAccessible:    aws.Bool(defaultAwsPubliclyAccessible),
-		AllocatedStorage:      aws.Int64(defaultAwsAllocatedStorage),
-		EngineVersion:         aws.String(defaultAwsEngineVersion),
+		DBInstanceIdentifier:       aws.String(testID),
+		DeletionProtection:         aws.Bool(defaultAwsPostgresDeletionProtection),
+		Port:                       aws.Int64(defaultAwsPostgresPort),
+		BackupRetentionPeriod:      aws.Int64(defaultAwsBackupRetentionPeriod),
+		DBInstanceClass:            aws.String(defaultAwsDBInstanceClass),
+		PubliclyAccessible:         aws.Bool(defaultAwsPubliclyAccessible),
+		AllocatedStorage:           aws.Int64(defaultAwsAllocatedStorage),
+		EngineVersion:              aws.String(defaultAwsEngineVersion),
 		PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
-		PreferredBackupWindow: aws.String(testPreferredBackupWindow),
-		MultiAZ:               aws.Bool(true),
+		PreferredBackupWindow:      aws.String(testPreferredBackupWindow),
+		MultiAZ:                    aws.Bool(true),
 	}
 }
 
 func buildRequiresModificationsCreateInput(testID string) *rds.CreateDBInstanceInput {
 	return &rds.CreateDBInstanceInput{
-		DBInstanceIdentifier:  aws.String(testID),
-		DeletionProtection:    aws.Bool(defaultAwsPostgresDeletionProtection),
-		Port:                  aws.Int64(123),
-		BackupRetentionPeriod: aws.Int64(defaultAwsBackupRetentionPeriod),
-		DBInstanceClass:       aws.String(defaultAwsDBInstanceClass),
-		PubliclyAccessible:    aws.Bool(defaultAwsPubliclyAccessible),
-		AllocatedStorage:      aws.Int64(defaultAwsAllocatedStorage),
-		EngineVersion:         aws.String(defaultAwsEngineVersion),
+		DBInstanceIdentifier:       aws.String(testID),
+		DeletionProtection:         aws.Bool(defaultAwsPostgresDeletionProtection),
+		Port:                       aws.Int64(123),
+		BackupRetentionPeriod:      aws.Int64(defaultAwsBackupRetentionPeriod),
+		DBInstanceClass:            aws.String(defaultAwsDBInstanceClass),
+		PubliclyAccessible:         aws.Bool(defaultAwsPubliclyAccessible),
+		AllocatedStorage:           aws.Int64(defaultAwsAllocatedStorage),
+		EngineVersion:              aws.String(defaultAwsEngineVersion),
 		PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
-		PreferredBackupWindow: aws.String(testPreferredBackupWindow),
-		MultiAZ:               aws.Bool(true),
+		PreferredBackupWindow:      aws.String(testPreferredBackupWindow),
+		MultiAZ:                    aws.Bool(true),
 	}
 }
 
 func buildNewRequiresModificationsCreateInput(testID string) *rds.CreateDBInstanceInput {
 	return &rds.CreateDBInstanceInput{
-		DBInstanceIdentifier:  aws.String(testID),
-		DeletionProtection:    aws.Bool(defaultAwsPostgresDeletionProtection),
-		Port:                  aws.Int64(123),
-		BackupRetentionPeriod: aws.Int64(123),
-		DBInstanceClass:       aws.String(defaultAwsDBInstanceClass),
-		PubliclyAccessible:    aws.Bool(defaultAwsPubliclyAccessible),
-		AllocatedStorage:      aws.Int64(defaultAwsAllocatedStorage),
-		EngineVersion:         aws.String(defaultAwsEngineVersion),
+		DBInstanceIdentifier:       aws.String(testID),
+		DeletionProtection:         aws.Bool(defaultAwsPostgresDeletionProtection),
+		Port:                       aws.Int64(123),
+		BackupRetentionPeriod:      aws.Int64(123),
+		DBInstanceClass:            aws.String(defaultAwsDBInstanceClass),
+		PubliclyAccessible:         aws.Bool(defaultAwsPubliclyAccessible),
+		AllocatedStorage:           aws.Int64(defaultAwsAllocatedStorage),
+		EngineVersion:              aws.String(defaultAwsEngineVersion),
 		PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
-		PreferredBackupWindow: aws.String(testPreferredBackupWindow),
-		MultiAZ:               aws.Bool(true),
+		PreferredBackupWindow:      aws.String(testPreferredBackupWindow),
+		MultiAZ:                    aws.Bool(true),
 	}
 }
 
 func buildPendingModifiedDBInstance(testID string) []*rds.DBInstance {
 	return []*rds.DBInstance{
 		{
-			DBInstanceIdentifier:  aws.String(testID),
-			DBInstanceStatus:      aws.String("available"),
-			AvailabilityZone:      aws.String("test-availabilityZone"),
-			DBInstanceArn:         aws.String("arn-test"),
-			DeletionProtection:    aws.Bool(defaultAwsPostgresDeletionProtection),
-			MasterUsername:        aws.String(defaultAwsPostgresUser),
-			DBName:                aws.String(defaultAwsPostgresDatabase),
-			BackupRetentionPeriod: aws.Int64(defaultAwsBackupRetentionPeriod),
-			DBInstanceClass:       aws.String(defaultAwsDBInstanceClass),
-			PubliclyAccessible:    aws.Bool(defaultAwsPubliclyAccessible),
-			AllocatedStorage:      aws.Int64(defaultAwsAllocatedStorage),
-			EngineVersion:         aws.String(defaultAwsEngineVersion),
-			Engine:                aws.String(defaultAwsEngine),
+			DBInstanceIdentifier:       aws.String(testID),
+			DBInstanceStatus:           aws.String("available"),
+			AvailabilityZone:           aws.String("test-availabilityZone"),
+			DBInstanceArn:              aws.String("arn-test"),
+			DeletionProtection:         aws.Bool(defaultAwsPostgresDeletionProtection),
+			MasterUsername:             aws.String(defaultAwsPostgresUser),
+			DBName:                     aws.String(defaultAwsPostgresDatabase),
+			BackupRetentionPeriod:      aws.Int64(defaultAwsBackupRetentionPeriod),
+			DBInstanceClass:            aws.String(defaultAwsDBInstanceClass),
+			PubliclyAccessible:         aws.Bool(defaultAwsPubliclyAccessible),
+			AllocatedStorage:           aws.Int64(defaultAwsAllocatedStorage),
+			EngineVersion:              aws.String(defaultAwsEngineVersion),
+			Engine:                     aws.String(defaultAwsEngine),
 			PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
-			PreferredBackupWindow: aws.String(testPreferredBackupWindow),
-			MultiAZ:               aws.Bool(true),
+			PreferredBackupWindow:      aws.String(testPreferredBackupWindow),
+			MultiAZ:                    aws.Bool(true),
 			Endpoint: &rds.Endpoint{
 				Address:      aws.String("blob"),
 				HostedZoneId: aws.String("blog"),

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -187,16 +187,27 @@ func (p *RedisProvider) createElasticacheCluster(ctx context.Context, r *v1alpha
 		logrus.Infof("found instance %s current status %s", *foundCache.ReplicationGroupId, *foundCache.Status)
 		return nil, croType.StatusMessage(fmt.Sprintf("createReplicationGroup() in progress, current aws elasticache status is %s", *foundCache.Status)), nil
 	}
-
-	// check if found cluster and user strategy differs, and modify instance
 	logrus.Infof("found existing elasticache instance %s", *foundCache.ReplicationGroupId)
-	ec := buildElasticacheUpdateStrategy(elasticacheConfig, foundCache)
-	if ec == nil {
+
+	cacheClustersOutput, err := cacheSvc.DescribeCacheClusters(&elasticache.DescribeCacheClustersInput{})
+	if err != nil {
+		errMsg := "failed to describe clusters"
+		return nil, croType.StatusMessage(fmt.Sprintf(errMsg)), errorUtil.Wrapf(err, errMsg)
+	}
+	var replicationGroupClusters []elasticache.CacheCluster
+	for _, checkedCluster := range cacheClustersOutput.CacheClusters {
+		if *checkedCluster.ReplicationGroupId == *foundCache.ReplicationGroupId {
+			replicationGroupClusters = append(replicationGroupClusters, *checkedCluster)
+		}
+	}
+	//check if found cluster and user strategy differs, and modify instance
+	modifyInput := buildElasticacheUpdateStrategy(elasticacheConfig, foundCache, replicationGroupClusters)
+	if modifyInput == nil {
 		logrus.Infof("elasticache replication group %s is as expected", *foundCache.ReplicationGroupId)
 	}
-	if ec != nil {
-		logrus.Infof("%s differs from expected strategy, applying pending modifications :\n%s", *foundCache.ReplicationGroupId, ec)
-		if _, err := cacheSvc.ModifyReplicationGroup(ec); err != nil {
+	if modifyInput != nil {
+		logrus.Infof("%s differs from expected strategy, applying pending modifications :\n%s", *foundCache.ReplicationGroupId, modifyInput)
+		if _, err := cacheSvc.ModifyReplicationGroup(modifyInput); err != nil {
 			errMsg := "failed to modify elasticache cluster"
 			return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
 		}
@@ -456,22 +467,33 @@ func (p *RedisProvider) getElasticacheConfig(ctx context.Context, r *v1alpha1.Re
 }
 
 // checks found config vs user strategy for changes, if found returns a modify replication group
-func buildElasticacheUpdateStrategy(elasticacheConfig *elasticache.CreateReplicationGroupInput, foundConfig *elasticache.ReplicationGroup) *elasticache.ModifyReplicationGroupInput {
+func buildElasticacheUpdateStrategy(elasticacheConfig *elasticache.CreateReplicationGroupInput, foundConfig *elasticache.ReplicationGroup, replicationGroupClusters []elasticache.CacheCluster) *elasticache.ModifyReplicationGroupInput {
 	logrus.Infof("verifying that %s configuration is as expected", *foundConfig.ReplicationGroupId)
 	updateFound := false
-	ec := &elasticache.ModifyReplicationGroupInput{}
-	ec.ReplicationGroupId = foundConfig.ReplicationGroupId
+	modifyInput := &elasticache.ModifyReplicationGroupInput{}
+	modifyInput.ReplicationGroupId = foundConfig.ReplicationGroupId
 
 	if *elasticacheConfig.CacheNodeType != *foundConfig.CacheNodeType {
-		ec.CacheNodeType = elasticacheConfig.CacheNodeType
+		modifyInput.CacheNodeType = elasticacheConfig.CacheNodeType
 		updateFound = true
 	}
 	if *elasticacheConfig.SnapshotRetentionLimit != *foundConfig.SnapshotRetentionLimit {
-		ec.SnapshotRetentionLimit = elasticacheConfig.SnapshotRetentionLimit
+		modifyInput.SnapshotRetentionLimit = elasticacheConfig.SnapshotRetentionLimit
 		updateFound = true
 	}
+
+	for _, foundCacheCluster := range replicationGroupClusters {
+		if elasticacheConfig.PreferredMaintenanceWindow != nil && *elasticacheConfig.PreferredMaintenanceWindow != *foundCacheCluster.PreferredMaintenanceWindow {
+			modifyInput.PreferredMaintenanceWindow = elasticacheConfig.PreferredMaintenanceWindow
+			updateFound = true
+		}
+		if elasticacheConfig.SnapshotWindow != nil && *elasticacheConfig.SnapshotWindow != *foundCacheCluster.SnapshotWindow {
+			modifyInput.SnapshotWindow = elasticacheConfig.SnapshotWindow
+			updateFound = true
+		}
+	}
 	if updateFound {
-		return ec
+		return modifyInput
 	}
 	return nil
 }

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -99,7 +99,7 @@ func (m *mockElasticacheClient) DescribeSnapshots(*elasticache.DescribeSnapshots
 	return &elasticache.DescribeSnapshotsOutput{}, nil
 }
 
-// mock elasticache DescribeReplicationGroups output
+// mock elasticache DescribeCacheClustersGroups output
 func (m *mockElasticacheClient) DescribeCacheClusters(*elasticache.DescribeCacheClustersInput) (*elasticache.DescribeCacheClustersOutput, error) {
 	if m.wantEmpty {
 		return &elasticache.DescribeCacheClustersOutput{}, nil
@@ -557,6 +557,79 @@ func TestAWSRedisProvider_TagElasticache(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("TagElasticache() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_buildElasticacheUpdateStrategy(t *testing.T) {
+	type args struct {
+		elasticacheConfig        *elasticache.CreateReplicationGroupInput
+		foundConfig              *elasticache.ReplicationGroup
+		replicationGroupClusters []elasticache.CacheCluster
+	}
+	tests := []struct {
+		name string
+		args args
+		want *elasticache.ModifyReplicationGroupInput
+	}{
+		{
+			name: "test no modification required",
+			args: args{
+				elasticacheConfig: &elasticache.CreateReplicationGroupInput{
+					CacheNodeType:              aws.String("test"),
+					SnapshotRetentionLimit:     aws.Int64(30),
+					PreferredMaintenanceWindow: aws.String("test"),
+					SnapshotWindow:             aws.String("test"),
+				},
+				foundConfig: &elasticache.ReplicationGroup{
+					ReplicationGroupId:     aws.String("test-id"),
+					CacheNodeType:          aws.String("test"),
+					SnapshotRetentionLimit: aws.Int64(30),
+				},
+				replicationGroupClusters: []elasticache.CacheCluster{
+					{
+						PreferredMaintenanceWindow: aws.String("test"),
+						SnapshotWindow:             aws.String("test"),
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "test when modification is required",
+			args: args{
+				elasticacheConfig: &elasticache.CreateReplicationGroupInput{
+					CacheNodeType:              aws.String("newValue"),
+					SnapshotRetentionLimit:     aws.Int64(50),
+					PreferredMaintenanceWindow: aws.String("newValue"),
+					SnapshotWindow:             aws.String("newValue"),
+				},
+				foundConfig: &elasticache.ReplicationGroup{
+					CacheNodeType:          aws.String("test"),
+					SnapshotRetentionLimit: aws.Int64(30),
+					ReplicationGroupId:     aws.String("test-id"),
+				},
+				replicationGroupClusters: []elasticache.CacheCluster{
+					{
+						PreferredMaintenanceWindow: aws.String("test"),
+						SnapshotWindow:             aws.String("test"),
+					},
+				},
+			},
+			want: &elasticache.ModifyReplicationGroupInput{
+				CacheNodeType:              aws.String("newValue"),
+				SnapshotRetentionLimit:     aws.Int64(50),
+				PreferredMaintenanceWindow: aws.String("newValue"),
+				SnapshotWindow:             aws.String("newValue"),
+				ReplicationGroupId:         aws.String("test-id"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildElasticacheUpdateStrategy(tt.args.elasticacheConfig, tt.args.foundConfig, tt.args.replicationGroupClusters); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildElasticacheUpdateStrategy() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -108,6 +108,7 @@ func (m *mockElasticacheClient) DescribeCacheClusters(*elasticache.DescribeCache
 		CacheClusters: []*elasticache.CacheCluster{
 			{
 				CacheClusterStatus: aws.String("available"),
+				ReplicationGroupId: aws.String("test-id"),
 			},
 		},
 	}, nil


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/INTLY-7205

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make cluster/seed/managed/redis`
- Run `make run`
- Ensure redis is installed correctly, note the maintenance and backup window using `aws elasticache describe-cache-clusters | grep "SnapshotWindow\|PreferredMaintenanceWindow"`
- Update the cloud-resources-aws-strategies config map in the cloud-resources-operator namespace
- Ensure the `SnapshotWindow` and `PreferredMaintenanceWindow` in the update differs from the current windows for the instance 

```
data:
  blobstorage: >
    {"development": { "region": "eu-west-1", "createStrategy": {},
    "deleteStrategy": {} }}
  postgres: >
    {"development": { "region": "eu-west-1", "createStrategy":
    {}, "deleteStrategy": {} }}
  redis: >
    {"development": { "region": "eu-west-1", "createStrategy": {"SnapshotWindow":"21:40-23:10",
    "PreferredMaintenanceWindow":"mon:00:00-mon:04:00"}, "deleteStrategy": {} }} 
```

- Ensure the operator reconciles on this config map (No debug log saying config map not found)
- Ensure the Backup and Maintenance window is updated to match the new values
