### PR TITLE
Refactor make run/local to use NAMESPACE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,7 @@ build:
 
 .PHONY: run
 run:
-	RECTIME=30 $(OPERATOR_SDK) up local --namespace=""
-
-.PHONY: run/local
-run/local:
-	RECTIME=30 $(OPERATOR_SDK) up local --namespace="$(NAMESPACE)"
+	RECTIME=30 $(OPERATOR_SDK) up local --namespace=$(NAMESPACE)
 
 .PHONY: setup/service_account
 setup/service_account:


### PR DESCRIPTION
## Overview
doing some refactoring on make targets used to run locally for develo…pment

`make run` didn't specify a namespace whereas `make run/local` did
it's more useful for multiple folks developing against one cluster to use
the target where a namespace is specified.

No docs update as `make run` is being repurposed, the [local dev](https://github.com/integr8ly/cloud-resource-operator#locally) section in the
README already suggest using it.

Also removed the quotations around $NAMESPACE

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make run`
- Ensure...

The output includes  `--namespace="cloud-resource-operator"`

eg.
<img width="1275" alt="Screenshot 2020-06-04 at 16 04 17" src="https://user-images.githubusercontent.com/6498727/83773971-16b05880-a67d-11ea-84b2-0c350f4c2b68.png">
