### PR TITLE
INTLY-9552:  add a check for valid status to ModifyDBInstance

### DIFF
--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -664,7 +664,11 @@ func buildRDSUpdateStrategy(rdsConfig *rds.CreateDBInstanceInput, foundConfig *r
 		mi.DeletionProtection = rdsConfig.DeletionProtection
 		updateFound = true
 	}
-	if *rdsConfig.Port != *foundConfig.Endpoint.Port {
+	config := *foundConfig
+	endpoint := config.Endpoint
+	if endpoint == nil {
+		// nil pointer check as *foundConfig.Endpoint doesn't exist on first run
+	} else if *rdsConfig.Port != *foundConfig.Endpoint.Port {
 		mi.DBPortNumber = rdsConfig.Port
 		updateFound = true
 	}

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -315,8 +315,8 @@ func (p *PostgresProvider) createRDSInstance(ctx context.Context, cr *v1alpha1.P
 		if _, err = rdsSvc.ModifyDBInstance(mi); err != nil {
 			// AWS handles invalid state with the ErrCodeInvalidDBInstanceStateFault
 			if aerr, ok := err.(awserr.Error); ok {
-				if  aerr.Code() == rds.ErrCodeInvalidDBInstanceStateFault{
-					logger.Errorf("modifyRDSInstance() failed invalid state fault %s error : %s",rds.ErrCodeInvalidDBInstanceStateFault, aerr.Error())
+				if aerr.Code() == rds.ErrCodeInvalidDBInstanceStateFault {
+					logger.Errorf("modifyRDSInstance() failed invalid state fault %s error : %s", rds.ErrCodeInvalidDBInstanceStateFault, aerr.Error())
 					return nil, croType.StatusMessage(fmt.Sprintf("modifyRDSInstance() failed, RDS can not be modified in current aws rds resource status %s", *foundInstance.DBInstanceStatus)), nil
 				}
 			}

--- a/pkg/providers/aws/provider_postgres_test.go
+++ b/pkg/providers/aws/provider_postgres_test.go
@@ -503,15 +503,6 @@ func buildAvailableDBInstance(testID string) []*rds.DBInstance {
 	}
 }
 
-func buildPendingDBInstance(testID string) []*rds.DBInstance {
-	return []*rds.DBInstance{
-		{
-			DBInstanceIdentifier: aws.String(testID),
-			DBInstanceStatus:     aws.String("pending"),
-		},
-	}
-}
-
 func buildAvailableCreateInput(testID string) *rds.CreateDBInstanceInput {
 	return &rds.CreateDBInstanceInput{
 		DBInstanceIdentifier:       aws.String(testID),
@@ -735,28 +726,6 @@ func TestAWSPostgresProvider_createPostgresInstance(t *testing.T) {
 				Database: defaultAwsEngine,
 				Port:     defaultAwsPostgresPort,
 			}},
-			wantErr: false,
-		},
-		{
-			name: "test rds exists and is not available (valid cluster bundle subnets)",
-			args: args{
-				rdsSvc: &mockRdsClient{dbInstances: buildPendingDBInstance(testIdentifier)},
-				ec2Svc: &mockEc2Client{vpcs: buildVpcs(), subnets: buildValidBundleSubnets(), secGroups: buildSecurityGroups(secName), azs: buildAZ()},
-				ctx:    context.TODO(),
-				cr:     buildTestPostgresCR(),
-				postgresCfg: &rds.CreateDBInstanceInput{
-					DBInstanceIdentifier: aws.String(testIdentifier),
-				},
-				standaloneNetworkExists: false,
-			},
-			fields: fields{
-				Client:            fake.NewFakeClientWithScheme(scheme, buildTestPostgresCR(), builtTestCredSecret(), buildTestInfra()),
-				Logger:            testLogger,
-				CredentialManager: nil,
-				ConfigManager:     nil,
-				TCPPinger:         buildMockConnectionTester(),
-			},
-			want:    nil,
 			wantErr: false,
 		},
 		{

--- a/pkg/providers/aws/provider_postgres_test.go
+++ b/pkg/providers/aws/provider_postgres_test.go
@@ -506,8 +506,8 @@ func buildAvailableDBInstance(testID string) []*rds.DBInstance {
 func buildPendingDBInstance(testID string) []*rds.DBInstance {
 	return []*rds.DBInstance{
 		{
-			DBInstanceIdentifier: aws.String(testID),
-			DBInstanceStatus:     aws.String("pending"),
+			DBInstanceIdentifier:       aws.String(testID),
+			DBInstanceStatus:           aws.String("pending"),
 			DeletionProtection:         aws.Bool(defaultAwsPostgresDeletionProtection),
 			BackupRetentionPeriod:      aws.Int64(defaultAwsBackupRetentionPeriod),
 			DBInstanceClass:            aws.String(defaultAwsDBInstanceClass),

--- a/pkg/providers/aws/provider_postgres_test.go
+++ b/pkg/providers/aws/provider_postgres_test.go
@@ -503,6 +503,24 @@ func buildAvailableDBInstance(testID string) []*rds.DBInstance {
 	}
 }
 
+func buildPendingDBInstance(testID string) []*rds.DBInstance {
+	return []*rds.DBInstance{
+		{
+			DBInstanceIdentifier: aws.String(testID),
+			DBInstanceStatus:     aws.String("pending"),
+			DeletionProtection:         aws.Bool(defaultAwsPostgresDeletionProtection),
+			BackupRetentionPeriod:      aws.Int64(defaultAwsBackupRetentionPeriod),
+			DBInstanceClass:            aws.String(defaultAwsDBInstanceClass),
+			PubliclyAccessible:         aws.Bool(defaultAwsPubliclyAccessible),
+			MaxAllocatedStorage:        aws.Int64(defaultAwsMaxAllocatedStorage),
+			PreferredBackupWindow:      aws.String(testPreferredBackupWindow),
+			EngineVersion:              aws.String(defaultAwsEngineVersion),
+			PreferredMaintenanceWindow: aws.String(testPreferredMaintenanceWindow),
+			MultiAZ:                    aws.Bool(true),
+		},
+	}
+}
+
 func buildAvailableCreateInput(testID string) *rds.CreateDBInstanceInput {
 	return &rds.CreateDBInstanceInput{
 		DBInstanceIdentifier:       aws.String(testID),
@@ -726,6 +744,28 @@ func TestAWSPostgresProvider_createPostgresInstance(t *testing.T) {
 				Database: defaultAwsEngine,
 				Port:     defaultAwsPostgresPort,
 			}},
+			wantErr: false,
+		},
+		{
+			name: "test rds exists and is not available (valid cluster bundle subnets)",
+			args: args{
+				rdsSvc: &mockRdsClient{dbInstances: buildPendingDBInstance(testIdentifier)},
+				ec2Svc: &mockEc2Client{vpcs: buildVpcs(), subnets: buildValidBundleSubnets(), secGroups: buildSecurityGroups(secName), azs: buildAZ()},
+				ctx:    context.TODO(),
+				cr:     buildTestPostgresCR(),
+				postgresCfg: &rds.CreateDBInstanceInput{
+					DBInstanceIdentifier: aws.String(testIdentifier),
+				},
+				standaloneNetworkExists: false,
+			},
+			fields: fields{
+				Client:            fake.NewFakeClientWithScheme(scheme, buildTestPostgresCR(), builtTestCredSecret(), buildTestInfra()),
+				Logger:            testLogger,
+				CredentialManager: nil,
+				ConfigManager:     nil,
+				TCPPinger:         buildMockConnectionTester(),
+			},
+			want:    nil,
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
## Overview
This is to cover a edge case where the configmap `cloud_resource_aws_strategies.yaml` createstrategy is updated but the rds instance status is something other that **available** from the time the configmap is updated to the end of the maintenance window

Jira: https://issues.redhat.com/browse/INTLY-9552

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make run`
- Run `make cluster/seed/managed/postgres` 
- wait for postgres cr status to be 
```yaml
status:
  message: 'successfully created and tagged, aws rds status is available'
```
- Set the status to `Backing-up` by taking a [snapshot](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CreateSnapshot.html)
- update the configmap `cloud_resource_aws_strategies.yaml` in the cro operator namespace and change the `postgres.development.createstrategy{}`
e.g.
```json
"createStrategy": {
      "DBInstanceClass": "db.t3.micro",
    }
```
- confirm that the pending modification update 
```bash
aws rds describe-db-instances --db-instance-identifier=<DBInstanceIdentifier> | jq -r '.DBInstances[0].PendingModifiedValues'
# e.g. output
{
  "DBInstanceClass": "db.t3.micro"
}
```

## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below