### PR TITLE
INTLY-7234 metric for cro_redis_engine_cpu_utilization_average

### DIFF
--- a/pkg/controller/cloudmetrics/cloudmetrics_controller.go
+++ b/pkg/controller/cloudmetrics/cloudmetrics_controller.go
@@ -32,6 +32,7 @@ const (
 	redisMemoryUsagePercentageAverage = "cro_redis_memory_usage_percentage_average"
 	redisFreeableMemoryAverage        = "cro_redis_freeable_memory_average"
 	redisCPUUtilizationAverage        = "cro_redis_cpu_utilization_average"
+	redisEngineCPUUtilizationAverage  = "cro_redis_engine_cpu_utilization_average"
 
 	labelClusterIDKey   = "clusterID"
 	labelResourceIDKey  = "resourceID"
@@ -159,6 +160,22 @@ var redisGaugeMetrics = []CroGaugeMetric{
 			providers.AWSDeploymentStrategy: {
 				PromethuesMetricName: redisCPUUtilizationAverage,
 				ProviderMetricName:   "CPUUtilization",
+				Statistic:            cloudwatch.StatisticAverage,
+			},
+		},
+	},
+	{
+		Name: redisEngineCPUUtilizationAverage,
+		GaugeVec: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: redisEngineCPUUtilizationAverage,
+				Help: "The percentage of CPU utilization. Units: Percent",
+			},
+			labels),
+		ProviderType: map[string]providers.CloudProviderMetricType{
+			providers.AWSDeploymentStrategy: {
+				PromethuesMetricName: redisEngineCPUUtilizationAverage,
+				ProviderMetricName:   "EngineCPUUtilization",
 				Statistic:            cloudwatch.StatisticAverage,
 			},
 		},


### PR DESCRIPTION
Co-authored-by: darahayes <dara.hayes@redhat.com>

## Overview

Jira: https://issues.redhat.com/browse/INTLY-7234

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make run`
- Run `make cluster/seed/managed/redis`
- Ensure Once Redis is deployed on aws check the metrics for this metric

```
curl localhost:8383/metrics | grep cro_redis_engine_cpu_utilization_average
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
# HELP cro_redis_engine_cpu_utilization_average The percentage of CPU utilization. Units: Percent
# TYPE cro_redis_engine_cpu_utilization_average gauge
cro_redis_engine_cpu_utilization_average{clusterID="mw-collab-byoc-z5xz6",instanceID="mwcollabbyocz5xz6redhatrhmioperator-o2wi-001",namespace="redhat-rhmi-operator",productName="productName",resourceID="example-redis",strategy="aws-elasticache"} 9.25
cro_redis_engine_cpu_utilization_average{clusterID="mw-collab-byoc-z5xz6",instanceID="mwcollabbyocz5xz6redhatrhmioperator-o2wi-002",namespace="redhat-rhmi-operator",productName="productName",resourceID="example-redis",strategy="aws-elasticache"} 1
100 74160    0 74160    0     0  27.8M      0 --:--:-- --:--:-- --:--:-- 35.3M