### PR TITLE
add EngineCpuUtilizationAverage metric

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -2,4 +2,6 @@
 
 A bunch of files and scripts to aid in development of the repo
 
+- `redis` - Dir to store helpers specific to redis
+- `postgres` - Dir to store helpers specific to postgres
 - `send_mail.go` - Can be used to send mail via a remote SMTP server. Used for quick verification of SMTP provider credentials.

--- a/hack/postgres/README.md
+++ b/hack/postgres/README.md
@@ -3,30 +3,42 @@
 Scripts to load postgres (AWS) with data to easily allow and test alerting
 
 ## Usage 
+### Prerequisites
+```
+export ns=cloud-resources-load-test
+# Spin up workshop `postgres` instance
+make cluster/prepare NAMESPACE=$ns
+make cluster/seed/workshop/postgres NAMESPACE=$ns
+make run NAMESPACE=$ns
+
+
+# In another terminal window run
+export ns=cloud-resources-load-test
+export aws_rds_db_host=<your-db-host.rds.amazonaws.com>
+export aws_rds_db_password=<password>
+# Size to fill in GiB
+export load_data_size=<number>
+
+# Get postgres workshop pod name
+export pod_name=$(oc get pods -n $ns -o jsonpath='{.items[0].metadata.name}')
+```
 ### Load Script
-Seed a workshop `postgres` instance
-```
-make cluster/seed/workshop/postgres
-```
+
 Copy `load.sh` file to provisioned postgres workshop pod  
 ```
- oc cp load.sh <<namespace>>/<<pod name>>:/var/lib/pgsql
+oc cp load.sh $ns/$pod_name:/var/lib/pgsql
 ```
 Run command
 ``` 
-oc exec oc exec <<pod name>> sh /var/lib/pgsql/load.sh <<host>> <<postgres password>> <<size to fill in GiB>> -n <<namespace>> sh /var/lib/pgsql/load.sh <<host>> <<postgres password>> <<size to fill in GiB>>
+oc exec $pod_name sh /var/lib/pgsql/load.sh $aws_rds_db_host $aws_rds_db_password $load_data_size -n $ns
 ```
 
 ### Clean Script
-Seed a workshop `postgres` instance
+Copy `clean.sh` file to provisioned postgres workshop pod  
 ```
-make cluster/seed/workshop/postgres
-```
-Copy `load.sh` file to provisioned postgres workshop pod  
-```
- oc cp clean.sh <<namespace>>/<<pod name>>:/var/lib/pgsql
+ oc cp clean.sh $ns/$pod_name:/var/lib/pgsql
 ```
 Run command
 ``` 
-oc exec oc exec <<pod name>> sh /var/lib/pgsql/clean.sh <<host>> <<postgres password>>
+oc exec $pod_name sh /var/lib/pgsql/clean.sh $aws_rds_db_host $aws_rds_db_password -n $ns
 ```

--- a/hack/postgres/README.md
+++ b/hack/postgres/README.md
@@ -1,9 +1,10 @@
 # Postgres 
 
-Scripts to load postgres (AWS) with data to easily allow and test alerting
+Scripts and helpers for working with postgres 
 
-## Usage 
-### Prerequisites
+## Load Testing Postgres AWS (RDS)
+### Usage 
+#### Prerequisites
 ```
 export ns=cloud-resources-load-test
 # Spin up workshop `postgres` instance
@@ -22,7 +23,7 @@ export load_data_size=<number>
 # Get postgres workshop pod name
 export pod_name=$(oc get pods -n $ns -o jsonpath='{.items[0].metadata.name}')
 ```
-### Load Script
+#### Load Script
 
 Copy `load.sh` file to provisioned postgres workshop pod  
 ```
@@ -33,7 +34,7 @@ Run command
 oc exec $pod_name sh /var/lib/pgsql/load.sh $aws_rds_db_host $aws_rds_db_password $load_data_size -n $ns
 ```
 
-### Clean Script
+#### Clean Script
 Copy `clean.sh` file to provisioned postgres workshop pod  
 ```
  oc cp clean.sh $ns/$pod_name:/var/lib/pgsql

--- a/hack/postgres/README.md
+++ b/hack/postgres/README.md
@@ -1,0 +1,32 @@
+# Postgres 
+
+Scripts to load postgres (AWS) with data to easily allow and test alerting
+
+## Usage 
+### Load Script
+Seed a workshop `postgres` instance
+```
+make cluster/seed/workshop/postgres
+```
+Copy `load.sh` file to provisioned postgres workshop pod  
+```
+ oc cp load.sh <<namespace>>/<<pod name>>:/var/lib/pgsql
+```
+Run command
+``` 
+oc exec oc exec <<pod name>> sh /var/lib/pgsql/load.sh <<host>> <<postgres password>> <<size to fill in GiB>> -n <<namespace>> sh /var/lib/pgsql/load.sh <<host>> <<postgres password>> <<size to fill in GiB>>
+```
+
+### Clean Script
+Seed a workshop `postgres` instance
+```
+make cluster/seed/workshop/postgres
+```
+Copy `load.sh` file to provisioned postgres workshop pod  
+```
+ oc cp clean.sh <<namespace>>/<<pod name>>:/var/lib/pgsql
+```
+Run command
+``` 
+oc exec oc exec <<pod name>> sh /var/lib/pgsql/clean.sh <<host>> <<postgres password>>
+```

--- a/hack/postgres/clean.sh
+++ b/hack/postgres/clean.sh
@@ -1,0 +1,20 @@
+PG_HOST=$1
+PG_PASS=$2
+
+if [ -z "${PG_HOST}" ]; then
+  echo "Host not set - exiting"
+  exit 1
+fi
+
+if [ -z "${PG_PASS}" ]; then
+  echo "Password not set - exiting"
+  exit 1
+fi
+
+PG_USER=postgres
+PG_PORT=5432
+PG_DB=postgres
+
+PGPASSWORD=$PG_PASS psql --host=$PG_HOST --port=$PG_PORT --username=$PG_USER --dbname=$PG_DB -c 'DROP TABLE stuff'
+
+

--- a/hack/postgres/load.sh
+++ b/hack/postgres/load.sh
@@ -1,0 +1,44 @@
+PG_HOST=$1
+PG_PASS=$2
+PG_SIZE=$3
+
+PG_USER=postgres
+PG_PORT=5432
+PG_DB=postgres
+
+calc_fill() {
+  # 225000 entries required to fill 1GiB of storage
+  ONE_GIB=225000
+  PG_FILL=$(($PG_SIZE * $ONE_GIB))
+}
+
+# create `stuff` table if one does not exist
+create_table() {
+  echo "Creating Table in $PG_HOST"
+  PGPASSWORD=$PG_PASS psql --host="$PG_HOST" --port="$PG_PORT" --username="$PG_USER" --dbname="$PG_DB" -a -c "CREATE TABLE IF NOT EXISTS stuff (thing varchar, otherthing varchar, anotherthing varchar, thirdthing varchar);"
+}
+
+# insert `calc_fill` entries into the table over a 2 hour period
+insert_data() {
+  calc_fill
+  INSERT="insert into stuff (thing, otherthing, anotherthing, thirdthing) select md5(random()::text), md5(random()::text), md5(random()::text), md5(random()::text) from generate_series(1, $PG_FILL) s(i);"
+
+  echo "Starting Load"
+  i="0"
+  while [ $i -lt 24 ]
+  do
+    echo "loading data iteration $i"
+    PGPASSWORD=$PG_PASS psql --host="$PG_HOST" --port="$PG_PORT" --username="$PG_USER" --dbname="$PG_DB" -a -c "$INSERT"
+    sleep 5m
+    i=$[$i+1]
+  done
+}
+
+# ensure all params are passed before executing psql commands.
+if [ -z "${PG_HOST}" ] | [ -z "${PG_PASS}" ] | [ -z "${PG_SIZE}" ]; then
+  echo "host, password, and entry count required and not set - exiting"
+  exit 1
+fi
+
+create_table
+insert_data

--- a/hack/postgres/load.sh
+++ b/hack/postgres/load.sh
@@ -8,7 +8,7 @@ PG_DB=postgres
 
 calc_fill() {
   # 225000 entries required to fill 1GiB of storage
-  ONE_GIB=225000
+  ONE_GIB=300000
   PG_FILL=$(($PG_SIZE * $ONE_GIB))
 }
 

--- a/hack/redis/README.md
+++ b/hack/redis/README.md
@@ -1,0 +1,22 @@
+# Redis
+
+Scripts and helpers for working with Redis
+
+## Load Testing Redis AWS (Elasticache)
+The following is taking from (redis-load)[https://github.com/ciaranRoche/redis-load] which generates random entries to redis
+### Usage 
+#### Prerequisites
+```
+export ns=<<namespace you want to deploy the load generator>>
+```
+#### Run Load Generator
+``` 
+oc create -f redis-load.yaml -n $ns
+oc process redis-load-template -p HOST=<<redis host>> -p PORT=6379 -p ENTRIES=<<no of entries to create>> -p USERS=<<no of concurrent user>> | oc create -f - 
+```
+
+#### Clean up Load Generator 
+``` 
+oc delete deployment -n $ns
+oc delete templates redis-load-template -n $ns
+```

--- a/hack/redis/README.md
+++ b/hack/redis/README.md
@@ -3,20 +3,20 @@
 Scripts and helpers for working with Redis
 
 ## Load Testing Redis AWS (Elasticache)
-The following is taking from (redis-load)[https://github.com/ciaranRoche/redis-load] which generates random entries to redis
+The deployments is taking from the source `redis-load` generates random entries to redis
 ### Usage 
 #### Prerequisites
 ```
 export ns=<<namespace you want to deploy the load generator>>
+export cr=<<name of redis cr>>
 ```
 #### Run Load Generator
 ``` 
-oc create -f redis-load.yaml -n $ns
-oc process redis-load-template -p HOST=<<redis host>> -p PORT=6379 -p ENTRIES=<<no of entries to create>> -p USERS=<<no of concurrent user>> | oc create -f - 
+oc process -f redis-load-test.yaml -p HOST=$(oc get secret -n $ns $(oc get redis $cr -n $ns -o jsonpath='{.status.secretRef.name}') -o jsonpath='{.data.uri}' | base64 --decode) -p PORT=6379 -p ENTRIES=<<no of entries>> -p USERS=<<no of concurrent users>> | oc create -f - -n $ns
 ```
+_Note roughly `50000` entries for `1` user will cause a `1%` memory usage jump for standard `cache.t3.micro` instance_
 
 #### Clean up Load Generator 
 ``` 
 oc delete deployment -n $ns
-oc delete templates redis-load-template -n $ns
 ```

--- a/hack/redis/redis-load-test.yaml
+++ b/hack/redis/redis-load-test.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: redis-load-template
+  annotations:
+    description: "load testing redis"
+    iconClass: "icon-redis"
+objects:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: redis-load
+    spec:
+      strategy:
+        type: Recreate
+      selector:
+        matchLabels:
+          app: redis-load
+      replicas: 1
+      template:
+        metadata:
+          labels:
+            app: redis-load
+        spec:
+          containers:
+            - env:
+                - name: PORT
+                  value: ${PORT}
+                - name: HOST
+                  value: ${HOST}
+                - name: ENTRIES
+                  value: ${ENTRIES}
+                - name: USERS
+                  value: ${USERS}
+              name: redis-load
+              image: quay.io/croche/redis-load:latest
+              ports:
+                - containerPort: 80
+parameters:
+  - name: PORT
+    description: redis port
+
+  - name: HOST
+    description: redis host
+
+  - name: ENTRIES
+    description: number of entries you require to redis
+
+  - name: USERS
+    description: number of concurrent users you want to create entries to redis

--- a/hack/redis/redis-load/Dockerfile
+++ b/hack/redis/redis-load/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+COPY redis-load .
+ENTRYPOINT [ "./redis-load" ]

--- a/hack/redis/redis-load/go.mod
+++ b/hack/redis/redis-load/go.mod
@@ -1,0 +1,8 @@
+module github.com/integr8ly/cloud-resource-operator/hack/redis/redis-load
+
+go 1.13
+
+require (
+	github.com/gomodule/redigo v2.0.0+incompatible
+	github.com/sirupsen/logrus v1.6.0
+)

--- a/hack/redis/redis-load/go.sum
+++ b/hack/redis/redis-load/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
+github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
+github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/hack/redis/redis-load/main.go
+++ b/hack/redis/redis-load/main.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"github.com/gomodule/redigo/redis"
+	"github.com/integr8ly/cloud-resource-operator/hack/redis/redis-load/pkg/concurrency"
+	croString "github.com/integr8ly/cloud-resource-operator/hack/redis/redis-load/pkg/string"
+	"github.com/sirupsen/logrus"
+	"os"
+	"strconv"
+)
+
+type LoadOptions struct {
+	host    string
+	port    string
+	entries int
+	users   int
+}
+
+func main() {
+	logger := logrus.WithFields(logrus.Fields{"action": "running redis load"})
+	logger.Info("starting redis load pre-reqs")
+
+	options, err := prerequisites()
+	if err != nil {
+		logger.Fatalf("prerequisites failed %v", err)
+	}
+	logger.Info("prerequisites passed")
+
+	makeNoise := func() {
+		logger := logrus.WithFields(logrus.Fields{"action": "makeNoise"})
+		connectionString := fmt.Sprintf("%s:%s", options.host, options.port)
+		logger.Infof("trying to connect to %s", connectionString)
+		conn, err := redis.Dial("tcp", connectionString)
+		if err != nil {
+			logger.Fatal(err)
+		}
+		logger.Infof("connection made to %s", connectionString)
+		defer conn.Close()
+
+		count := 0
+		for count < options.entries {
+			entry := fmt.Sprintf("stuff:%s", croString.RandomString(42))
+
+			logger.Infof("adding stuff entry %s", entry)
+			_, err = conn.Do("HMSET", entry, "stuff", "all the stuff", "n thangs", "mo stuff", "no stuff", 42)
+			if err != nil {
+				logger.Fatal(err)
+				logrus.Info("stuff added")
+			}
+
+			count++
+		}
+	}
+
+	count := 0
+	var funcs []func()
+	for count < options.users {
+		funcs = append(funcs, makeNoise)
+		count++
+	}
+
+	concurrency.ConcurrentFuncs(funcs)
+	logger.Info("no more noise")
+}
+
+func prerequisites() (*LoadOptions, error) {
+	logger := logrus.WithFields(logrus.Fields{"action": "running prerequisites"})
+	logger.Info("starting redis load pre-reqs")
+
+	host, hostExists := os.LookupEnv("HOST")
+	port, portExists := os.LookupEnv("PORT")
+	entries, entriesExists := os.LookupEnv("ENTRIES")
+	users, usersExist := os.LookupEnv("USERS")
+
+	if !hostExists || !portExists || !entriesExists || !usersExist {
+		logger.Error("host, port, entries or users env missing")
+		return nil, errors.New("host, port, entries or users env missing")
+	}
+
+	noEntries, err := strconv.Atoi(entries)
+	if err != nil {
+		return nil, fmt.Errorf("can not parse number of entries to int %w", err)
+	}
+
+	noUsers, err := strconv.Atoi(users)
+	if err != nil {
+		return nil, fmt.Errorf("can not parse number of users to int %w", err)
+	}
+
+	return &LoadOptions{
+		host:    host,
+		port:    port,
+		entries: noEntries,
+		users:   noUsers,
+	}, nil
+}

--- a/hack/redis/redis-load/pkg/concurrency/concurrent.go
+++ b/hack/redis/redis-load/pkg/concurrency/concurrent.go
@@ -1,0 +1,22 @@
+package concurrency
+
+import (
+	"github.com/sirupsen/logrus"
+	"sync"
+)
+
+func ConcurrentFuncs(functions []func()) {
+	logger := logrus.WithFields(logrus.Fields{"action": "concurrentFuncs"})
+
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(len(functions))
+	defer waitGroup.Wait()
+
+	for index, function := range functions {
+		logger.Infof("running noise no %d", index)
+		go func(copy func()) {
+			defer waitGroup.Done()
+			copy()
+		}(function)
+	}
+}

--- a/hack/redis/redis-load/pkg/string/randomString.go
+++ b/hack/redis/redis-load/pkg/string/randomString.go
@@ -1,0 +1,19 @@
+package string
+
+import (
+	"math/rand"
+	"time"
+)
+
+func stringFromBytes(length int) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = byte(65 + rand.Intn(90-65))
+	}
+	return string(b)
+}
+
+func RandomString(length int) string {
+	rand.Seed(time.Now().UTC().UnixNano())
+	return stringFromBytes(length)
+}

--- a/pkg/controller/cloudmetrics/cloudmetrics_controller.go
+++ b/pkg/controller/cloudmetrics/cloudmetrics_controller.go
@@ -32,6 +32,7 @@ const (
 	redisMemoryUsagePercentageAverage = "cro_redis_memory_usage_percentage_average"
 	redisFreeableMemoryAverage        = "cro_redis_freeable_memory_average"
 	redisCPUUtilizationAverage        = "cro_redis_cpu_utilization_average"
+	redisEngineCPUUtilizationAverage  = "cro_redis_engine_cpu_utilization_average"
 
 	labelClusterIDKey   = "clusterID"
 	labelResourceIDKey  = "resourceID"
@@ -159,6 +160,22 @@ var redisGaugeMetrics = []CroGaugeMetric{
 			providers.AWSDeploymentStrategy: {
 				PromethuesMetricName: redisCPUUtilizationAverage,
 				ProviderMetricName:   "CPUUtilization",
+				Statistic:            cloudwatch.StatisticAverage,
+			},
+		},
+	},
+	{
+		Name: redisEngineCPUUtilizationAverage,
+		GaugeVec: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: redisEngineCPUUtilizationAverage,
+				Help: "The percentage of CPU utilization. Units: Percent",
+			},
+			labels),
+		ProviderType: map[string]providers.CloudProviderMetricType{
+			providers.AWSDeploymentStrategy: {
+				PromethuesMetricName: redisEngineCPUUtilizationAverage,
+				ProviderMetricName:   "EngineCPUUtilization",
 				Statistic:            cloudwatch.StatisticAverage,
 			},
 		},


### PR DESCRIPTION
Co-authored-by: darahayes

## Overview

Jira: https://issues.redhat.com/browse/INTLY-7234

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make run`
- Run `make cluster/seed/managed/redis`
- Ensure Once Redis is deployed on aws check the metrics for this metric

```
curl localhost:8383/metrics | grep cro_redis_engine_cpu_utilization_average
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
# HELP cro_redis_engine_cpu_utilization_average The percentage of CPU utilization. Units: Percent
# TYPE cro_redis_engine_cpu_utilization_average gauge
cro_redis_engine_cpu_utilization_average{clusterID="mw-collab-byoc-z5xz6",instanceID="mwcollabbyocz5xz6redhatrhmioperator-o2wi-001",namespace="redhat-rhmi-operator",productName="productName",resourceID="example-redis",strategy="aws-elasticache"} 9.25
cro_redis_engine_cpu_utilization_average{clusterID="mw-collab-byoc-z5xz6",instanceID="mwcollabbyocz5xz6redhatrhmioperator-o2wi-002",namespace="redhat-rhmi-operator",productName="productName",resourceID="example-redis",strategy="aws-elasticache"} 1
100 74160    0 74160    0     0  27.8M      0 --:--:-- --:--:-- --:--:-- 35.3M

## Checklist
- [ ] This PR includes a change to an instance type