### PR TITLE
update makefile target run to use undeprecated flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build:
 
 .PHONY: run
 run:
-	RECTIME=30 $(OPERATOR_SDK) run --local --operator-namespace=$(NAMESPACE)
+	RECTIME=30 $(OPERATOR_SDK) run local --watch-namespace=$(NAMESPACE)
 
 .PHONY: setup/service_account
 setup/service_account:


### PR DESCRIPTION
## Overview
operator-sdk v0.19.0 is throwing deprecation warnings on 
```bash
operator-sdk run --local --operator-namespace=$(NAMESPACE)
```

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make run`
- Ensure... runs without the following notices
```
Flag --local has been deprecated, use 'run local' instead
Flag --operator-namespace has been deprecated, use this flag with 'run packagemanifests' instead
```