### PR TITLE
add nil checks to postgres maintenance metric

### DIFF
--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -1085,10 +1085,17 @@ func (p *PostgresProvider) setPostgresServiceMaintenanceMetric(ctx context.Conte
 		metricLabels := map[string]string{}
 
 		metricLabels["clusterID"] = clusterID
+
+		if su.ResourceIdentifier == nil {
+			logrus.Info("could not set pending maintenance metric as resource identifier null")
+		}
 		metricLabels["ResourceIdentifier"] = *su.ResourceIdentifier
 
 		for _, pma := range su.PendingMaintenanceActionDetails {
-
+			if pma.AutoAppliedAfterDate == nil || pma.CurrentApplyDate == nil || pma.Description == nil {
+				logrus.Infof("could not set pending maintenance metric for resource {%s} as values are missing", aws.StringValue(su.ResourceIdentifier))
+				continue
+			}
 			metricLabels["AutoAppliedAfterDate"] = strconv.FormatInt((*pma.AutoAppliedAfterDate).Unix(), 10)
 			metricLabels["CurrentApplyDate"] = strconv.FormatInt((*pma.CurrentApplyDate).Unix(), 10)
 			metricLabels["Description"] = *pma.Description


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/OHSS-1776

## Verification

- Checkout v0.17.0
- Run `make cluster/prepare`
- Run `make cluster/seed/managed/postgres`
- Run `make run`
- We expect there to be an error `nil pointer` outlined in JIRA above
- Clone this branch
- Run `make run`
- Ensure no `nil pointer` error

## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below