### PR TITLE
exposing provider metrics in controller

### DIFF
--- a/pkg/controller/cloudmetrics/cloudmetrics_controller.go
+++ b/pkg/controller/cloudmetrics/cloudmetrics_controller.go
@@ -5,9 +5,11 @@ package cloudmetrics
 
 import (
 	"context"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers"
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers/aws"
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
 	integreatlyv1alpha1 "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
@@ -17,9 +19,63 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	customMetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
+
+const (
+	postgresFreeStorageAverage = "cro_postgres_free_storage_average"
+
+	labelClusterIDKey   = "clusterID"
+	labelResourceIDKey  = "resourceID"
+	labelNamespaceKey   = "namespace"
+	labelInstanceIDKey  = "instanceID"
+	labelProductNameKey = "productName"
+	labelStrategyKey    = "strategy"
+)
+
+// generic list of label keys used for Gauge Vectors
+var labels = []string{
+	labelClusterIDKey,
+	labelResourceIDKey,
+	labelNamespaceKey,
+	labelInstanceIDKey,
+	labelProductNameKey,
+	labelStrategyKey,
+}
+
+// CroGaugeMetric allows for a mapping between an exposed prometheus metric and multiple cloud provider specific metric
+type CroGaugeMetric struct {
+	Name         string
+	GaugeVec     *prometheus.GaugeVec
+	ProviderType map[string]providers.CloudProviderMetricType
+}
+
+// postgresGaugeMetrics stores a mapping between an exposed (postgres) prometheus metric and multiple cloud provider specific metric
+// to add any addition metrics simply add to this mapping and it will be scraped and exposed
+var postgresGaugeMetrics = []CroGaugeMetric{
+	{
+		Name: postgresFreeStorageAverage,
+		GaugeVec: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: postgresFreeStorageAverage,
+				Help: "The amount of available storage space",
+			},
+			labels),
+		ProviderType: map[string]providers.CloudProviderMetricType{
+			providers.AWSDeploymentStrategy: {
+				PromethuesMetricName: postgresFreeStorageAverage,
+				ProviderMetricName:   "FreeStorageSpace",
+				Statistic:            cloudwatch.StatisticAverage,
+			},
+		},
+	},
+}
+
+// redisGaugeMetrics stores a mapping between an exposed (redis) prometheus metric and multiple cloud provider specific metric
+// to add any addition metrics simply add to this mapping and it will be scraped and exposed
+var redisGaugeMetrics []CroGaugeMetric
 
 // Add creates a new CloudMetrics Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -33,6 +89,12 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	logger := logrus.WithFields(logrus.Fields{"controller": "controller_cloudmetrics"})
 	postgresProviderList := []providers.PostgresMetricsProvider{aws.NewAWSPostgresMetricsProvider(c, logger)}
 	redisProviderList := []providers.RedisMetricsProvider{aws.NewAWSRedisMetricsProvider(c, logger)}
+
+	// we only wish to register metrics once when the new reconciler is created
+	// as the metrics we want to expose are known in advance we can register them all
+	// they will only be exposed if there is a value returned for the vector for a provider
+	registerGaugeVectorMetrics(logger)
+
 	return &ReconcileCloudMetrics{
 		client:               mgr.GetClient(),
 		scheme:               mgr.GetScheme(),
@@ -85,28 +147,33 @@ type ReconcileCloudMetrics struct {
 	redisProviderList    []providers.RedisMetricsProvider
 }
 
-// Reconcile reads all redis and postgres crs periodically and reconcile metrics for these
+// reconcile reads all redis and postgres crs periodically and reconcile metrics for these
 // resources.
-// The Controller will requeue the Request every 5 minutes constantly when RequeueAfter is set
+// the Controller will requeue the Request every 5 minutes constantly when RequeueAfter is set
 func (r *ReconcileCloudMetrics) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	r.logger.Info("reconciling CloudMetrics")
 	ctx := context.Background()
 
-	// Fetch all redis crs
+	// scrapedMetrics stores the GenericCloudMetric which are returned from the providers
+	var scrapedMetrics []*providers.GenericCloudMetric
+
+	// fetch all redis crs
 	redisInstances := &integreatlyv1alpha1.RedisList{}
 	err := r.client.List(ctx, redisInstances)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+
+	// loop through the redis crs and scrape the related provider specific metrics
 	for _, redis := range redisInstances.Items {
-		r.logger.Infof("beginning to reconcile cloud metrics for redis cr: %s", redis.Name)
+		r.logger.Infof("beginning to scrape metrics for redis cr: %s", redis.Name)
 		for _, p := range r.redisProviderList {
 			// only scrape metrics on supported strategies
 			if !p.SupportsStrategy(redis.Status.Strategy) {
 				continue
 			}
 
-			// all redis metric providers inherit the same interface
+			// all redis scrapedMetric providers inherit the same interface
 			// scrapeMetrics returns scraped metrics output which contains a list of GenericCloudMetrics
 			scrapedMetricsOutput, err := p.ScrapeRedisMetrics(ctx, &redis)
 			if err != nil {
@@ -115,7 +182,7 @@ func (r *ReconcileCloudMetrics) Reconcile(request reconcile.Request) (reconcile.
 			}
 
 			for _, metricData := range scrapedMetricsOutput.Metrics {
-				r.logger.Debug(*metricData)
+				scrapedMetrics = append(scrapedMetrics, metricData)
 			}
 		}
 	}
@@ -127,23 +194,52 @@ func (r *ReconcileCloudMetrics) Reconcile(request reconcile.Request) (reconcile.
 		r.logger.Error(err)
 	}
 	for _, postgres := range postgresInstances.Items {
-		r.logger.Infof("beginning to reconcile cloud metrics for postgres cr: %s", postgres.Name)
+		r.logger.Infof("beginning to scrape metrics for postgres cr: %s", postgres.Name)
 		for _, p := range r.postgresProviderList {
 			// only scrape metrics on supported strategies
 			if !p.SupportsStrategy(postgres.Status.Strategy) {
 				continue
 			}
 
-			// all postgres metric providers inherit the same interface
+			// filter out the provider specific metric from the postgresGaugeMetrics map which defines the metrics we want to scrape
+			var postgresMetricTypes []providers.CloudProviderMetricType
+			for _, gaugeMetric := range postgresGaugeMetrics {
+				for provider, metricType := range gaugeMetric.ProviderType {
+					if provider == postgres.Status.Strategy {
+						postgresMetricTypes = append(postgresMetricTypes, metricType)
+						continue
+					}
+				}
+			}
+
+			// all postgres scrapedMetric providers inherit the same interface
 			// scrapeMetrics returns scraped metrics output which contains a list of GenericCloudMetrics
-			scrapedMetricsOutput, err := p.ScrapePostgresMetrics(ctx, &postgres)
+			scrapedMetricsOutput, err := p.ScrapePostgresMetrics(ctx, &postgres, postgresMetricTypes)
 			if err != nil {
 				r.logger.Errorf("failed to scrape metrics for postgres %v", err)
 				continue
 			}
 
+			// add the returned scraped metrics to the list of metrics
 			for _, metricData := range scrapedMetricsOutput.Metrics {
-				r.logger.Debug(*metricData)
+				scrapedMetrics = append(scrapedMetrics, metricData)
+			}
+		}
+	}
+
+	// for each scraped metric value we check postgresGaugeMetrics for a match and set the value and labels
+	for _, scrapedMetric := range scrapedMetrics {
+		for _, croMetric := range postgresGaugeMetrics {
+			if scrapedMetric.Name == croMetric.Name {
+				croMetric.GaugeVec.WithLabelValues(
+					scrapedMetric.Labels[labelClusterIDKey],
+					scrapedMetric.Labels[labelResourceIDKey],
+					scrapedMetric.Labels[labelNamespaceKey],
+					scrapedMetric.Labels[labelInstanceIDKey],
+					scrapedMetric.Labels[labelProductNameKey],
+					scrapedMetric.Labels[labelStrategyKey]).Set(scrapedMetric.Value)
+				r.logger.Infof("successfully set metric value for %s", croMetric.Name)
+				continue
 			}
 		}
 	}
@@ -155,4 +251,15 @@ func (r *ReconcileCloudMetrics) Reconcile(request reconcile.Request) (reconcile.
 	return reconcile.Result{
 		RequeueAfter: resources.GetMetricReconcileTimeOrDefault(resources.MetricsWatchDuration),
 	}, nil
+}
+
+func registerGaugeVectorMetrics(logger *logrus.Entry) {
+	for _, metric := range postgresGaugeMetrics {
+		logger.Infof("registering metric: %s ", metric.Name)
+		customMetrics.Registry.MustRegister(metric.GaugeVec)
+	}
+	for _, metric := range redisGaugeMetrics {
+		logger.Infof("registering metric: %s ", metric.Name)
+		customMetrics.Registry.MustRegister(metric.GaugeVec)
+	}
 }

--- a/pkg/providers/aws/provider_postgres_metrics_test.go
+++ b/pkg/providers/aws/provider_postgres_metrics_test.go
@@ -29,11 +29,11 @@ var testMetricLabels = map[string]string{
 	"strategy":    "aws-rds",
 }
 
-func buildProviderMetricType(modifyFn func(*providers.CloudProviderMetricType)) providers.CloudProviderMetricType{
+func buildProviderMetricType(modifyFn func(*providers.CloudProviderMetricType)) providers.CloudProviderMetricType {
 	mock := &providers.CloudProviderMetricType{
 		PromethuesMetricName: testMetricName,
-		ProviderMetricName: "test",
-		Statistic: "test",
+		ProviderMetricName:   "test",
+		Statistic:            "test",
 	}
 	if modifyFn != nil {
 		modifyFn(mock)
@@ -56,7 +56,7 @@ func TestPostgresMetricsProvider_scrapeRDSCloudWatchMetricData(t *testing.T) {
 		ctx           context.Context
 		cloudWatchApi cloudwatchiface.CloudWatchAPI
 		postgres      *v1alpha1.Postgres
-		metricTypes  []providers.CloudProviderMetricType
+		metricTypes   []providers.CloudProviderMetricType
 	}
 	tests := []struct {
 		name    string

--- a/pkg/providers/aws/provider_postgres_metrics_test.go
+++ b/pkg/providers/aws/provider_postgres_metrics_test.go
@@ -29,6 +29,18 @@ var testMetricLabels = map[string]string{
 	"strategy":    "aws-rds",
 }
 
+func buildProviderMetricType(modifyFn func(*providers.CloudProviderMetricType)) providers.CloudProviderMetricType{
+	mock := &providers.CloudProviderMetricType{
+		PromethuesMetricName: testMetricName,
+		ProviderMetricName: "test",
+		Statistic: "test",
+	}
+	if modifyFn != nil {
+		modifyFn(mock)
+	}
+	return *mock
+}
+
 func TestPostgresMetricsProvider_scrapeRDSCloudWatchMetricData(t *testing.T) {
 	scheme, err := buildTestScheme()
 	if err != nil {
@@ -44,6 +56,7 @@ func TestPostgresMetricsProvider_scrapeRDSCloudWatchMetricData(t *testing.T) {
 		ctx           context.Context
 		cloudWatchApi cloudwatchiface.CloudWatchAPI
 		postgres      *v1alpha1.Postgres
+		metricTypes  []providers.CloudProviderMetricType
 	}
 	tests := []struct {
 		name    string
@@ -77,6 +90,9 @@ func TestPostgresMetricsProvider_scrapeRDSCloudWatchMetricData(t *testing.T) {
 					}
 				}),
 				postgres: buildTestPostgresCR(),
+				metricTypes: []providers.CloudProviderMetricType{
+					buildProviderMetricType(func(metricType *providers.CloudProviderMetricType) {}),
+				},
 			},
 			want: []*providers.GenericCloudMetric{
 				{
@@ -115,6 +131,9 @@ func TestPostgresMetricsProvider_scrapeRDSCloudWatchMetricData(t *testing.T) {
 					}
 				}),
 				postgres: buildTestPostgresCR(),
+				metricTypes: []providers.CloudProviderMetricType{
+					buildProviderMetricType(func(metricType *providers.CloudProviderMetricType) {}),
+				},
 			},
 			want: []*providers.GenericCloudMetric{
 				{
@@ -141,6 +160,9 @@ func TestPostgresMetricsProvider_scrapeRDSCloudWatchMetricData(t *testing.T) {
 					}
 				}),
 				postgres: buildTestPostgresCR(),
+				metricTypes: []providers.CloudProviderMetricType{
+					buildProviderMetricType(func(metricType *providers.CloudProviderMetricType) {}),
+				},
 			},
 			wantErr: true,
 		},
@@ -153,7 +175,7 @@ func TestPostgresMetricsProvider_scrapeRDSCloudWatchMetricData(t *testing.T) {
 				CredentialManager: tt.fields.CredentialManager,
 				ConfigManager:     tt.fields.ConfigManager,
 			}
-			got, err := p.scrapeRDSCloudWatchMetricData(tt.args.ctx, tt.args.cloudWatchApi, tt.args.postgres)
+			got, err := p.scrapeRDSCloudWatchMetricData(tt.args.ctx, tt.args.cloudWatchApi, tt.args.postgres, tt.args.metricTypes)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("scrapeRDSCloudWatchMetricData() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/providers/types.go
+++ b/pkg/providers/types.go
@@ -151,5 +151,5 @@ type RedisMetricsProvider interface {
 
 type PostgresMetricsProvider interface {
 	SupportsStrategy(s string) bool
-	ScrapePostgresMetrics(ctx context.Context, postgres *v1alpha1.Postgres) (*ScrapeMetricsData, error)
+	ScrapePostgresMetrics(ctx context.Context, postgres *v1alpha1.Postgres, metricTypes []CloudProviderMetricType) (*ScrapeMetricsData, error)
 }


### PR DESCRIPTION
Co-authored-by: ciaranRoche <croche@redhat.com>

## Overview

Jira: https://issues.redhat.com/browse/INTLY-7226
Jira: https://issues.redhat.com/browse/INTLY-7229
Jira: https://issues.redhat.com/browse/INTLY-7230

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make cluster/seed/managed/postgres` - do this twice if you like. :D 
- Run `make run`
- Run `curl localhost:8383/metrics | grep cro_postgres_`
- You should see output similar to: 
```
╭─croche@localhost ~/Projects/integreatly/cloud-resource-operator ‹intly-7226› 
╰─$ curl localhost:8383/metrics | grep cro_postgres_                                                                                                                                                                             130 ↵

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
# HELP cro_postgres_cpu_utilization_average The percentage of CPU utilization. Units: Percent
# TYPE cro_postgres_cpu_utilization_average gauge
cro_postgres_cpu_utilization_average{clusterID="hcd-rhmi-clouds-6pdvc",instanceID="hcdrhmiclouds6pdvccloudresourceoper-eu6t",namespace="cloud-resource-operator",productName="productName",resourceID="example-postgres",strategy="aws-rds"} 1.5
cro_postgres_cpu_utilization_average{clusterID="hcd-rhmi-clouds-6pdvc",instanceID="hcdrhmiclouds6pdvccloudresourceoper-zaj2",namespace="cloud-resource-operator",productName="productName",resourceID="example-postgres-metric",strategy="aws-rds"} 1.8
# HELP cro_postgres_free_storage_average The amount of available storage space. Units: Bytes
# TYPE cro_postgres_free_storage_average gauge
cro_postgres_free_storage_average{clusterID="hcd-rhmi-clouds-6pdvc",instanceID="hcdrhmiclouds6pdvccloudresourceoper-eu6t",namespace="cloud-resource-operator",productName="productName",resourceID="example-postgres",strategy="aws-rds"} 2.00888623104e+10
cro_postgres_free_storage_average{clusterID="hcd-rhmi-clouds-6pdvc",instanceID="hcdrhmiclouds6pdvccloudresourceoper-zaj2",namespace="cloud-resource-operator",productName="productName",resourceID="example-postgres-metric",strategy="aws-rds"} 2.00888614912e+10
# HELP cro_postgres_freeable_memory_average The amount of available random access memory. Units: Bytes
# TYPE cro_postgres_freeable_memory_average gauge
cro_postgres_freeable_memory_average{clusterID="hcd-rhmi-clouds-6pdvc",instanceID="hcdrhmiclouds6pdvccloudresourceoper-eu6t",namespace="cloud-resource-operator",productName="productName",resourceID="example-postgres",strategy="aws-rds"} 9.495584768e+08
cro_postgres_freeable_memory_average{clusterID="hcd-rhmi-clouds-6pdvc",instanceID="hcdrhmiclouds6pdvccloudresourceoper-zaj2",namespace="cloud-resource-operator",productName="productName",resourceID="example-postgres-metric",strategy="aws-rds"} 9.441558528e+08
100 33247    0 33247    0     0  6493k      0 --:--:-- --:--:-- --:--:-- 6493k


```