### PR TITLE
Create standalone VPC when "_network" block is defined

### DIFF
--- a/pkg/providers/aws/cluster_network_provider.go
+++ b/pkg/providers/aws/cluster_network_provider.go
@@ -87,7 +87,7 @@ type NetworkManager interface {
 	DeleteNetwork(context.Context) error
 	CreateNetworkPeering(context.Context, *Network) (*NetworkPeering, error)
 	GetClusterNetworkPeering(context.Context) (*NetworkPeering, error)
-	DeleteNetworkPeering(context.Context, *NetworkPeering) error
+	DeleteNetworkPeering(*NetworkPeering) error
 	IsEnabled(context.Context) (bool, error)
 }
 
@@ -148,10 +148,14 @@ func (n *NetworkProvider) CreateNetwork(ctx context.Context, vpcCidrBlock *net.I
 		//By default, `integreatly.org/clusterID`.
 		//
 		//NOTE - Once a VPC is created we do not want to update it. To avoid changing cidr block
-		if !isValidCIDRRange(vpcCidrBlock) {
-			return nil, errorUtil.New(fmt.Sprintf("%s is out of range, block sizes must be between `/16` and `/26`, please update `_network` strategy", vpcCidrBlock.String()))
-		}
 
+		// standalone vpc cidr block can not overlap with existing cluster vpc cidr block
+		// issue arises when trying to peer both vpcs with invalid vpc error - `overlapping CIDR range`
+		// we need to ensure both cidr ranges do not intersect before creating the standalone vpc
+		// as the creation of a standalone vpc is designed to be a one shot pass and not to be updated after the fact
+		if err := validateStandaloneCidrBlock(ctx, n.Client, n.Ec2Api, logger, vpcCidrBlock); err != nil {
+			return nil, errorUtil.Wrap(err, "vpc validation failure")
+		}
 		logger.Infof("cidr %s is valid 👍", vpcCidrBlock.String())
 
 		// create vpc using cidr string from _network
@@ -385,6 +389,7 @@ func (n *NetworkProvider) CreateNetworkPeering(ctx context.Context, network *Net
 	}, nil
 }
 
+//GetClusterNetworking returns an active Net
 func (n *NetworkProvider) GetClusterNetworkPeering(ctx context.Context) (*NetworkPeering, error) {
 	logger := resources.NewActionLogger(n.Logger, "GetClusterNetworkPeering")
 
@@ -462,8 +467,12 @@ func (n *NetworkProvider) getNetworkPeering(ctx context.Context, network *Networ
 
 // deletes a provided vpc peering connection
 // this will remove network connectivity between the vpcs that are part of the provided peering connection
-func (n *NetworkProvider) DeleteNetworkPeering(ctx context.Context, peering *NetworkPeering) error {
+func (n *NetworkProvider) DeleteNetworkPeering(peering *NetworkPeering) error {
 	logger := resources.NewActionLogger(n.Logger, "DeleteNetworkPeering")
+	if peering.PeeringConnection == nil {
+		logger.Info("networking peering connection nil, skipping delete network peering")
+		return nil
+	}
 	logger = logger.WithField("vpc_peering", aws.StringValue(peering.PeeringConnection.VpcPeeringConnectionId))
 
 	// describe the vpc peering connection first, it could be possible that the peering connection is already in a
@@ -903,13 +912,43 @@ func isValidCIDRRange(CIDR *net.IPNet) bool {
 	return mask > 15 && mask < 27
 }
 
+// validateStandaloneCidrBlock validates the standalone cidr block before creation, returning an error if the cidr is not valid
+// checks carried out :
+// 		* has a cidr range between \16 and \26
+// 		* does not overlap with cluster vpc cidr block
+func validateStandaloneCidrBlock(ctx context.Context, client client.Client, ec2Api ec2iface.EC2API, logger *logrus.Entry, vpcCidrBlock *net.IPNet) error {
+	// validate has a cidr range between \16 and \26
+	if !isValidCIDRRange(vpcCidrBlock) {
+		return errorUtil.New(fmt.Sprintf("%s is out of range, block sizes must be between `/16` and `/26`, please update `_network` strategy", vpcCidrBlock.String()))
+	}
+
+	clusterVPC, err := getClusterVpc(ctx, client, ec2Api, logger)
+	if err != nil {
+		return errorUtil.Wrap(err, "failed to get cluster vpc")
+	}
+
+	_, clusterVPCCidr, err := net.ParseCIDR(*clusterVPC.CidrBlock)
+	if err != nil {
+		return errorUtil.Wrap(err, "failed to parse cluster vpc cidr block")
+	}
+
+	// standalone vpc cidr block can not overlap with existing cluster vpc cidr block
+	// issue arises when trying to peer both vpcs with invalid vpc error - `overlapping CIDR range`
+	// this utility function returns true if either cidr range intersect
+	if clusterVPCCidr.Contains(vpcCidrBlock.IP) || vpcCidrBlock.Contains(clusterVPCCidr.IP) {
+		return errorUtil.New(fmt.Sprintf("standalone vpc creation failed: standalone cidr block %s overlaps with cluster vpc cidr block %s, update _network strategy to continue vpc creation", vpcCidrBlock.String(), *clusterVPC.CidrBlock))
+
+	}
+	return nil
+}
+
 // getNetworkProviderConfig return parsed ipNet cidr block
 // a _network resource type strategy, is expected to have the same tier as either postgres or redis resource type
 // ie. for a postgres tier X there should be a corresponding _network tier X
 //
 // the _network strategy config is unmarshalled into a ec2 create vpc input struct
 // from the struct the cidr block is parsed to ensure validity
-func getNetworkProviderConfig(ctx context.Context, configManager ConfigManager, logger *logrus.Entry, tier string) (*net.IPNet, error) {
+func getNetworkProviderConfig(ctx context.Context, configManager ConfigManager, tier string, logger *logrus.Entry) (*net.IPNet, error) {
 	logger.Infof("fetching _network strategy config for tier %s", tier)
 
 	stratCfg, err := configManager.ReadStorageStrategy(ctx, providers.NetworkResourceType, tier)

--- a/pkg/providers/aws/config_test.go
+++ b/pkg/providers/aws/config_test.go
@@ -20,6 +20,20 @@ import (
 
 var configMapNameSpace, _ = k8sutil.GetWatchNamespace()
 
+type mockConfigManager struct{
+	ConfigManager
+	createStrategy json.RawMessage
+}
+
+var _ ConfigManager = (*mockConfigManager) (nil)
+
+func (m *mockConfigManager) ReadStorageStrategy(ctx context.Context, rt providers.ResourceType, tier string) (*StrategyConfig, error) {
+	return &StrategyConfig{
+		CreateStrategy: m.createStrategy,
+	}, nil
+}
+
+
 func newFakeInfrastructure() *configv1.Infrastructure {
 	return &configv1.Infrastructure{
 		ObjectMeta: controllerruntime.ObjectMeta{

--- a/pkg/providers/aws/config_test.go
+++ b/pkg/providers/aws/config_test.go
@@ -20,20 +20,6 @@ import (
 
 var configMapNameSpace, _ = k8sutil.GetWatchNamespace()
 
-type mockConfigManager struct{
-	ConfigManager
-	createStrategy json.RawMessage
-}
-
-var _ ConfigManager = (*mockConfigManager) (nil)
-
-func (m *mockConfigManager) ReadStorageStrategy(ctx context.Context, rt providers.ResourceType, tier string) (*StrategyConfig, error) {
-	return &StrategyConfig{
-		CreateStrategy: m.createStrategy,
-	}, nil
-}
-
-
 func newFakeInfrastructure() *configv1.Infrastructure {
 	return &configv1.Infrastructure{
 		ObjectMeta: controllerruntime.ObjectMeta{

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
 	"strconv"
 	"time"
 
@@ -149,14 +148,18 @@ func (p *PostgresProvider) CreatePostgres(ctx context.Context, pg *v1alpha1.Post
 		errMsg := "failed to check cluster vpc subnets"
 		return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
 	}
-	// if a standalone network is required configure the network
-	// (standalone vpc, private subnets, subnet groups, security groups, vpc peering)
+
+	//networkManager isEnabled checks for the presence of valid RHMI subnets in the cluster vpc
+	//when rhmi subnets are present in a cluster vpc it indicates that the vpc configuration
+	//was created in a cluster with a cluster version <= 4.4.5
+	//
+	//when rhmi subnets are absent in a cluster vpc it indicates that the vpc configuration has not been created
+	//and a new vpc is created for all resources to be deployed in and peered with the cluster vpc
 	if isEnabled {
-		// todo handle getting vpc cidr block from _network strat - https://issues.redhat.com/browse/INTLY-8103
-		logger.Debug("using temp cidr block")
-		_, tempCIDR, err := net.ParseCIDR("10.0.0.0/26")
+		// get cidr block from _network strat map, based on tier from postgres cr
+		vpcCidrBlock, err := getNetworkProviderConfig(ctx, p.ConfigManager, logger, pg.Spec.Tier)
 		if err != nil {
-			errMsg := "failed to parse vpc cidr"
+			errMsg := "failed to get _network strategy config"
 			return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
 		}
 
@@ -192,8 +195,11 @@ func (p *PostgresProvider) createRDSInstance(ctx context.Context, cr *v1alpha1.P
 		return nil, croType.StatusMessage(msg), err
 	}
 
-	// we should handle networking higher up for installs on >= 4.4.6 openshift cluster
+	// we handle standalone networking in CreatePostgres() for installs on >= 4.4.6 openshift cluster
 	// this check is to ensure backward compatibility with <= 4.4.5 openshift cluster
+	// creating bundled (in cluster vpc) subnets, subnet groups, security groups
+	//
+	// standaloneNetworkExists if no bundled resources are found in the cluster vpc
 	if !standaloneNetworkExists {
 		// setup networking in cluster vpc rds vpc
 		if err := p.configureRDSVpc(ctx, rdsSvc, ec2Svc); err != nil {
@@ -207,11 +213,6 @@ func (p *PostgresProvider) createRDSInstance(ctx context.Context, cr *v1alpha1.P
 			return nil, croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
 		}
 	}
-
-	// uncomment lines 183 and 184 for development/verification
-	// TODO Will be removed in https://issues.redhat.com/browse/INTLY-8103
-	//errMsg := "we don;t wanna create other stufff and thngs"
-	//return nil, croType.StatusMessage(errMsg), errorUtil.New(errMsg)
 
 	// getting postgres user password from created secret
 	credSec := &v1.Secret{}
@@ -404,7 +405,7 @@ func (p *PostgresProvider) DeletePostgres(ctx context.Context, r *v1alpha1.Postg
 		return croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
 	}
 
-	// network manager required for cleaning up network.
+	// network manager required for cleaning up network vpc, subnet and subnet groups.
 	networkManager := NewNetworkManager(sess, p.Client, logger)
 
 	return p.deleteRDSInstance(ctx, r, networkManager, rds.New(sess), rdsCreateConfig, rdsDeleteConfig)

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -164,7 +164,7 @@ func (p *PostgresProvider) CreatePostgres(ctx context.Context, pg *v1alpha1.Post
 		}
 
 		logger.Debug("standalone network provider enabled, reconciling standalone vpc")
-		standaloneNetwork, err := networkManager.CreateNetwork(ctx, tempCIDR)
+		standaloneNetwork, err := networkManager.CreateNetwork(ctx, vpcCidrBlock)
 		if err != nil {
 			errMsg := "failed to create resource network"
 			return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -157,7 +157,7 @@ func (p *PostgresProvider) CreatePostgres(ctx context.Context, pg *v1alpha1.Post
 	//and a new vpc is created for all resources to be deployed in and peered with the cluster vpc
 	if isEnabled {
 		// get cidr block from _network strat map, based on tier from postgres cr
-		vpcCidrBlock, err := getNetworkProviderConfig(ctx, p.ConfigManager, logger, pg.Spec.Tier)
+		vpcCidrBlock, err := getNetworkProviderConfig(ctx, p.ConfigManager, pg.Spec.Tier, logger)
 		if err != nil {
 			errMsg := "failed to get _network strategy config"
 			return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
@@ -443,7 +443,7 @@ func (p *PostgresProvider) deleteRDSInstance(ctx context.Context, pg *v1alpha1.P
 			return croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
 		}
 
-		if err = networkManager.DeleteNetworkPeering(ctx, networkPeering); err != nil {
+		if err = networkManager.DeleteNetworkPeering(networkPeering); err != nil {
 			msg := "failed to delete cluster network peering"
 			return croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
 		}

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -137,7 +137,7 @@ func (p *RedisProvider) CreateRedis(ctx context.Context, r *v1alpha1.Redis) (*pr
 		}
 
 		logger.Debug("standalone network provider enabled, reconciling standalone vpc")
-		standaloneNetwork, err := networkManager.CreateNetwork(ctx, tempCIDR)
+		standaloneNetwork, err := networkManager.CreateNetwork(ctx, vpcCidrBlock)
 		if err != nil {
 			errMsg := "failed to create resource network"
 			return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
 	"strconv"
 	"time"
 
@@ -123,23 +122,17 @@ func (p *RedisProvider) CreateRedis(ctx context.Context, r *v1alpha1.Redis) (*pr
 		return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
 	}
 
-	/*
-		reconcileElasticacheNetworking configures networking required for cro resources (postgres)
-
-		networkManager isEnabled checks for the presence of valid RHMI subnets in the cluster vpc
-		when rhmi subnets are present in a cluster vpc it indicates that the vpc configuration
-		was created in a cluster with a cluster version <= 4.4.5
-
-		when rhmi subnets are absent in a cluster vpc it indicates that the vpc configuration has not been created
-		and we should create a new vpc for all resources to be deployed in and we should peer the
-		resource vpc and cluster vpc
-	*/
+	//networkManager isEnabled checks for the presence of valid RHMI subnets in the cluster vpc
+	//when rhmi subnets are present in a cluster vpc it indicates that the vpc configuration
+	//was created in a cluster with a cluster version <= 4.4.5
+	//
+	//when rhmi subnets are absent in a cluster vpc it indicates that the vpc configuration has not been created
+	//and a new vpc is created for all resources to be deployed in and peered with the cluster vpc
 	if isEnabled {
-		// todo handle getting vpc cidr block from _network strat - https://issues.redhat.com/browse/INTLY-8103
-		logger.Debug("using temp cidr block")
-		_, tempCIDR, err := net.ParseCIDR("10.0.0.0/26")
+		// get cidr block from _network strat map, based on tier from redis cr
+		vpcCidrBlock, err := getNetworkProviderConfig(ctx, p.ConfigManager, logger, r.Spec.Tier)
 		if err != nil {
-			errMsg := "failed to parse vpc cidr"
+			errMsg := "failed to get _network strategy config"
 			return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
 		}
 
@@ -158,6 +151,7 @@ func (p *RedisProvider) CreateRedis(ctx context.Context, r *v1alpha1.Redis) (*pr
 		}
 		logger.Infof("created network peering %s", aws.StringValue(networkPeering.PeeringConnection.VpcPeeringConnectionId))
 	}
+
 	// create the aws elasticache cluster
 	return p.createElasticacheCluster(ctx, r, elasticache.New(sess), sts.New(sess), ec2.New(sess), elasticacheCreateConfig, stratCfg, isEnabled)
 }
@@ -173,6 +167,11 @@ func (p *RedisProvider) createElasticacheCluster(ctx context.Context, r *v1alpha
 		return nil, croType.StatusMessage(errMsg), errorUtil.Wrapf(err, errMsg)
 	}
 
+	// we handle standalone networking in CreateRedis() for installs on >= 4.4.6 openshift clusters
+	// this check is to ensure backward compatibility with <= 4.4.5 openshift clusters
+	// creating bundled (in cluster vpc) subnets, subnet groups, security groups
+	//
+	// standaloneNetworkExists if no bundled resources are found in the cluster vpc
 	if !standaloneNetworkExists {
 		// setup networking in cluster vpc
 		if err := p.configureElasticacheVpc(ctx, cacheSvc, ec2Svc); err != nil {
@@ -186,10 +185,6 @@ func (p *RedisProvider) createElasticacheCluster(ctx context.Context, r *v1alpha
 			return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
 		}
 	}
-	// uncomment lines 183 and 184 for development/verification
-	// TODO Will be removed in https://issues.redhat.com/browse/INTLY-8103
-	//errMsg := "we don;t wanna create other stufff and thngs"
-	//return nil, croType.StatusMessage(errMsg), errorUtil.New(errMsg)
 
 	// verify and build elasticache create config
 	if err := p.buildElasticacheCreateStrategy(ctx, r, ec2Svc, elasticacheConfig); err != nil {

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -196,7 +196,6 @@ func buildTestRedisCluster() *providers.RedisCluster {
 	}}
 }
 
-// todo tests should be extended when createNetwork is implemented, we should ensure creation of both vpc implementations
 func Test_createRedisCluster(t *testing.T) {
 	scheme, err := buildTestSchemeRedis()
 	if err != nil {
@@ -335,6 +334,28 @@ func Test_createRedisCluster(t *testing.T) {
 				},
 				stratCfg:                &StrategyConfig{Region: "test"},
 				standaloneNetworkExists: false,
+			},
+			fields: fields{
+				ConfigManager:     nil,
+				CredentialManager: nil,
+				Logger:            testLogger,
+				TCPPinger:         buildMockConnectionTester(),
+				Client:            fake.NewFakeClientWithScheme(scheme, buildTestRedisCR(), builtTestCredSecret(), buildTestInfra(), buildTestPrometheusRule()),
+			},
+			want:    buildTestRedisCluster(),
+			wantErr: false,
+		},
+		{
+			name: "test elasticache already exists and status is available (valid standalone rhmi subnets)",
+			args: args{
+				ctx:                     context.TODO(),
+				cacheSvc:                &mockElasticacheClient{replicationGroups: buildReplicationGroupReady()},
+				ec2Svc:                  &mockEc2Client{secGroups: buildSecurityGroups(secName)},
+				r:                       buildTestRedisCR(),
+				stsSvc:                  &mockStsClient{},
+				redisConfig:             &elasticache.CreateReplicationGroupInput{ReplicationGroupId: aws.String("test-id")},
+				stratCfg:                &StrategyConfig{Region: "test"},
+				standaloneNetworkExists: true,
 			},
 			fields: fields{
 				ConfigManager:     nil,

--- a/pkg/providers/aws/sort.go
+++ b/pkg/providers/aws/sort.go
@@ -1,3 +1,7 @@
+// a helper utility for the cluster network provider.
+// the network provider provisions subnets in two availability zones.
+// to ensure a mapping between subnets and availability zones this sort utility,
+// allows for deterministic sorting of availability zones based on the zone names
 package aws
 
 import "github.com/aws/aws-sdk-go/service/ec2"


### PR DESCRIPTION
Co-authored-by: laurafitzgerald <lfitzger@example.com>

## Overview

Jira: https://issues.redhat.com/browse/INTLY-8103

## Verification Consuming _network Strat Map

_Note : verification must be completed in a fresh cluster and aws account. No remnants of bundled cluster networking (cluster subnets, subnet groups, security groups) should exist in cluster vpc_

_Note : the seeded resource will not fully install, as the security group is not implemented and will cause the install to fail,  the standalone networking is provisioned before the error, the DeleteNetwork()  function is provisionally implemented, so removing the CR will clean up the standalone network. There are follow on tickets for both security group and DeleteNetwork() implementation_

- Clone this branch
- Run `make cluster/prepare`
- Run `make cluster/seed/managed/postgres`
- Run `make run`
- Make note of the `cidrBlock` value in the `_network` strategy map
- Run `aws ec2 describe-vpcs`
- The `cidrBlock` for the vpc name `RHMI Cloud Resource VPC` it should match the `cidrBlock` in the `_network` strategy map
- Make note of the vpc-id
- Run ` aws ec2 describe-subnets --filters "Name=vpc-id,Values=<<noted vpc-id>>"`   
- Ensure two subnets are returned
- Ensure the `cidrBlock` mask for each subnet is one bit greater then the `cidrBlock` mask in the `_network` strategy map
- Update the `cidrBlock` value in the `_network` strategy map     
- Recheck the `cidrBlock` value in the vpc and subnets, these should not change from the original values        

## Verification Cidr Overlap
_Note we can not have both standalone and bundled vpc cidr blocks overlapping_

- Remove CR from previous verification 
- Ensure standalone vpc, subnets and subnet groups have been cleaned
- Run `make cluster/seed/managed/postgres`
- Run `aws ec2 describe-vpcs`
- Note the `cidrBlock` on the cluster vpc, which can be found by the following tag
```
{
    "Key": "kubernetes.io/cluster/<<cluster id>>",
    "Value": "owned"
}
```
- ensure the `_network` type `cidrBlock` value in the `cloud-resources-aws-strategies` config map overlaps with the `cidrBlock` from the cluster vpc
- Run `make run`
- Ensure the following error :
```
failed to create resource network: standalone vpc creation failed: standalone cidr block 10.0.0.0/26 overlaps with cluster vpc cidr block 10.0.0.0/16, update _network strategy to continue vpc creation
```