### PR TITLE
deleting bundle network resources on deletion of last rds or elasticache

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Operator is running.
 ## Running the Cloud Resource Operator
 ## Locally
 
+## Supported Openshift Versions
+
+Due to a change in how networking is configured for Openshift >= v4.4.6 the use of cro <= v0.16.1 with these Openshift versions is unsupported.
+Please use >= v0.17.x of CRO for Openshift >= v4.4.6.
+
+
 Prerequisites:
 - `go`
 - `make`
@@ -56,39 +62,6 @@ Clean up the Kubernetes/OpenShift cluster:
 ```shell script
 $ make cluster/clean
 ```
-
-## VPC Peering 
-Currently AWS resources are deployed into a separate Virtual Private Cloud (VPC) than the VPC that the cluster is deployed into. In order for these to communicate, a `peering connection` must be established between the two VPCS. To do this:
-1. Create a new peering connection between the two VPCs.
-  - Go to `VPC` > `Peering Connections`
-  - Click on `Create Peering Connection`
-    - **NOTE**: This is a two-way communication channel so only one needs to be created.
-  - Select the newly created connection, then click `Actions` > `Accept Request` to accept the peering request.
-2. Edit your cluster's VPC route table
-  - Go to `VPC` > `Your VPCs`
-  - Find the VPC your cluster is using and click on its route table under the heading `Main Route Table`
-    - Your cluster VPC name is usually in a format of `<cluster-name>-<uid>-vpc`
-  - Select the cluster route table and click on `Action` > `Edit routes`
-  - Add a new route with the following details:
-    ```
-    Destination: <resource VPC CIDR block>
-    Target: <newly created peering connection>
-    ```
-  - Click on `Save routes`
-3. Edit the resource VPC route table
-  - Go to `VPC` > `Your VPCs`
-  - Find the VPC where the AWS resources are provisioned in and click on its route table under the heading `Main Route Table`
-    - The name of this VPC is usually empty or named as `default`
-  - Select the cluster route table and click on `Action` > `Edit routes`
-  - Add a new route with the following details:
-    ```
-    Destination: <your cluster's VPC CIDR block>
-    Target: <newly created peering connection>
-    ```
-  - Click on `Save routes`
-4. Edit the Security Groups associated with the resource VPC to ensure database and cache traffic can pass between the two VPCs.
-
-The two VPCs should now be able to communicate with each other. 
 
 ## Snapshots
 The cloud resource operator supports the taking of arbitrary snapshots in the AWS provider for both `Postgres` and `Redis`. To take a snapshot you must create a `RedisSnapshot` or `PostgresSnapshot` resource, which should reference the `Redis` or `Postgres` resource you wish to create a snapshot of. The snapshot resource must also exist in the same namespace.

--- a/pkg/providers/aws/cluster_network_provider_moq.go
+++ b/pkg/providers/aws/cluster_network_provider_moq.go
@@ -10,14 +10,15 @@ import (
 )
 
 var (
-	lockNetworkManagerMockCreateNetwork            sync.RWMutex
-	lockNetworkManagerMockCreateNetworkConnection  sync.RWMutex
-	lockNetworkManagerMockCreateNetworkPeering     sync.RWMutex
-	lockNetworkManagerMockDeleteNetwork            sync.RWMutex
-	lockNetworkManagerMockDeleteNetworkConnection  sync.RWMutex
-	lockNetworkManagerMockDeleteNetworkPeering     sync.RWMutex
-	lockNetworkManagerMockGetClusterNetworkPeering sync.RWMutex
-	lockNetworkManagerMockIsEnabled                sync.RWMutex
+	lockNetworkManagerMockCreateNetwork               sync.RWMutex
+	lockNetworkManagerMockCreateNetworkConnection     sync.RWMutex
+	lockNetworkManagerMockCreateNetworkPeering        sync.RWMutex
+	lockNetworkManagerMockDeleteBundledCloudResources sync.RWMutex
+	lockNetworkManagerMockDeleteNetwork               sync.RWMutex
+	lockNetworkManagerMockDeleteNetworkConnection     sync.RWMutex
+	lockNetworkManagerMockDeleteNetworkPeering        sync.RWMutex
+	lockNetworkManagerMockGetClusterNetworkPeering    sync.RWMutex
+	lockNetworkManagerMockIsEnabled                   sync.RWMutex
 )
 
 // Ensure, that NetworkManagerMock does implement NetworkManager.
@@ -38,6 +39,9 @@ var _ NetworkManager = &NetworkManagerMock{}
 //             },
 //             CreateNetworkPeeringFunc: func(in1 context.Context, in2 *Network) (*NetworkPeering, error) {
 // 	               panic("mock out the CreateNetworkPeering method")
+//             },
+//             DeleteBundledCloudResourcesFunc: func(in1 context.Context) error {
+// 	               panic("mock out the DeleteBundledCloudResources method")
 //             },
 //             DeleteNetworkFunc: func(in1 context.Context) error {
 // 	               panic("mock out the DeleteNetwork method")
@@ -69,6 +73,9 @@ type NetworkManagerMock struct {
 
 	// CreateNetworkPeeringFunc mocks the CreateNetworkPeering method.
 	CreateNetworkPeeringFunc func(in1 context.Context, in2 *Network) (*NetworkPeering, error)
+
+	// DeleteBundledCloudResourcesFunc mocks the DeleteBundledCloudResources method.
+	DeleteBundledCloudResourcesFunc func(in1 context.Context) error
 
 	// DeleteNetworkFunc mocks the DeleteNetwork method.
 	DeleteNetworkFunc func(in1 context.Context) error
@@ -107,6 +114,11 @@ type NetworkManagerMock struct {
 			In1 context.Context
 			// In2 is the in2 argument value.
 			In2 *Network
+		}
+		// DeleteBundledCloudResources holds details about calls to the DeleteBundledCloudResources method.
+		DeleteBundledCloudResources []struct {
+			// In1 is the in1 argument value.
+			In1 context.Context
 		}
 		// DeleteNetwork holds details about calls to the DeleteNetwork method.
 		DeleteNetwork []struct {
@@ -240,6 +252,37 @@ func (mock *NetworkManagerMock) CreateNetworkPeeringCalls() []struct {
 	lockNetworkManagerMockCreateNetworkPeering.RLock()
 	calls = mock.calls.CreateNetworkPeering
 	lockNetworkManagerMockCreateNetworkPeering.RUnlock()
+	return calls
+}
+
+// DeleteBundledCloudResources calls DeleteBundledCloudResourcesFunc.
+func (mock *NetworkManagerMock) DeleteBundledCloudResources(in1 context.Context) error {
+	if mock.DeleteBundledCloudResourcesFunc == nil {
+		panic("NetworkManagerMock.DeleteBundledCloudResourcesFunc: method is nil but NetworkManager.DeleteBundledCloudResources was just called")
+	}
+	callInfo := struct {
+		In1 context.Context
+	}{
+		In1: in1,
+	}
+	lockNetworkManagerMockDeleteBundledCloudResources.Lock()
+	mock.calls.DeleteBundledCloudResources = append(mock.calls.DeleteBundledCloudResources, callInfo)
+	lockNetworkManagerMockDeleteBundledCloudResources.Unlock()
+	return mock.DeleteBundledCloudResourcesFunc(in1)
+}
+
+// DeleteBundledCloudResourcesCalls gets all the calls that were made to DeleteBundledCloudResources.
+// Check the length with:
+//     len(mockedNetworkManager.DeleteBundledCloudResourcesCalls())
+func (mock *NetworkManagerMock) DeleteBundledCloudResourcesCalls() []struct {
+	In1 context.Context
+} {
+	var calls []struct {
+		In1 context.Context
+	}
+	lockNetworkManagerMockDeleteBundledCloudResources.RLock()
+	calls = mock.calls.DeleteBundledCloudResources
+	lockNetworkManagerMockDeleteBundledCloudResources.RUnlock()
 	return calls
 }
 

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -461,7 +461,8 @@ func (p *PostgresProvider) deleteRDSInstance(ctx context.Context, pg *v1alpha1.P
 		}
 	}
 
-	// check if instance does not exist, delete finalizer and credential secret
+	// check if instance exists, if it does attempt to delete it
+	// if not delete finalizer and credential secret
 	if foundInstance != nil {
 		// set status metric
 		p.exposePostgresMetrics(ctx, pg, foundInstance)
@@ -518,6 +519,17 @@ func (p *PostgresProvider) deleteRDSInstance(ctx context.Context, pg *v1alpha1.P
 
 		if err = networkManager.DeleteNetwork(ctx); err != nil {
 			msg := "failed to delete aws networking"
+			return croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
+		}
+	}
+
+	// in the case of standalone network not existing and the last resource is being deleted the
+	// bundled networking resources should be cleaned up similarly to standalone networking resources
+	// this involves the deletion of bundled elasticace and rds subnet group and ec2 security group
+	if !standaloneNetworkExists && isLastResource {
+		err := networkManager.DeleteBundledCloudResources(ctx)
+		if err != nil {
+			msg := "failed to delete bundled networking resources"
 			return croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
 		}
 	}

--- a/pkg/providers/aws/provider_postgres_test.go
+++ b/pkg/providers/aws/provider_postgres_test.go
@@ -608,13 +608,23 @@ func buildAZ() []*ec2.AvailabilityZone {
 		},
 	}
 }
+func buildSecurityGroup(modifyFn func(cluster *ec2.SecurityGroup)) *ec2.SecurityGroup {
+	mock := &ec2.SecurityGroup{
+		GroupName: aws.String("test"),
+		GroupId:   aws.String("testID"),
+	}
+
+	if modifyFn != nil {
+		modifyFn(mock)
+	}
+	return mock
+}
 
 func buildSecurityGroups(groupName string) []*ec2.SecurityGroup {
 	return []*ec2.SecurityGroup{
-		{
-			GroupName: aws.String(groupName),
-			GroupId:   aws.String("testID"),
-		},
+		buildSecurityGroup(func(mock *ec2.SecurityGroup) {
+			mock.GroupName = aws.String(groupName)
+		}),
 	}
 }
 

--- a/pkg/providers/aws/provider_postgres_test.go
+++ b/pkg/providers/aws/provider_postgres_test.go
@@ -2,11 +2,12 @@ package aws
 
 import (
 	"context"
-	errorUtil "github.com/pkg/errors"
 	"reflect"
 	"sync"
 	"testing"
 	"time"
+
+	errorUtil "github.com/pkg/errors"
 
 	v12 "github.com/integr8ly/cloud-resource-operator/pkg/apis/config/v1"
 
@@ -57,6 +58,7 @@ type mockRdsClient struct {
 	modifyDBSubnetGroupFn    func(*rds.ModifyDBSubnetGroupInput) (*rds.ModifyDBSubnetGroupOutput, error)
 	listTagsForResourceFn    func(*rds.ListTagsForResourceInput) (*rds.ListTagsForResourceOutput, error)
 	removeTagsFromResourceFn func(*rds.RemoveTagsFromResourceInput) (*rds.RemoveTagsFromResourceOutput, error)
+	deleteDBSubnetGroupFn    func(*rds.DeleteDBSubnetGroupInput) (*rds.DeleteDBSubnetGroupOutput, error)
 }
 
 type mockEc2Client struct {
@@ -75,6 +77,7 @@ type mockEc2Client struct {
 	createTagsFn                   func(*ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error)
 	describeVpcsFn                 func(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error)
 	describeSecurityGroupsFn       func(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error)
+	deleteSecurityGroupFn          func(*ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error)
 	describeVpcPeeringConnectionFn func(*ec2.DescribeVpcPeeringConnectionsInput) (*ec2.DescribeVpcPeeringConnectionsOutput, error)
 	createVpcPeeringConnectionFn   func(*ec2.CreateVpcPeeringConnectionInput) (*ec2.CreateVpcPeeringConnectionOutput, error)
 	acceptVpcPeeringConnectionFn   func(*ec2.AcceptVpcPeeringConnectionInput) (*ec2.AcceptVpcPeeringConnectionOutput, error)
@@ -177,12 +180,12 @@ func (m *mockRdsClient) CreateDBSubnetGroup(*rds.CreateDBSubnetGroupInput) (*rds
 	return &rds.CreateDBSubnetGroupOutput{}, nil
 }
 
-func (m *mockRdsClient) DeleteDBSubnetGroup(*rds.DeleteDBSubnetGroupInput) (*rds.DeleteDBSubnetGroupOutput, error) {
-	return &rds.DeleteDBSubnetGroupOutput{}, nil
-}
-
 func (m *mockRdsClient) ModifyDBSubnetGroup(input *rds.ModifyDBSubnetGroupInput) (*rds.ModifyDBSubnetGroupOutput, error) {
 	return m.modifyDBSubnetGroupFn(input)
+}
+
+func (m *mockRdsClient) DeleteDBSubnetGroup(input *rds.DeleteDBSubnetGroupInput) (*rds.DeleteDBSubnetGroupOutput, error) {
+	return m.deleteDBSubnetGroupFn(input)
 }
 
 func (m *mockRdsClient) ListTagsForResource(input *rds.ListTagsForResourceInput) (*rds.ListTagsForResourceOutput, error) {
@@ -321,8 +324,8 @@ func (m *mockEc2Client) CreateSecurityGroup(*ec2.CreateSecurityGroupInput) (*ec2
 	return &ec2.CreateSecurityGroupOutput{}, nil
 }
 
-func (m *mockEc2Client) DeleteSecurityGroup(*ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
-	return &ec2.DeleteSecurityGroupOutput{}, nil
+func (m *mockEc2Client) DeleteSecurityGroup(input *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+	return m.deleteSecurityGroupFn(input)
 }
 
 func (m *mockEc2Client) AuthorizeSecurityGroupIngress(*ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
@@ -367,6 +370,9 @@ func buildMockNetworkManager() *NetworkManagerMock {
 			return nil
 		},
 		DeleteNetworkFunc: func(ctx context.Context) error {
+			return nil
+		},
+		DeleteBundledCloudResourcesFunc: func(ctx context.Context) error {
 			return nil
 		},
 	}
@@ -964,6 +970,26 @@ func TestAWSPostgresProvider_deletePostgresInstance(t *testing.T) {
 				networkManager:          buildMockNetworkManager(),
 				instanceSvc:             &mockRdsClient{dbInstances: []*rds.DBInstance{}},
 				standaloneNetworkExists: true,
+				isLastResource:          true,
+			},
+			fields: fields{
+				Client:            fake.NewFakeClientWithScheme(scheme, buildTestPostgresCR(), buildTestInfra(), buildTestPostgresqlPrometheusRule()),
+				Logger:            testLogger,
+				CredentialManager: &CredentialManagerMock{},
+				ConfigManager:     &ConfigManagerMock{},
+			},
+			want:    croType.StatusMessage(""),
+			wantErr: false,
+		},
+		{
+			name: "test successful delete with no postgres and deletion of bundled network resources",
+			args: args{
+				postgresDeleteConfig:    &rds.DeleteDBInstanceInput{},
+				postgresCreateConfig:    &rds.CreateDBInstanceInput{},
+				pg:                      buildTestPostgresCR(),
+				networkManager:          buildMockNetworkManager(),
+				instanceSvc:             &mockRdsClient{dbInstances: []*rds.DBInstance{}},
+				standaloneNetworkExists: false,
 				isLastResource:          true,
 			},
 			fields: fields{

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -517,6 +517,17 @@ func (p *RedisProvider) deleteElasticacheCluster(ctx context.Context, networkMan
 			return croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
 		}
 	}
+
+	// in the case of standalone network not existing and the last resource is being deleted the
+	// bundled networking resources should be cleaned up similarly to standalone networking resources
+	// this involves the deletion of bundled elasticace and rds subnet group and ec2 security group
+	if !standaloneNetworkExists && isLastResource {
+		err := networkManager.DeleteBundledCloudResources(ctx)
+		if err != nil {
+			msg := "failed to delete bundled networking resources"
+			return croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
+		}
+	}
 	// remove the finalizer added by the provider
 	resources.RemoveFinalizer(&r.ObjectMeta, DefaultFinalizer)
 	if err := p.Client.Update(ctx, r); err != nil {

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -344,7 +344,7 @@ func Test_createRedisCluster(t *testing.T) {
 										},
 									}
 								},
-							)},
+								)},
 						}, nil
 					}
 				}),

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -2,9 +2,10 @@ package aws
 
 import (
 	"context"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"reflect"
 	"time"
+
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
@@ -44,17 +45,41 @@ type mockElasticacheClient struct {
 	wantErrList       bool
 	wantErrCreate     bool
 	wantErrDelete     bool
-	wantEmpty         bool
 	replicationGroups []*elasticache.ReplicationGroup
-	cacheSubnetGroup  []*elasticache.CacheSubnetGroup
 
 	// new approach for manually defined mocks
 	// to allow for simple overrides in test table declarations
-	modifyCacheSubnetGroupFn func(*elasticache.ModifyCacheSubnetGroupInput) (*elasticache.ModifyCacheSubnetGroupOutput, error)
+	modifyCacheSubnetGroupFn    func(*elasticache.ModifyCacheSubnetGroupInput) (*elasticache.ModifyCacheSubnetGroupOutput, error)
+	deleteCacheSubnetGroupFn    func(*elasticache.DeleteCacheSubnetGroupInput) (*elasticache.DeleteCacheSubnetGroupOutput, error)
+	describeCacheSubnetGroupsFn func(*elasticache.DescribeCacheSubnetGroupsInput) (*elasticache.DescribeCacheSubnetGroupsOutput, error)
+	describeCacheClustersFn     func(*elasticache.DescribeCacheClustersInput) (*elasticache.DescribeCacheClustersOutput, error)
+	describeReplicationGroupsFn func(*elasticache.DescribeReplicationGroupsInput) (*elasticache.DescribeReplicationGroupsOutput, error)
+	describeSnapshotsFn         func(*elasticache.DescribeSnapshotsInput) (*elasticache.DescribeSnapshotsOutput, error)
+	createSnapshotFn            func(*elasticache.CreateSnapshotInput) (*elasticache.CreateSnapshotOutput, error)
+	deleteSnapshotFn            func(*elasticache.DeleteSnapshotInput) (*elasticache.DeleteSnapshotOutput, error)
+
+	calls struct {
+		DescribeSnapshots []struct {
+			In1 *elasticache.DescribeSnapshotsInput
+		}
+		DescribeReplicationGroups []struct {
+			In1 *elasticache.DescribeReplicationGroupsInput
+		}
+		CreateSnapshot []struct {
+			In1 *elasticache.CreateSnapshotInput
+		}
+		DeleteSnapshot []struct {
+			In1 *elasticache.DeleteSnapshotInput
+		}
+	}
 }
 
 func buildMockElasticacheClient(modifyFn func(*mockElasticacheClient)) *mockElasticacheClient {
-	mock := &mockElasticacheClient{}
+	mock := &mockElasticacheClient{
+		describeCacheSubnetGroupsFn: func(input *elasticache.DescribeCacheSubnetGroupsInput) (*elasticache.DescribeCacheSubnetGroupsOutput, error) {
+			return &elasticache.DescribeCacheSubnetGroupsOutput{}, nil
+		},
+	}
 	if modifyFn != nil {
 		modifyFn(mock)
 	}
@@ -63,6 +88,20 @@ func buildMockElasticacheClient(modifyFn func(*mockElasticacheClient)) *mockElas
 
 type mockStsClient struct {
 	stsiface.STSAPI
+}
+
+func buildCacheClusterList(modifyFn func([]*elasticache.CacheCluster)) []*elasticache.CacheCluster {
+	mock := []*elasticache.CacheCluster{
+		{
+			CacheClusterStatus: aws.String("available"),
+			ReplicationGroupId: aws.String("test-id"),
+			EngineVersion:      aws.String(defaultEngineVersion),
+		},
+	}
+	if modifyFn != nil {
+		modifyFn(mock)
+	}
+	return mock
 }
 
 func buildTestSchemeRedis() (*runtime.Scheme, error) {
@@ -78,13 +117,15 @@ func buildTestSchemeRedis() (*runtime.Scheme, error) {
 }
 
 // mock elasticache DescribeReplicationGroups output
-func (m *mockElasticacheClient) DescribeReplicationGroups(*elasticache.DescribeReplicationGroupsInput) (*elasticache.DescribeReplicationGroupsOutput, error) {
-	if m.wantEmpty {
-		return &elasticache.DescribeReplicationGroupsOutput{}, nil
+func (m *mockElasticacheClient) DescribeReplicationGroups(input *elasticache.DescribeReplicationGroupsInput) (*elasticache.DescribeReplicationGroupsOutput, error) {
+	callInfo := struct {
+		In1 *elasticache.DescribeReplicationGroupsInput
+	}{
+		In1: input,
 	}
-	return &elasticache.DescribeReplicationGroupsOutput{
-		ReplicationGroups: m.replicationGroups,
-	}, nil
+	m.calls.DescribeReplicationGroups = append(m.calls.DescribeReplicationGroups, callInfo)
+	return m.describeReplicationGroupsFn(input)
+
 }
 
 // mock elasticache CreateReplicationGroup output
@@ -108,42 +149,66 @@ func (m *mockElasticacheClient) AddTagsToResource(*elasticache.AddTagsToResource
 }
 
 // mock elasticache DescribeSnapshots
-func (m *mockElasticacheClient) DescribeSnapshots(*elasticache.DescribeSnapshotsInput) (*elasticache.DescribeSnapshotsOutput, error) {
-	return &elasticache.DescribeSnapshotsOutput{}, nil
+func (m *mockElasticacheClient) DescribeSnapshots(input *elasticache.DescribeSnapshotsInput) (*elasticache.DescribeSnapshotsOutput, error) {
+	if m.describeSnapshotsFn == nil {
+		panic("describeSnapshotsFn: method is nil but elasticacheClient.DescribeSnapshots was just called")
+	}
+	callInfo := struct {
+		In1 *elasticache.DescribeSnapshotsInput
+	}{
+		In1: input,
+	}
+	m.calls.DescribeSnapshots = append(m.calls.DescribeSnapshots, callInfo)
+	return m.describeSnapshotsFn(input)
 }
 
-// mock elasticache DescribeCacheClustersGroups output
-func (m *mockElasticacheClient) DescribeCacheClusters(*elasticache.DescribeCacheClustersInput) (*elasticache.DescribeCacheClustersOutput, error) {
-	if m.wantEmpty {
-		return &elasticache.DescribeCacheClustersOutput{}, nil
+func (m *mockElasticacheClient) CreateSnapshot(input *elasticache.CreateSnapshotInput) (*elasticache.CreateSnapshotOutput, error) {
+	if m.createSnapshotFn == nil {
+		panic("createSnapshotFn: method is nil but elasticacheClient.CreateSnapshot was just called")
 	}
-	return &elasticache.DescribeCacheClustersOutput{
-		CacheClusters: []*elasticache.CacheCluster{
-			{
-				CacheClusterStatus: aws.String("available"),
-				ReplicationGroupId: aws.String("test-id"),
-				EngineVersion:      aws.String(defaultEngineVersion),
-			},
-		},
-	}, nil
+	callInfo := struct {
+		In1 *elasticache.CreateSnapshotInput
+	}{
+		In1: input,
+	}
+	m.calls.CreateSnapshot = append(m.calls.CreateSnapshot, callInfo)
+	return m.createSnapshotFn(input)
+}
+
+func (m *mockElasticacheClient) DeleteSnapshot(input *elasticache.DeleteSnapshotInput) (*elasticache.DeleteSnapshotOutput, error) {
+	if m.deleteSnapshotFn == nil {
+		panic("deleteSnapshotFn: method is nil but elasticacheClient.DeleteSnapshot was just called")
+	}
+	callInfo := struct {
+		In1 *elasticache.DeleteSnapshotInput
+	}{
+		In1: input,
+	}
+	m.calls.DeleteSnapshot = append(m.calls.DeleteSnapshot, callInfo)
+	return m.deleteSnapshotFn(input)
+}
+
+func (m *mockElasticacheClient) DescribeCacheClusters(input *elasticache.DescribeCacheClustersInput) (*elasticache.DescribeCacheClustersOutput, error) {
+	if m.describeCacheClustersFn == nil {
+		panic("describeCacheClustersFn: method is nil but elasticacheClient.DescribeCacheClusters was just called")
+	}
+	return m.describeCacheClustersFn(input)
 }
 
 func (m *mockElasticacheClient) DescribeServiceUpdates(*elasticache.DescribeServiceUpdatesInput) (*elasticache.DescribeServiceUpdatesOutput, error) {
 	return &elasticache.DescribeServiceUpdatesOutput{}, nil
 }
 
-func (m *mockElasticacheClient) DescribeCacheSubnetGroups(*elasticache.DescribeCacheSubnetGroupsInput) (*elasticache.DescribeCacheSubnetGroupsOutput, error) {
-	return &elasticache.DescribeCacheSubnetGroupsOutput{
-		CacheSubnetGroups: m.cacheSubnetGroup,
-	}, nil
+func (m *mockElasticacheClient) DescribeCacheSubnetGroups(input *elasticache.DescribeCacheSubnetGroupsInput) (*elasticache.DescribeCacheSubnetGroupsOutput, error) {
+	return m.describeCacheSubnetGroupsFn(input)
 }
 
 func (m *mockElasticacheClient) CreateCacheSubnetGroup(*elasticache.CreateCacheSubnetGroupInput) (*elasticache.CreateCacheSubnetGroupOutput, error) {
 	return &elasticache.CreateCacheSubnetGroupOutput{}, nil
 }
 
-func (m *mockElasticacheClient) DeleteCacheSubnetGroup(*elasticache.DeleteCacheSubnetGroupInput) (*elasticache.DeleteCacheSubnetGroupOutput, error) {
-	return &elasticache.DeleteCacheSubnetGroupOutput{}, nil
+func (m *mockElasticacheClient) DeleteCacheSubnetGroup(input *elasticache.DeleteCacheSubnetGroupInput) (*elasticache.DeleteCacheSubnetGroupOutput, error) {
+	return m.deleteCacheSubnetGroupFn(input)
 }
 
 func (m *mockElasticacheClient) ModifyCacheSubnetGroup(input *elasticache.ModifyCacheSubnetGroupInput) (*elasticache.ModifyCacheSubnetGroupOutput, error) {
@@ -175,35 +240,12 @@ func buildTestRedisCR() *v1alpha1.Redis {
 	}
 }
 
-func buildReplicationGroupPending() []*elasticache.ReplicationGroup {
-	return []*elasticache.ReplicationGroup{
-		{
-			ReplicationGroupId: aws.String("test-id"),
-			Status:             aws.String("pending"),
-		},
+func buildReplicationGroup(modifyFn func(*elasticache.ReplicationGroup)) *elasticache.ReplicationGroup {
+	mock := &elasticache.ReplicationGroup{}
+	if modifyFn != nil {
+		modifyFn(mock)
 	}
-}
-
-func buildReplicationGroupReady() []*elasticache.ReplicationGroup {
-	return []*elasticache.ReplicationGroup{
-		{
-			ReplicationGroupId:     aws.String("test-id"),
-			Status:                 aws.String("available"),
-			CacheNodeType:          aws.String("test"),
-			SnapshotRetentionLimit: aws.Int64(20),
-			NodeGroups: []*elasticache.NodeGroup{
-				{
-					NodeGroupId:      aws.String("primary-node"),
-					NodeGroupMembers: nil,
-					PrimaryEndpoint: &elasticache.Endpoint{
-						Address: testAddress,
-						Port:    testPort,
-					},
-					Status: aws.String("available"),
-				},
-			},
-		},
-	}
+	return mock
 }
 
 func buildTestRedisCluster() *providers.RedisCluster {
@@ -251,8 +293,12 @@ func Test_createRedisCluster(t *testing.T) {
 		{
 			name: "test elasticache buildReplicationGroupPending is called (valid cluster rhmi subnets)",
 			args: args{
-				ctx:                     context.TODO(),
-				cacheSvc:                &mockElasticacheClient{replicationGroups: []*elasticache.ReplicationGroup{}},
+				ctx: context.TODO(),
+				cacheSvc: buildMockElasticacheClient(func(elasticacheClient *mockElasticacheClient) {
+					elasticacheClient.describeReplicationGroupsFn = func(*elasticache.DescribeReplicationGroupsInput) (*elasticache.DescribeReplicationGroupsOutput, error) {
+						return &elasticache.DescribeReplicationGroupsOutput{}, nil
+					}
+				}),
 				ec2Svc:                  &mockEc2Client{vpcs: buildVpcs(), subnets: buildValidBundleSubnets(), secGroups: buildSecurityGroups(secName)},
 				r:                       buildTestRedisCR(),
 				stsSvc:                  &mockStsClient{},
@@ -273,8 +319,35 @@ func Test_createRedisCluster(t *testing.T) {
 		{
 			name: "test elasticache already exists and status is available (valid cluster rhmi subnets)",
 			args: args{
-				ctx:                     context.TODO(),
-				cacheSvc:                &mockElasticacheClient{replicationGroups: buildReplicationGroupReady()},
+				ctx: context.TODO(),
+				cacheSvc: buildMockElasticacheClient(func(elasticacheClient *mockElasticacheClient) {
+					elasticacheClient.describeCacheClustersFn = func(*elasticache.DescribeCacheClustersInput) (*elasticache.DescribeCacheClustersOutput, error) {
+						return &elasticache.DescribeCacheClustersOutput{}, nil
+					}
+					elasticacheClient.describeReplicationGroupsFn = func(*elasticache.DescribeReplicationGroupsInput) (*elasticache.DescribeReplicationGroupsOutput, error) {
+						return &elasticache.DescribeReplicationGroupsOutput{
+							ReplicationGroups: []*elasticache.ReplicationGroup{
+								buildReplicationGroup(func(group *elasticache.ReplicationGroup) {
+									group.ReplicationGroupId = aws.String("test-id")
+									group.Status = aws.String("available")
+									group.CacheNodeType = aws.String("test")
+									group.SnapshotRetentionLimit = aws.Int64(20)
+									group.NodeGroups = []*elasticache.NodeGroup{
+										{
+											NodeGroupId:      aws.String("primary-node"),
+											NodeGroupMembers: nil,
+											PrimaryEndpoint: &elasticache.Endpoint{
+												Address: testAddress,
+												Port:    testPort,
+											},
+											Status: aws.String("available"),
+										},
+									}
+								},
+							)},
+						}, nil
+					}
+				}),
 				ec2Svc:                  &mockEc2Client{vpcs: buildVpcs(), subnets: buildValidBundleSubnets(), secGroups: buildSecurityGroups(secName)},
 				r:                       buildTestRedisCR(),
 				stsSvc:                  &mockStsClient{},
@@ -295,8 +368,19 @@ func Test_createRedisCluster(t *testing.T) {
 		{
 			name: "test elasticache already exists and status is not available (valid cluster rhmi subnets)",
 			args: args{
-				ctx:                     context.TODO(),
-				cacheSvc:                &mockElasticacheClient{replicationGroups: buildReplicationGroupPending()},
+				ctx: context.TODO(),
+				cacheSvc: buildMockElasticacheClient(func(elasticacheClient *mockElasticacheClient) {
+					elasticacheClient.describeReplicationGroupsFn = func(*elasticache.DescribeReplicationGroupsInput) (*elasticache.DescribeReplicationGroupsOutput, error) {
+						return &elasticache.DescribeReplicationGroupsOutput{
+							ReplicationGroups: []*elasticache.ReplicationGroup{
+								buildReplicationGroup(func(group *elasticache.ReplicationGroup) {
+									group.ReplicationGroupId = aws.String("test-id")
+									group.Status = aws.String("pending")
+								}),
+							},
+						}, nil
+					}
+				}),
 				ec2Svc:                  &mockEc2Client{vpcs: buildVpcs(), subnets: buildValidBundleSubnets(), secGroups: buildSecurityGroups(secName)},
 				r:                       buildTestRedisCR(),
 				stsSvc:                  &mockStsClient{},
@@ -317,8 +401,35 @@ func Test_createRedisCluster(t *testing.T) {
 		{
 			name: "test elasticache exists and status is available and needs to be modified (valid cluster rhmi subnets)",
 			args: args{
-				ctx:                     context.TODO(),
-				cacheSvc:                &mockElasticacheClient{replicationGroups: buildReplicationGroupReady()},
+				ctx: context.TODO(),
+				cacheSvc: buildMockElasticacheClient(func(elasticacheClient *mockElasticacheClient) {
+					elasticacheClient.describeReplicationGroupsFn = func(*elasticache.DescribeReplicationGroupsInput) (*elasticache.DescribeReplicationGroupsOutput, error) {
+						return &elasticache.DescribeReplicationGroupsOutput{
+							ReplicationGroups: []*elasticache.ReplicationGroup{
+								buildReplicationGroup(func(group *elasticache.ReplicationGroup) {
+									group.ReplicationGroupId = aws.String("test-id")
+									group.Status = aws.String("available")
+									group.CacheNodeType = aws.String("test")
+									group.SnapshotRetentionLimit = aws.Int64(20)
+									group.NodeGroups = []*elasticache.NodeGroup{
+										{
+											NodeGroupId:      aws.String("primary-node"),
+											NodeGroupMembers: nil,
+											PrimaryEndpoint: &elasticache.Endpoint{
+												Address: testAddress,
+												Port:    testPort,
+											},
+											Status: aws.String("available"),
+										},
+									}
+								},
+								)},
+						}, nil
+					}
+					elasticacheClient.describeCacheClustersFn = func(*elasticache.DescribeCacheClustersInput) (*elasticache.DescribeCacheClustersOutput, error) {
+						return &elasticache.DescribeCacheClustersOutput{}, nil
+					}
+				}),
 				r:                       buildTestRedisCR(),
 				stsSvc:                  &mockStsClient{},
 				ec2Svc:                  &mockEc2Client{vpcs: buildVpcs(), subnets: buildValidBundleSubnets(), secGroups: buildSecurityGroups(secName)},
@@ -339,11 +450,38 @@ func Test_createRedisCluster(t *testing.T) {
 		{
 			name: "test elasticache exists and status is available and does not need to be modified (valid cluster rhmi subnets)",
 			args: args{
-				ctx:      context.TODO(),
-				cacheSvc: &mockElasticacheClient{replicationGroups: buildReplicationGroupReady()},
-				r:        buildTestRedisCR(),
-				stsSvc:   &mockStsClient{},
-				ec2Svc:   &mockEc2Client{vpcs: buildVpcs(), subnets: buildValidBundleSubnets(), secGroups: buildSecurityGroups(secName)},
+				ctx: context.TODO(),
+				cacheSvc: buildMockElasticacheClient(func(elasticacheClient *mockElasticacheClient) {
+					elasticacheClient.describeReplicationGroupsFn = func(*elasticache.DescribeReplicationGroupsInput) (*elasticache.DescribeReplicationGroupsOutput, error) {
+						return &elasticache.DescribeReplicationGroupsOutput{
+							ReplicationGroups: []*elasticache.ReplicationGroup{
+								buildReplicationGroup(func(group *elasticache.ReplicationGroup) {
+									group.ReplicationGroupId = aws.String("test-id")
+									group.Status = aws.String("available")
+									group.CacheNodeType = aws.String("test")
+									group.SnapshotRetentionLimit = aws.Int64(20)
+									group.NodeGroups = []*elasticache.NodeGroup{
+										{
+											NodeGroupId:      aws.String("primary-node"),
+											NodeGroupMembers: nil,
+											PrimaryEndpoint: &elasticache.Endpoint{
+												Address: testAddress,
+												Port:    testPort,
+											},
+											Status: aws.String("available"),
+										},
+									}
+								},
+								)},
+						}, nil
+					}
+					elasticacheClient.describeCacheClustersFn = func(*elasticache.DescribeCacheClustersInput) (*elasticache.DescribeCacheClustersOutput, error) {
+						return &elasticache.DescribeCacheClustersOutput{}, nil
+					}
+				}),
+				r:      buildTestRedisCR(),
+				stsSvc: &mockStsClient{},
+				ec2Svc: &mockEc2Client{vpcs: buildVpcs(), subnets: buildValidBundleSubnets(), secGroups: buildSecurityGroups(secName)},
 				redisConfig: &elasticache.CreateReplicationGroupInput{
 					ReplicationGroupId:     aws.String("test-id"),
 					CacheNodeType:          aws.String("test"),
@@ -365,8 +503,35 @@ func Test_createRedisCluster(t *testing.T) {
 		{
 			name: "test elasticache already exists and status is available (valid standalone rhmi subnets)",
 			args: args{
-				ctx:                     context.TODO(),
-				cacheSvc:                &mockElasticacheClient{replicationGroups: buildReplicationGroupReady()},
+				ctx: context.TODO(),
+				cacheSvc: buildMockElasticacheClient(func(elasticacheClient *mockElasticacheClient) {
+					elasticacheClient.describeReplicationGroupsFn = func(*elasticache.DescribeReplicationGroupsInput) (*elasticache.DescribeReplicationGroupsOutput, error) {
+						return &elasticache.DescribeReplicationGroupsOutput{
+							ReplicationGroups: []*elasticache.ReplicationGroup{
+								buildReplicationGroup(func(group *elasticache.ReplicationGroup) {
+									group.ReplicationGroupId = aws.String("test-id")
+									group.Status = aws.String("available")
+									group.CacheNodeType = aws.String("test")
+									group.SnapshotRetentionLimit = aws.Int64(20)
+									group.NodeGroups = []*elasticache.NodeGroup{
+										{
+											NodeGroupId:      aws.String("primary-node"),
+											NodeGroupMembers: nil,
+											PrimaryEndpoint: &elasticache.Endpoint{
+												Address: testAddress,
+												Port:    testPort,
+											},
+											Status: aws.String("available"),
+										},
+									}
+								},
+								)},
+						}, nil
+					}
+					elasticacheClient.describeCacheClustersFn = func(*elasticache.DescribeCacheClustersInput) (*elasticache.DescribeCacheClustersOutput, error) {
+						return &elasticache.DescribeCacheClustersOutput{}, nil
+					}
+				}),
 				ec2Svc:                  &mockEc2Client{secGroups: buildSecurityGroups(secName)},
 				r:                       buildTestRedisCR(),
 				stsSvc:                  &mockStsClient{},
@@ -451,7 +616,11 @@ func TestAWSRedisProvider_deleteRedisCluster(t *testing.T) {
 				Logger:            testLogger,
 				CredentialManager: &CredentialManagerMock{},
 				ConfigManager:     &ConfigManagerMock{},
-				CacheSvc:          &mockElasticacheClient{replicationGroups: []*elasticache.ReplicationGroup{}},
+				CacheSvc: buildMockElasticacheClient(func(elasticacheClient *mockElasticacheClient) {
+					elasticacheClient.describeReplicationGroupsFn = func(*elasticache.DescribeReplicationGroupsInput) (*elasticache.DescribeReplicationGroupsOutput, error) {
+						return &elasticache.DescribeReplicationGroupsOutput{}, nil
+					}
+				}),
 			},
 			wantErr: false,
 		},
@@ -470,7 +639,18 @@ func TestAWSRedisProvider_deleteRedisCluster(t *testing.T) {
 				Logger:            testLogger,
 				CredentialManager: &CredentialManagerMock{},
 				ConfigManager:     &ConfigManagerMock{},
-				CacheSvc:          &mockElasticacheClient{replicationGroups: buildReplicationGroupPending()},
+				CacheSvc: buildMockElasticacheClient(func(elasticacheClient *mockElasticacheClient) {
+					elasticacheClient.describeReplicationGroupsFn = func(*elasticache.DescribeReplicationGroupsInput) (*elasticache.DescribeReplicationGroupsOutput, error) {
+						return &elasticache.DescribeReplicationGroupsOutput{
+							ReplicationGroups: []*elasticache.ReplicationGroup{
+								buildReplicationGroup(func(group *elasticache.ReplicationGroup) {
+									group.ReplicationGroupId = aws.String("test-id")
+									group.Status = aws.String("pending")
+								}),
+							},
+						}, nil
+					}
+				}),
 			},
 			wantErr: false,
 		},
@@ -489,7 +669,31 @@ func TestAWSRedisProvider_deleteRedisCluster(t *testing.T) {
 				Logger:            testLogger,
 				CredentialManager: &CredentialManagerMock{},
 				ConfigManager:     &ConfigManagerMock{},
-				CacheSvc:          &mockElasticacheClient{replicationGroups: buildReplicationGroupReady()},
+				CacheSvc: buildMockElasticacheClient(func(elasticacheClient *mockElasticacheClient) {
+					elasticacheClient.describeReplicationGroupsFn = func(*elasticache.DescribeReplicationGroupsInput) (*elasticache.DescribeReplicationGroupsOutput, error) {
+						return &elasticache.DescribeReplicationGroupsOutput{
+							ReplicationGroups: []*elasticache.ReplicationGroup{
+								buildReplicationGroup(func(group *elasticache.ReplicationGroup) {
+									group.ReplicationGroupId = aws.String("test-id")
+									group.Status = aws.String("available")
+									group.CacheNodeType = aws.String("test")
+									group.SnapshotRetentionLimit = aws.Int64(20)
+									group.NodeGroups = []*elasticache.NodeGroup{
+										{
+											NodeGroupId:      aws.String("primary-node"),
+											NodeGroupMembers: nil,
+											PrimaryEndpoint: &elasticache.Endpoint{
+												Address: testAddress,
+												Port:    testPort,
+											},
+											Status: aws.String("available"),
+										},
+									}
+								},
+								)},
+						}, nil
+					}
+				}),
 			},
 			wantErr: false,
 		},
@@ -508,7 +712,33 @@ func TestAWSRedisProvider_deleteRedisCluster(t *testing.T) {
 				Logger:            testLogger,
 				CredentialManager: &CredentialManagerMock{},
 				ConfigManager:     &ConfigManagerMock{},
-				CacheSvc:          &mockElasticacheClient{replicationGroups: buildReplicationGroupReady(), wantEmpty: true},
+				CacheSvc: buildMockElasticacheClient(func(elasticacheClient *mockElasticacheClient) {
+					elasticacheClient.describeReplicationGroupsFn = func(*elasticache.DescribeReplicationGroupsInput) (*elasticache.DescribeReplicationGroupsOutput, error) {
+						return &elasticache.DescribeReplicationGroupsOutput{}, nil
+					}
+				}),
+			},
+			wantErr: false,
+		}, {
+			name: "test successful delete with no existing redis but with bundled network resources",
+			args: args{
+				networkManager:          buildMockNetworkManager(),
+				redisCreateConfig:       &elasticache.CreateReplicationGroupInput{ReplicationGroupId: aws.String("test-id")},
+				redisDeleteConfig:       &elasticache.DeleteReplicationGroupInput{ReplicationGroupId: aws.String("test-id")},
+				redis:                   buildTestRedisCR(),
+				standaloneNetworkExists: false,
+				isLastResource:          true,
+			},
+			fields: fields{
+				Client:            fake.NewFakeClientWithScheme(scheme, buildTestRedisCR(), builtTestCredSecret(), buildTestInfra(), buildTestPrometheusRule()),
+				Logger:            testLogger,
+				CredentialManager: &CredentialManagerMock{},
+				ConfigManager:     &ConfigManagerMock{},
+				CacheSvc: buildMockElasticacheClient(func(elasticacheClient *mockElasticacheClient) {
+					elasticacheClient.describeReplicationGroupsFn = func(*elasticache.DescribeReplicationGroupsInput) (*elasticache.DescribeReplicationGroupsOutput, error) {
+						return &elasticache.DescribeReplicationGroupsOutput{}, nil
+					}
+				}),
 			},
 			wantErr: false,
 		},
@@ -602,9 +832,18 @@ func TestAWSRedisProvider_TagElasticache(t *testing.T) {
 		{
 			name: "test tags reconcile completes successfully",
 			args: args{
-				ctx:      context.TODO(),
-				r:        buildTestRedisCR(),
-				cacheSvc: &mockElasticacheClient{replicationGroups: buildReplicationGroupReady()},
+				ctx: context.TODO(),
+				r:   buildTestRedisCR(),
+				cacheSvc: buildMockElasticacheClient(func(elasticacheClient *mockElasticacheClient) {
+					elasticacheClient.describeCacheClustersFn = func(input *elasticache.DescribeCacheClustersInput) (*elasticache.DescribeCacheClustersOutput, error) {
+						return &elasticache.DescribeCacheClustersOutput{
+							CacheClusters: buildCacheClusterList(nil),
+						}, nil
+					}
+					elasticacheClient.describeSnapshotsFn = func(input *elasticache.DescribeSnapshotsInput) (*elasticache.DescribeSnapshotsOutput, error) {
+						return &elasticache.DescribeSnapshotsOutput{}, nil
+					}
+				}),
 				stsSvc:   &mockStsClient{},
 				stratCfg: StrategyConfig{Region: "test"},
 				cache: &elasticache.NodeGroupMember{


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/INTLY-5160

Pushing an early pr for review to verify that the approach is good. 

## Verification

- Install cloud-resource-operator with bundled resources
  - git checkout v0.16.1 
  - `make cluster/prepare NAMESPACE=cloud-resource-operator-<name>`
  - `make cluster/seed/managed/redis NAMESPACE=clourd-resource-operator-<name>`
  - `make cluster/seed/managed/redis NAMESPACE=cloud-resource-operator-<name>`
  - `make run/local NAMESPACE=cloud-resource-operator-<name>`
  - Get the cluster vpc id by running `aws ec2 describe-vpcs` and noting the vpc id with the tag     ```{
                    "Key": "kubernetes.io/cluster/<clustername>-<randomchars>",
                    "Value": "owned"
                }```
  - Wait for the resources to install. The resources of interest are below and will follow naming syntax `<clustername><randomchars>subnetgroup` and `<clustername><randomchars>securitygroup` and an associated vpc noted above.
      - ec2 security group with security group 
      - rds subent group with the name similar to the below
      - elasticache subnet group with the name similar to the below

See images below for examples for cluster mw-colab-byoc - using ui rather than cli as there's problems with the cli for some of the resources.
<img width="270" alt="Screenshot 2020-07-07 at 15 25 10" src="https://user-images.githubusercontent.com/6498727/86796110-2947f400-c066-11ea-9441-d601240c21a7.png">
<img width="352" alt="Screenshot 2020-07-07 at 15 26 47" src="https://user-images.githubusercontent.com/6498727/86796260-51375780-c066-11ea-94d5-067c7ef99e32.png">
       - elasticache subnet group with the name similar to the below
<img width="605" alt="Screenshot 2020-07-07 at 15 27 46" src="https://user-images.githubusercontent.com/6498727/86796380-6f04bc80-c066-11ea-81b4-fb02dfba78f1.png">


- Run the operator with the deletion changes in place - i.e. use this branch
  - `git checkout INTLY-5160`
  - `make run NAMESPACE=cloud-resource-operator-<name>`
  - delete either a postgres or redis
  - wait for the resource and the cr to delete (this will take a few minutes as the postgres is deleted)
  - verify that the network resources (rds subnet group, elasticache group & ec2 security group) are still in place
      - check in the aws console as above
  - delete the remaining either postgres or redis
  - verify that the operator doesn't error on reconcile if any of the resources are removed.
  - verify that the network resources are deleted - verify in the aws console the resources listed above are deleted.


  
  