### PR TITLE
remove hardcoded regions from the aws strategy configmap example

### DIFF
--- a/deploy/examples/cloud_resources_aws_strategies.yaml
+++ b/deploy/examples/cloud_resources_aws_strategies.yaml
@@ -4,11 +4,11 @@ metadata:
   name: cloud-resources-aws-strategies
 data:
   blobstorage: |
-    {"development": { "region": "eu-west-1", "createStrategy": {}, "deleteStrategy": {} }}
+    {"development": { "region": "", "createStrategy": {}, "deleteStrategy": {} }}
   redis: |
-    {"development": { "region": "eu-west-1", "createStrategy": {}, "deleteStrategy": {} }}
+    {"development": { "region": "", "createStrategy": {}, "deleteStrategy": {} }}
   postgres: |
-    {"development": { "region": "eu-west-1", "createStrategy": {}, "deleteStrategy": {} }}
+    {"development": { "region": "", "createStrategy": {}, "deleteStrategy": {} }}
   _network: |
-    {"development": { "region": "eu-west-1", "createStrategy": { "CidrBlock": "10.1.0.0/16" }, "deleteStrategy": {} }}
+    {"development": { "region": "", "createStrategy": { "CidrBlock": "10.1.0.0/16" }, "deleteStrategy": {} }}
     


### PR DESCRIPTION
currently the example aws strategy configmap is created in dev make
targets. this means that the hardcoded region of eu-west-1 is used
even if the cluster isn't in eu-west-1 which can cause issues with
vpc setup.

remove the hardcoded region but keep the explicit keys to let users
know the possible keys that can be used in the strategy configmap.

verification:
- in cluster in a non-eu-west-1 region
- run make cluster/prepare NAMESPACE=<your-namespace>
- ensure the region isn't specified in the aws strategy configmap
- create a postgres, redis and blobstorage and ensure each are
  created in the region of the cluster


## additional notes

it appears that custom resources (at least postgres and redis) for
aws can no longer specify a specific region. we either need to
consider this a bug or work to remove the region key entirely from
the strategy configmap.