### PR TITLE
bump default version of postgres

### DIFF
--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -52,7 +52,7 @@ const (
 	defaultAwsBackupRetentionPeriod      = 31
 	defaultAwsDBInstanceClass            = "db.t3.small"
 	defaultAwsEngine                     = "postgres"
-	defaultAwsEngineVersion              = "10.6"
+	defaultAwsEngineVersion              = "10.13"
 	defaultAwsPubliclyAccessible         = false
 	defaultAwsSkipFinalSnapshot          = false
 	defaultAWSCopyTagsToSnapshot         = true
@@ -64,7 +64,7 @@ const (
 )
 
 var (
-	defaultSupportedEngineVersions = []string{"10.6", "9.6", "9.5"}
+	defaultSupportedEngineVersions = []string{"10.13", "10.6", "9.6", "9.5"}
 	healthyAWSDBInstanceStatuses   = []string{
 		"backtracking",
 		"available",


### PR DESCRIPTION
## Overview
Jira: https://issues.redhat.com/browse/INTLY-10248



## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make run`
- Create a Postgres CR and ensure the version is 10.13
`aws rds describe-db-instances | grep EngineVersion`
