### PR TITLE
migrate aws resources to use t3 instance types by default

### DIFF
--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -48,7 +48,7 @@ const (
 	defaultAwsMaxAllocatedStorage        = 100
 	defaultAwsPostgresDatabase           = "postgres"
 	defaultAwsBackupRetentionPeriod      = 31
-	defaultAwsDBInstanceClass            = "db.t2.small"
+	defaultAwsDBInstanceClass            = "db.t3.small"
 	defaultAwsEngine                     = "postgres"
 	defaultAwsEngineVersion              = "10.6"
 	defaultAwsPubliclyAccessible         = false

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -36,9 +36,9 @@ import (
 const (
 	redisProviderName = "aws-elasticache"
 	// default create params
-	defaultCacheNodeType = "cache.t2.micro"
+	defaultCacheNodeType = "cache.t3.micro"
 	// required for at rest encryption, see https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/at-rest-encryption.html
-	defaultEngineVersion     = "3.2.6"
+	defaultEngineVersion     = "5.0.6"
 	defaultDescription       = "A Redis replication group"
 	defaultNumCacheClusters  = 2
 	defaultSnapshotRetention = 31
@@ -566,6 +566,10 @@ func buildElasticacheUpdateStrategy(elasticacheConfig *elasticache.CreateReplica
 	}
 
 	for _, foundCacheCluster := range replicationGroupClusters {
+		if elasticacheConfig.EngineVersion != nil && *elasticacheConfig.EngineVersion != *foundCacheCluster.EngineVersion {
+			modifyInput.EngineVersion = elasticacheConfig.EngineVersion
+			updateFound = true
+		}
 		if elasticacheConfig.PreferredMaintenanceWindow != nil && *elasticacheConfig.PreferredMaintenanceWindow != *foundCacheCluster.PreferredMaintenanceWindow {
 			modifyInput.PreferredMaintenanceWindow = elasticacheConfig.PreferredMaintenanceWindow
 			updateFound = true

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -635,6 +635,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 					SnapshotRetentionLimit:     aws.Int64(30),
 					PreferredMaintenanceWindow: aws.String("test"),
 					SnapshotWindow:             aws.String("test"),
+					EngineVersion:              aws.String("3.2.6"),
 				},
 				foundConfig: &elasticache.ReplicationGroup{
 					ReplicationGroupId:     aws.String("test-id"),
@@ -643,7 +644,8 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 				},
 				replicationGroupClusters: []elasticache.CacheCluster{
 					{
-						EngineVersion:              aws.String("3.2.6"),
+						EngineVersion: aws.String("3.2.6"),
+						//EngineVersion:              aws.String(defaultEngineVersion),
 						PreferredMaintenanceWindow: aws.String("test"),
 						SnapshotWindow:             aws.String("test"),
 					},
@@ -668,6 +670,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 				},
 				replicationGroupClusters: []elasticache.CacheCluster{
 					{
+						EngineVersion:              aws.String("3.2.6"),
 						PreferredMaintenanceWindow: aws.String("test"),
 						SnapshotWindow:             aws.String("test"),
 					},

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -122,6 +122,7 @@ func (m *mockElasticacheClient) DescribeCacheClusters(*elasticache.DescribeCache
 			{
 				CacheClusterStatus: aws.String("available"),
 				ReplicationGroupId: aws.String("test-id"),
+				EngineVersion:      aws.String(defaultEngineVersion),
 			},
 		},
 	}, nil
@@ -642,6 +643,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 				},
 				replicationGroupClusters: []elasticache.CacheCluster{
 					{
+						EngineVersion:              aws.String("3.2.6"),
 						PreferredMaintenanceWindow: aws.String("test"),
 						SnapshotWindow:             aws.String("test"),
 					},
@@ -657,6 +659,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 					SnapshotRetentionLimit:     aws.Int64(50),
 					PreferredMaintenanceWindow: aws.String("newValue"),
 					SnapshotWindow:             aws.String("newValue"),
+					EngineVersion:              aws.String(defaultEngineVersion),
 				},
 				foundConfig: &elasticache.ReplicationGroup{
 					CacheNodeType:          aws.String("test"),
@@ -676,6 +679,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 				PreferredMaintenanceWindow: aws.String("newValue"),
 				SnapshotWindow:             aws.String("newValue"),
 				ReplicationGroupId:         aws.String("test-id"),
+				EngineVersion:              aws.String(defaultEngineVersion),
 			},
 		},
 	}


### PR DESCRIPTION
regions such as stockholm are deprecating the t2 instance type, we
should migrate to t3 instance types

verification (create):
- run 'make cluster/seed/managed/postgres'
- run 'make cluster/seed/managed/redis'
- ensure elasticache is now using 'cache.t3.micro' instances
- ensure rds is now using 'db.t3.small' instances

verification (migrate):
- from 'master', run 'make cluster/seed/managed/postgres'
- from 'master', run 'make cluster/seed/managed/redis'
- ensure elasticache is using 'cache.t2.micro' instances
- ensure rds is using 'db.t2.small' instances
- set the maintenance window for both instances to an
  hour from now
- from this branch, run the operator
- ensure in aws there are now maintenance actions for upgrading
  the instance type of both resources
- ensure the maintenance actions are completed in the
  maintenance window