### PR TITLE
add phase status metric to aws resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ build:
 run:
 	RECTIME=30 $(OPERATOR_SDK) up local --namespace=""
 
+.PHONY: run/local
+run/local:
+	RECTIME=30 $(OPERATOR_SDK) up local --namespace="$(NAMESPACE)"
+
 .PHONY: setup/service_account
 setup/service_account:
 	@oc replace --force -f deploy/role.yaml -n $(NAMESPACE)

--- a/pkg/controller/postgressnapshot/postgressnapshot_controller.go
+++ b/pkg/controller/postgressnapshot/postgressnapshot_controller.go
@@ -30,6 +30,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+const (
+	postgresProviderName = "aws-rds"
+)
+
 // Add creates a new PostgresSnapshot Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
@@ -189,6 +193,10 @@ func (r *ReconcilePostgresSnapshot) createSnapshot(ctx context.Context, rdsSvc r
 
 	// update cr with snapshot name
 	snapshot.Status.SnapshotID = snapshotName
+
+	// set info metric
+	defer r.exposePostgresSnapshotMetrics(ctx, snapshot)
+
 	if err = r.client.Status().Update(ctx, snapshot); err != nil {
 		errMsg := fmt.Sprintf("failed to update instance %s in namespace %s", snapshot.Name, snapshot.Namespace)
 		return croType.PhaseFailed, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
@@ -236,4 +244,52 @@ func (r *ReconcilePostgresSnapshot) createSnapshot(ctx context.Context, rdsSvc r
 	msg := fmt.Sprintf("current snapshot status : %s", *foundSnapshot.Status)
 	r.logger.Info(msg)
 	return croType.PhaseInProgress, croType.StatusMessage(msg), nil
+}
+
+func buildPostgresSnapshotInfoMetricLabels(cr *integreatlyv1alpha1.PostgresSnapshot, clusterID, bucketName string) map[string]string {
+	labels := buildPostgresSnapshotGenericMetricLabels(cr, clusterID, bucketName)
+	if len(string(cr.Status.Phase)) != 0 {
+		labels["statusPhase"] = string(cr.Status.Phase)
+		return labels
+	}
+	// If the status hasn't reconciled using cr.Status.Phase need to return something
+	labels["statusPhase"] = "nil"
+	return labels
+}
+
+func buildPostgresSnapshotGenericMetricLabels(cr *integreatlyv1alpha1.PostgresSnapshot, clusterID, snapshotName string) map[string]string {
+	labels := map[string]string{}
+	labels["clusterID"] = clusterID
+	labels["resourceID"] = cr.Name
+	labels["namespace"] = cr.Namespace
+	labels["instanceID"] = snapshotName
+	labels["productName"] = cr.Labels["productName"]
+	labels["strategy"] = postgresProviderName
+	return labels
+}
+
+func (r *ReconcilePostgresSnapshot) exposePostgresSnapshotMetrics(ctx context.Context, cr *integreatlyv1alpha1.PostgresSnapshot) {
+	// build instance name
+	snapshotName := cr.Status.SnapshotID
+
+	// get Cluster Id
+	logrus.Info("setting postgres snapshot information metric")
+	clusterID, err := resources.GetClusterID(ctx, r.client)
+	if err != nil {
+		logrus.Errorf("failed to get cluster id while exposing information metric for %v", snapshotName)
+		return
+	}
+
+	// build metric labels
+	infoLabels := buildPostgresSnapshotInfoMetricLabels(cr, clusterID, snapshotName)
+
+	// set status gauge
+	resources.SetMetricCurrentTime(resources.DefaultPostgresSnapshotMetricName, infoLabels)
+
+	// set available metric
+	if len(string(cr.Status.Phase)) == 0 || cr.Status.Phase != croType.PhaseComplete {
+		resources.SetMetric(resources.DefaultPostgresSnapshotMetricName, infoLabels, 0)
+		return
+	}
+	resources.SetMetric(resources.DefaultPostgresSnapshotMetricName, infoLabels, 1)
 }

--- a/pkg/controller/postgressnapshot/postgressnapshot_controller.go
+++ b/pkg/controller/postgressnapshot/postgressnapshot_controller.go
@@ -275,12 +275,12 @@ func (r *ReconcilePostgresSnapshot) exposePostgresSnapshotMetrics(ctx context.Co
 	}
 
 	// build status metric labels
-	statusLables := buildPostgresSnapshotStatusMetricLabels(cr, clusterID, snapshotName)
+	statusLabels := buildPostgresSnapshotStatusMetricLabels(cr, clusterID, snapshotName)
 
 	// set available metric
 	if len(string(cr.Status.Phase)) == 0 || cr.Status.Phase != croType.PhaseComplete {
-		resources.SetMetric(resources.DefaultPostgresSnapshotStatusMetricName, statusLables, 0)
+		resources.SetMetric(resources.DefaultPostgresSnapshotStatusMetricName, statusLabels, 0)
 		return
 	}
-	resources.SetMetric(resources.DefaultPostgresSnapshotStatusMetricName, statusLables, 1)
+	resources.SetMetric(resources.DefaultPostgresSnapshotStatusMetricName, statusLabels, 1)
 }

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -782,13 +782,13 @@ func buildPostgresGenericMetricLabels(cr *v1alpha1.Postgres, clusterID, instance
 	return labels
 }
 
-func buildPostgresStatusMetricsLabels(cr *v1alpha1.Postgres, clusterID, cacheName string) map[string]string {
-	labels := buildPostgresGenericMetricLabels(cr, clusterID, cacheName)
+func buildPostgresStatusMetricsLabels(cr *v1alpha1.Postgres, clusterID, instanceName string) map[string]string {
+	labels := buildPostgresGenericMetricLabels(cr, clusterID, instanceName)
 	if len(string(cr.Status.Phase)) != 0 {
 		labels["statusPhase"] = string(cr.Status.Phase)
 		return labels
 	}
-	labels["statusPhase"] = fmt.Sprintf("%s is nil", cacheName)
+	labels["statusPhase"] = "nil"
 	return labels
 }
 
@@ -812,15 +812,15 @@ func (p *PostgresProvider) exposePostgresMetrics(ctx context.Context, cr *v1alph
 	// build available mertic labels
 	genericLabels := buildPostgresGenericMetricLabels(cr, clusterID, instanceName)
 
-	statusLables := buildPostgresStatusMetricsLabels(cr, clusterID, instanceName)
+	statusLabels := buildPostgresStatusMetricsLabels(cr, clusterID, instanceName)
 	// set status gauge
 	resources.SetMetricCurrentTime(resources.DefaultPostgresInfoMetricName, infoLabels)
 
 	// set the status phase metric
 	if len(string(cr.Status.Phase)) == 0 || cr.Status.Phase != croType.PhaseComplete {
-		resources.SetMetric(resources.DefaultPostgresStatusMetricName, statusLables, 0)
+		resources.SetMetric(resources.DefaultPostgresStatusMetricName, statusLabels, 0)
 	} else {
-		resources.SetMetric(resources.DefaultPostgresStatusMetricName, statusLables, 1)
+		resources.SetMetric(resources.DefaultPostgresStatusMetricName, statusLabels, 1)
 	}
 
 	// set available metric

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -768,8 +768,6 @@ func buildPostgresInfoMetricLabels(cr *v1alpha1.Postgres, instance *rds.DBInstan
 		labels["statusPhase"] = string(cr.Status.Phase)
 		return labels
 	}
-	labels["statusAWS"] = "nil"
-	labels["statusPhase"] = "nil"
 	return labels
 }
 
@@ -781,6 +779,8 @@ func buildPostgresGenericMetricLabels(cr *v1alpha1.Postgres, clusterID, instance
 	labels["instanceID"] = instanceName
 	labels["productName"] = cr.Labels["productName"]
 	labels["strategy"] = postgresProviderName
+	labels["statusAWS"] = ""
+	labels["statusPhase"] = ""
 	return labels
 }
 
@@ -802,14 +802,14 @@ func (p *PostgresProvider) exposePostgresMetrics(ctx context.Context, cr *v1alph
 	// build metric labels
 	infoLabels := buildPostgresInfoMetricLabels(cr, instance, clusterID, instanceName)
 	// build available mertic labels
-	//genericLabels := buildPostgresGenericMetricLabels(cr, clusterID, instanceName)
+	genericLabels := buildPostgresGenericMetricLabels(cr, clusterID, instanceName)
 
 	// set status gauge
 	resources.SetMetricCurrentTime(resources.DefaultPostgresInfoMetricName, infoLabels)
 
 	// set available metric
 	if len(string(cr.Status.Phase)) == 0 || cr.Status.Phase != croType.PhaseComplete {
-		resources.SetMetric(resources.DefaultPostgresAvailMetricName, infoLabels, 0)
+		resources.SetMetric(resources.DefaultPostgresAvailMetricName, genericLabels, 0)
 		return
 	}
 	resources.SetMetric(resources.DefaultPostgresAvailMetricName, infoLabels, 1)

--- a/pkg/providers/aws/provider_postgres_test.go
+++ b/pkg/providers/aws/provider_postgres_test.go
@@ -30,9 +30,10 @@ import (
 )
 
 const (
-	testPreferredBackupWindow = "02:40-03:10"
+	testPreferredBackupWindow      = "02:40-03:10"
 	testPreferredMaintenanceWindow = "mon:00:29-mon:00:59"
 )
+
 type mockRdsClient struct {
 	rdsiface.RDSAPI
 	wantErrList   bool
@@ -196,12 +197,12 @@ func buildDbInstanceGroupPending() []*rds.DBInstance {
 func buildDbInstanceGroupAvailable() []*rds.DBInstance {
 	return []*rds.DBInstance{
 		{
-			DBInstanceIdentifier: aws.String("test-id"),
-			DBInstanceStatus:     aws.String("available"),
-			AvailabilityZone:     aws.String("test-availabilityZone"),
+			DBInstanceIdentifier:       aws.String("test-id"),
+			DBInstanceStatus:           aws.String("available"),
+			AvailabilityZone:           aws.String("test-availabilityZone"),
 			PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
-			PreferredBackupWindow: aws.String(testPreferredBackupWindow),
-			DeletionProtection:   aws.Bool(false),
+			PreferredBackupWindow:      aws.String(testPreferredBackupWindow),
+			DeletionProtection:         aws.Bool(false),
 		},
 	}
 }
@@ -220,22 +221,22 @@ func buildDbInstanceDeletionProtection() []*rds.DBInstance {
 func buildAvailableDBInstance(testID string) []*rds.DBInstance {
 	return []*rds.DBInstance{
 		{
-			DBInstanceIdentifier:  aws.String(testID),
-			DBInstanceStatus:      aws.String("available"),
-			AvailabilityZone:      aws.String("test-availabilityZone"),
-			DBInstanceArn:         aws.String("arn-test"),
-			DeletionProtection:    aws.Bool(defaultAwsPostgresDeletionProtection),
-			MasterUsername:        aws.String(defaultAwsPostgresUser),
-			DBName:                aws.String(defaultAwsPostgresDatabase),
-			BackupRetentionPeriod: aws.Int64(defaultAwsBackupRetentionPeriod),
-			DBInstanceClass:       aws.String(defaultAwsDBInstanceClass),
-			PubliclyAccessible:    aws.Bool(defaultAwsPubliclyAccessible),
-			AllocatedStorage:      aws.Int64(defaultAwsAllocatedStorage),
-			EngineVersion:         aws.String(defaultAwsEngineVersion),
-			Engine:                aws.String(defaultAwsEngine),
+			DBInstanceIdentifier:       aws.String(testID),
+			DBInstanceStatus:           aws.String("available"),
+			AvailabilityZone:           aws.String("test-availabilityZone"),
+			DBInstanceArn:              aws.String("arn-test"),
+			DeletionProtection:         aws.Bool(defaultAwsPostgresDeletionProtection),
+			MasterUsername:             aws.String(defaultAwsPostgresUser),
+			DBName:                     aws.String(defaultAwsPostgresDatabase),
+			BackupRetentionPeriod:      aws.Int64(defaultAwsBackupRetentionPeriod),
+			DBInstanceClass:            aws.String(defaultAwsDBInstanceClass),
+			PubliclyAccessible:         aws.Bool(defaultAwsPubliclyAccessible),
+			AllocatedStorage:           aws.Int64(defaultAwsAllocatedStorage),
+			EngineVersion:              aws.String(defaultAwsEngineVersion),
+			Engine:                     aws.String(defaultAwsEngine),
 			PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
-			PreferredBackupWindow: aws.String(testPreferredBackupWindow),
-			MultiAZ:               aws.Bool(true),
+			PreferredBackupWindow:      aws.String(testPreferredBackupWindow),
+			MultiAZ:                    aws.Bool(true),
 			Endpoint: &rds.Endpoint{
 				Address:      aws.String("blob"),
 				HostedZoneId: aws.String("blog"),
@@ -256,71 +257,71 @@ func buildPendingDBInstance(testID string) []*rds.DBInstance {
 
 func buildAvailableCreateInput(testID string) *rds.CreateDBInstanceInput {
 	return &rds.CreateDBInstanceInput{
-		DBInstanceIdentifier:  aws.String(testID),
-		DeletionProtection:    aws.Bool(defaultAwsPostgresDeletionProtection),
-		Port:                  aws.Int64(defaultAwsPostgresPort),
-		BackupRetentionPeriod: aws.Int64(defaultAwsBackupRetentionPeriod),
-		DBInstanceClass:       aws.String(defaultAwsDBInstanceClass),
-		PubliclyAccessible:    aws.Bool(defaultAwsPubliclyAccessible),
-		AllocatedStorage:      aws.Int64(defaultAwsAllocatedStorage),
-		EngineVersion:         aws.String(defaultAwsEngineVersion),
+		DBInstanceIdentifier:       aws.String(testID),
+		DeletionProtection:         aws.Bool(defaultAwsPostgresDeletionProtection),
+		Port:                       aws.Int64(defaultAwsPostgresPort),
+		BackupRetentionPeriod:      aws.Int64(defaultAwsBackupRetentionPeriod),
+		DBInstanceClass:            aws.String(defaultAwsDBInstanceClass),
+		PubliclyAccessible:         aws.Bool(defaultAwsPubliclyAccessible),
+		AllocatedStorage:           aws.Int64(defaultAwsAllocatedStorage),
+		EngineVersion:              aws.String(defaultAwsEngineVersion),
 		PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
-		PreferredBackupWindow: aws.String(testPreferredBackupWindow),
-		MultiAZ:               aws.Bool(true),
+		PreferredBackupWindow:      aws.String(testPreferredBackupWindow),
+		MultiAZ:                    aws.Bool(true),
 	}
 }
 
 func buildRequiresModificationsCreateInput(testID string) *rds.CreateDBInstanceInput {
 	return &rds.CreateDBInstanceInput{
-		DBInstanceIdentifier:  aws.String(testID),
-		DeletionProtection:    aws.Bool(defaultAwsPostgresDeletionProtection),
-		Port:                  aws.Int64(123),
-		BackupRetentionPeriod: aws.Int64(defaultAwsBackupRetentionPeriod),
-		DBInstanceClass:       aws.String(defaultAwsDBInstanceClass),
-		PubliclyAccessible:    aws.Bool(defaultAwsPubliclyAccessible),
-		AllocatedStorage:      aws.Int64(defaultAwsAllocatedStorage),
-		EngineVersion:         aws.String(defaultAwsEngineVersion),
+		DBInstanceIdentifier:       aws.String(testID),
+		DeletionProtection:         aws.Bool(defaultAwsPostgresDeletionProtection),
+		Port:                       aws.Int64(123),
+		BackupRetentionPeriod:      aws.Int64(defaultAwsBackupRetentionPeriod),
+		DBInstanceClass:            aws.String(defaultAwsDBInstanceClass),
+		PubliclyAccessible:         aws.Bool(defaultAwsPubliclyAccessible),
+		AllocatedStorage:           aws.Int64(defaultAwsAllocatedStorage),
+		EngineVersion:              aws.String(defaultAwsEngineVersion),
 		PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
-		PreferredBackupWindow: aws.String(testPreferredBackupWindow),
-		MultiAZ:               aws.Bool(true),
+		PreferredBackupWindow:      aws.String(testPreferredBackupWindow),
+		MultiAZ:                    aws.Bool(true),
 	}
 }
 
 func buildNewRequiresModificationsCreateInput(testID string) *rds.CreateDBInstanceInput {
 	return &rds.CreateDBInstanceInput{
-		DBInstanceIdentifier:  aws.String(testID),
-		DeletionProtection:    aws.Bool(defaultAwsPostgresDeletionProtection),
-		Port:                  aws.Int64(123),
-		BackupRetentionPeriod: aws.Int64(123),
-		DBInstanceClass:       aws.String(defaultAwsDBInstanceClass),
-		PubliclyAccessible:    aws.Bool(defaultAwsPubliclyAccessible),
-		AllocatedStorage:      aws.Int64(defaultAwsAllocatedStorage),
-		EngineVersion:         aws.String(defaultAwsEngineVersion),
+		DBInstanceIdentifier:       aws.String(testID),
+		DeletionProtection:         aws.Bool(defaultAwsPostgresDeletionProtection),
+		Port:                       aws.Int64(123),
+		BackupRetentionPeriod:      aws.Int64(123),
+		DBInstanceClass:            aws.String(defaultAwsDBInstanceClass),
+		PubliclyAccessible:         aws.Bool(defaultAwsPubliclyAccessible),
+		AllocatedStorage:           aws.Int64(defaultAwsAllocatedStorage),
+		EngineVersion:              aws.String(defaultAwsEngineVersion),
 		PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
-		PreferredBackupWindow: aws.String(testPreferredBackupWindow),
-		MultiAZ:               aws.Bool(true),
+		PreferredBackupWindow:      aws.String(testPreferredBackupWindow),
+		MultiAZ:                    aws.Bool(true),
 	}
 }
 
 func buildPendingModifiedDBInstance(testID string) []*rds.DBInstance {
 	return []*rds.DBInstance{
 		{
-			DBInstanceIdentifier:  aws.String(testID),
-			DBInstanceStatus:      aws.String("available"),
-			AvailabilityZone:      aws.String("test-availabilityZone"),
-			DBInstanceArn:         aws.String("arn-test"),
-			DeletionProtection:    aws.Bool(defaultAwsPostgresDeletionProtection),
-			MasterUsername:        aws.String(defaultAwsPostgresUser),
-			DBName:                aws.String(defaultAwsPostgresDatabase),
-			BackupRetentionPeriod: aws.Int64(defaultAwsBackupRetentionPeriod),
-			DBInstanceClass:       aws.String(defaultAwsDBInstanceClass),
-			PubliclyAccessible:    aws.Bool(defaultAwsPubliclyAccessible),
-			AllocatedStorage:      aws.Int64(defaultAwsAllocatedStorage),
-			EngineVersion:         aws.String(defaultAwsEngineVersion),
-			Engine:                aws.String(defaultAwsEngine),
+			DBInstanceIdentifier:       aws.String(testID),
+			DBInstanceStatus:           aws.String("available"),
+			AvailabilityZone:           aws.String("test-availabilityZone"),
+			DBInstanceArn:              aws.String("arn-test"),
+			DeletionProtection:         aws.Bool(defaultAwsPostgresDeletionProtection),
+			MasterUsername:             aws.String(defaultAwsPostgresUser),
+			DBName:                     aws.String(defaultAwsPostgresDatabase),
+			BackupRetentionPeriod:      aws.Int64(defaultAwsBackupRetentionPeriod),
+			DBInstanceClass:            aws.String(defaultAwsDBInstanceClass),
+			PubliclyAccessible:         aws.Bool(defaultAwsPubliclyAccessible),
+			AllocatedStorage:           aws.Int64(defaultAwsAllocatedStorage),
+			EngineVersion:              aws.String(defaultAwsEngineVersion),
+			Engine:                     aws.String(defaultAwsEngine),
 			PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
-			PreferredBackupWindow: aws.String(testPreferredBackupWindow),
-			MultiAZ:               aws.Bool(true),
+			PreferredBackupWindow:      aws.String(testPreferredBackupWindow),
+			MultiAZ:                    aws.Bool(true),
 			Endpoint: &rds.Endpoint{
 				Address:      aws.String("blob"),
 				HostedZoneId: aws.String("blog"),

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -624,13 +624,13 @@ func buildRedisGenericMetricLabels(r *v1alpha1.Redis, clusterID, cacheName strin
 }
 
 // adds extra information to labels around resource
-func buildRedisInfoMetricLables(r *v1alpha1.Redis, group *elasticache.ReplicationGroup, clusterID, cacheName string) map[string]string {
+func buildRedisInfoMetricLabels(r *v1alpha1.Redis, group *elasticache.ReplicationGroup, clusterID, cacheName string) map[string]string {
 	labels := buildRedisGenericMetricLabels(r, clusterID, cacheName)
 	if group != nil {
 		labels["status"] = *group.Status
 		return labels
 	}
-	labels["status"] = fmt.Sprintf("%s is nil", cacheName)
+	labels["status"] = "nil"
 	return labels
 }
 
@@ -640,7 +640,7 @@ func buildRedisStatusMetricsLabels(r *v1alpha1.Redis, clusterID, cacheName strin
 		labels["statusPhase"] = string(r.Status.Phase)
 		return labels
 	}
-	labels["statusPhase"] = fmt.Sprintf("%s is nil", cacheName)
+	labels["statusPhase"] = "nil"
 	return labels
 }
 
@@ -660,21 +660,21 @@ func (p *RedisProvider) exposeRedisMetrics(ctx context.Context, cr *v1alpha1.Red
 	}
 
 	// build metric labels
-	infoLabels := buildRedisInfoMetricLables(cr, instance, clusterID, cacheName)
+	infoLabels := buildRedisInfoMetricLabels(cr, instance, clusterID, cacheName)
 
 	// build generic metrics
 	genericLabels := buildRedisGenericMetricLabels(cr, clusterID, cacheName)
 
-	statusLables := buildRedisStatusMetricsLabels(cr, clusterID, cacheName)
+	statusLabels := buildRedisStatusMetricsLabels(cr, clusterID, cacheName)
 
 	// set status gauge
 	resources.SetMetricCurrentTime(resources.DefaultRedisInfoMetricName, infoLabels)
 
 	// set the status phase metric
 	if len(string(cr.Status.Phase)) == 0 || cr.Status.Phase != croType.PhaseComplete {
-		resources.SetMetric(resources.DefaultRedisStatusMetricName, statusLables, 0)
+		resources.SetMetric(resources.DefaultRedisStatusMetricName, statusLabels, 0)
 	} else {
-		resources.SetMetric(resources.DefaultRedisStatusMetricName, statusLables, 1)
+		resources.SetMetric(resources.DefaultRedisStatusMetricName, statusLabels, 1)
 	}
 
 	// set available metric

--- a/pkg/resources/custom_metrics.go
+++ b/pkg/resources/custom_metrics.go
@@ -19,19 +19,19 @@ import (
 
 const (
 	sleepytime                              = 3600
-	DefaultPostgresMaintenanceMetricName    = "redhat_rhmi_postgres_service_maintenance"
-	DefaultPostgresInfoMetricName           = "redhat_rhmi_postgres_info"
-	DefaultPostgresAvailMetricName          = "redhat_rhmi_postgres_available"
-	DefaultPostgresConnectionMetricName     = "redhat_rhmi_postgres_connection"
-	DefaultPostgresStatusMetricName         = "redhat_rhmi_postgres_status_phase"
-	DefaultPostgresSnapshotStatusMetricName = "redhat_rhmi_postgres_snapshot_status_phase"
-	DefaultRedisMaintenanceMetricName       = "redhat_rhmi_redis_service_maintenance"
-	DefaultRedisInfoMetricName              = "redhat_rhmi_redis_info"
-	DefaultRedisAvailMetricName             = "redhat_rhmi_redis_available"
-	DefaultRedisConnectionMetricName        = "redhat_rhmi_redis_connection"
-	DefaultRedisStatusMetricName            = "redhat_rhmi_redis_status_phase"
-	DefaultRedisSnapshotStatusMetricName    = "redhat_rhmi_redis_snapshot_status_phase"
-	DefaultBlobStorageStatusMetricName      = "redhat_rhmi_blobstorage_status_phase"
+	DefaultPostgresMaintenanceMetricName    = "cro_postgres_service_maintenance"
+	DefaultPostgresInfoMetricName           = "cro_postgres_info"
+	DefaultPostgresAvailMetricName          = "cro_postgres_available"
+	DefaultPostgresConnectionMetricName     = "cro_postgres_connection"
+	DefaultPostgresStatusMetricName         = "cro_postgres_status_phase"
+	DefaultPostgresSnapshotStatusMetricName = "cro_postgres_snapshot_status_phase"
+	DefaultRedisMaintenanceMetricName       = "cro_redis_service_maintenance"
+	DefaultRedisInfoMetricName              = "cro_redis_info"
+	DefaultRedisAvailMetricName             = "cro_redis_available"
+	DefaultRedisConnectionMetricName        = "cro_redis_connection"
+	DefaultRedisStatusMetricName            = "cro_redis_status_phase"
+	DefaultRedisSnapshotStatusMetricName    = "cro_redis_snapshot_status_phase"
+	DefaultBlobStorageStatusMetricName      = "cro_blobstorage_status_phase"
 )
 
 var (

--- a/pkg/resources/custom_metrics.go
+++ b/pkg/resources/custom_metrics.go
@@ -18,18 +18,20 @@ import (
 )
 
 const (
-	sleepytime                           = 3600
-	DefaultPostgresMaintenanceMetricName = "cro_postgres_service_maintenance"
-	DefaultPostgresInfoMetricName        = "cro_postgres_info"
-	DefaultPostgresAvailMetricName       = "cro_postgres_available"
-	DefaultPostgresConnectionMetricName  = "cro_postgres_connection"
-	DefaultPostgresSnapshotMetricName    = "cro_postgres_snapshot_info"
-	DefaultRedisMaintenanceMetricName    = "cro_redis_service_maintenance"
-	DefaultRedisInfoMetricName           = "cro_redis_info"
-	DefaultRedisAvailMetricName          = "cro_redis_available"
-	DefaultRedisConnectionMetricName     = "cro_redis_connection"
-	DefaultRedisSnapshotMetricName       = "cro_redis_snapshot_info"
-	DefaultBlobStorageInfoMetricName     = "cro_blobstorage_info"
+	sleepytime                              = 3600
+	DefaultPostgresMaintenanceMetricName    = "redhat_rhmi_postgres_service_maintenance"
+	DefaultPostgresInfoMetricName           = "redhat_rhmi_postgres_info"
+	DefaultPostgresAvailMetricName          = "redhat_rhmi_postgres_available"
+	DefaultPostgresConnectionMetricName     = "redhat_rhmi_postgres_connection"
+	DefaultPostgresStatusMetricName         = "redhat_rhmi_postgres_status_phase"
+	DefaultPostgresSnapshotStatusMetricName = "redhat_rhmi_postgres_snapshot_status_phase"
+	DefaultRedisMaintenanceMetricName       = "redhat_rhmi_redis_service_maintenance"
+	DefaultRedisInfoMetricName              = "redhat_rhmi_redis_info"
+	DefaultRedisAvailMetricName             = "redhat_rhmi_redis_available"
+	DefaultRedisConnectionMetricName        = "redhat_rhmi_redis_connection"
+	DefaultRedisStatusMetricName            = "redhat_rhmi_redis_status_phase"
+	DefaultRedisSnapshotStatusMetricName    = "redhat_rhmi_redis_snapshot_status_phase"
+	DefaultBlobStorageStatusMetricName      = "redhat_rhmi_blobstorage_status_phase"
 )
 
 var (

--- a/pkg/resources/custom_metrics.go
+++ b/pkg/resources/custom_metrics.go
@@ -23,10 +23,13 @@ const (
 	DefaultPostgresInfoMetricName        = "cro_postgres_info"
 	DefaultPostgresAvailMetricName       = "cro_postgres_available"
 	DefaultPostgresConnectionMetricName  = "cro_postgres_connection"
+	DefaultPostgresSnapshotMetricName    = "cro_postgres_snapshot_info"
 	DefaultRedisMaintenanceMetricName    = "cro_redis_service_maintenance"
 	DefaultRedisInfoMetricName           = "cro_redis_info"
 	DefaultRedisAvailMetricName          = "cro_redis_available"
 	DefaultRedisConnectionMetricName     = "cro_redis_connection"
+	DefaultRedisSnapshotMetricName       = "cro_redis_snapshot_info"
+	DefaultBlobStorageInfoMetricName     = "cro_blobstorage_info"
 )
 
 var (


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/INTLY-6521

## Verification
BYOC required
- Run ```make cluster/prepare```
- Run ```make cluster/seed/managed/postgres cluster/seed/managed/redis cluster/seed/managed/blobstorage```
- Run ```make run/local```
- Wait for the redis and postgres to reconcile 
- create snapshots from the following cr for redis and posgres 
```yaml
apiVersion: integreatly.org/v1alpha1
kind: RedisSnapshot
metadata:
  name: example
  namespace: cloud-resource-operator
spec: 
  resourceName: example-redis

```
```yaml
apiVersion: integreatly.org/v1alpha1
kind: PostgresSnapshot
metadata:
  name: example
  namespace: cloud-resource-operator
spec: 
  resourceName: example-postgres
```
- Run ```curl localhost:8383/metrics | grep aws```
- Ensure the following metrics are there 
  - redhat_rhmi_postgres_status_phase 
  - redhat_rhmi_postgres_snapshot_status_phase
  - redhat_rhmi_blobstorage_status_phase
  - redhat_rhmi_redis_status_phase
  - redhat_rhmi_redis_snapshot_status_phase
