### PR TITLE
Bumping the version of the operator-sdk to v0.19.0 for the prow

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,6 +1,6 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13
 
-ENV OPERATOR_SDK_VERSION=v0.12.0
+ENV OPERATOR_SDK_VERSION=v0.19.0
 
 # install operator-sdk (from git with no history and only the tag)
 RUN mkdir -p $GOPATH/src/github.com/operator-framework \

--- a/openshift-ci/README.md
+++ b/openshift-ci/README.md
@@ -2,14 +2,14 @@
 
 ### Dockerfile.tools
 
-Base image used on CI for all builds and test jobs.
+Base image used on CI for all builds and test jobs. See [here](https://github.com/integr8ly/ci-cd/blob/master/openshift-ci/README.md) for more information on creating and deploying a new image.
 
 #### Build and Test
 
 ```
 $ docker build -t registry.svc.ci.openshift.org/integr8ly/cro-base-image:latest - < Dockerfile.tools
 $ IMAGE_NAME=registry.svc.ci.openshift.org/integr8ly/cro-base-image:latest test/run 
-operator-sdk version: "v0.12.0", commit: "2445fcda834ca4b7cf0d6c38fba6317fb219b469", go version: "go1.13.5 linux/amd64"
+operator-sdk version: "v0.19.0", commit: "8e28aca60994c5cb1aec0251b85f0116cc4c9427", kubernetes version: "v1.18.2", go version: "go1.13.5 linux/amd64"
 go version go1.13.5 linux/amd64
 go mod tidy
 ...


### PR DESCRIPTION
/openshift-ci image. We've already bumped the version in our makefile so keeping things aligned here

## Overview

Jira: https://issues.redhat.com/browse/INTLY-9952

## Verification

- Clone this branch
- Run `cd openshift-ci`
- Run the commands from openshift-ci/README.md
- Ensure that the output completes and ends in `Success!!`

- See that the image is build here: https://api.ci.openshift.org/console/project/integr8ly/browse/builds/cro-base-image?tab=history and that the logs show the operator-sdk is version v0.19.0 and that the retests pass.