### PR TITLE
verify last instance of postgres or redis before deleting standalone network

### DIFF
--- a/deploy/examples/cloud_resources_aws_strategies.yaml
+++ b/deploy/examples/cloud_resources_aws_strategies.yaml
@@ -10,5 +10,5 @@ data:
   postgres: |
     {"development": { "region": "eu-west-1", "createStrategy": {}, "deleteStrategy": {} }}
   _network: |
-    {"development": { "region": "eu-west-1", "createStrategy": { "CidrBlock": "10.0.0.0/16" }, "deleteStrategy": {} }}
+    {"development": { "region": "eu-west-1", "createStrategy": { "CidrBlock": "10.1.0.0/16" }, "deleteStrategy": {} }}
     


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/INTLY-8163

Pushing for review initially. Verification steps are included below but they can wait until code review are done in case of changes. 

## Verification

Note: this should be run on a fresh BYOC cluster with no previous networking configuration
Note: You don't need to let the redis and postgres install completely. It's enough to ensure they get deleted correctly on deletion of the cr. (I think 🤔 )


- Checkout this branch
- Run `make cluster/prepare`
- Run `make cluster/seed/managed/postgres`
- Run `make cluster/seed/managed/redis`
- Run `make run`

- Verify the standalone vpc is created by running ` aws ec2 describe-vpcs --filter "Name=tag-value,Values=RHMI Cloud Resource VPC"` - There should be one VPC - note the id of the vpc.
- Check that the redis and postgres resources are being created by running the following:
   - `aws rds describe-db-instances`  - there should be one instance associated with `DBInstanceIdentifier` == `<clustername><randomstring>cloudresourceoper<randomstring>`
   - `aws elasticache describe-cache-clusters` - there should be on instance associated with `CacheClusterId` == `<clustername><randomstring>cloudresourceoper-<randomstring>`

- Run `oc new-project cro-other-project`
- Run `make cluster/seed/managed/postgres NAMESPACE=cro-other-project`
- Check it's created. cro shouldn't respond to that one.

- Delete the redis cr from the namespace cro is running against.
- Wait for the redis instance to be deleted from aws and the cr to be deleted from the cluster. This may take a while.

- Verify that the VPC is still in aws ` aws ec2 describe-vpcs --filter "Name=tag-value,Values=RHMI Cloud Resource VPC"` - There should be one VPC with the same id previously noted.

- Delete the postgres cr from the namespace cro is running against
- Wait for the postgres instance to be deleted from aws and the cr to be deleted from the cluster. This may also take a while.

- Verify that the VPC is deleted in aws. It should ignore the additional postgres in the other namespace.

