### PR TITLE
ensure duplicate azs are never used

### DIFF
--- a/pkg/providers/aws/cluster_network_provider.go
+++ b/pkg/providers/aws/cluster_network_provider.go
@@ -1041,13 +1041,18 @@ func (n *NetworkProvider) reconcileStandaloneVPCSubnets(ctx context.Context, log
 	}
 
 	// filter the availability zones to only include ones that support the default instance types.
+	// ensure if any duplicate regions are returned, they are removed.
 	var supportedAzs []*ec2.AvailabilityZone
 	for _, az := range azs.AvailabilityZones {
+		foundAz := false
 		for _, instanceTypeOffering := range describeInstanceTypeOfferingsOutput.InstanceTypeOfferings {
 			if aws.StringValue(instanceTypeOffering.Location) == aws.StringValue(az.ZoneName) {
-				supportedAzs = append(supportedAzs, az)
-				continue
+				foundAz = true
+				break
 			}
+		}
+		if foundAz {
+			supportedAzs = append(supportedAzs, az)
 		}
 	}
 


### PR DESCRIPTION
currently it is possible that duplicate azs in a region are used
to attempt to create a subnet group, under two conditions.

- aws returns a duplicate set of subnet groups
- a legacy subnet exists

ensure that duplicate azs are never used in subnet creation by
filtering out any duplicates.

verification:
- run 'make run'
- create a redis and postgres instance
- ensure both instances are created successfully in aws