### PR TITLE
adding logic to provide a default non overlapping cidr block for the standanlone network

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/elazarl/goproxy/ext v0.0.0-20190421051319-9d40249d3c2f // indirect
 	github.com/ghodss/yaml v1.0.1-0.20180820084758-c7ce16629ff4 // indirect
 	github.com/go-openapi/spec v0.19.3
-	github.com/gomodule/redigo v2.0.0+incompatible // indirect
 	github.com/google/uuid v1.1.1
 	github.com/gregjones/httpcache v0.0.0-20190203031600-7a902570cb17 // indirect
 	github.com/hashicorp/go-version v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -465,9 +465,6 @@ github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450/go.mod h1:Bk6SMAONeMXrxql8uvOKuAZSu8aM5RUGv+1C6IJaEho=
 github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995/go.mod h1:lJgMEyOkYFkPcDKwRXegd+iM6E7matEszMG5HhwytU8=
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//k/eakGydO4jKRoRL2j92ZKSzTgj9tclaCrvXHk=
-github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
-github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
-github.com/gomodule/redigo/redis v0.0.0-do-not-use h1:J7XIp6Kau0WoyT4JtXHT3Ei0gA1KkSc6bc87j9v9WIo=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=

--- a/pkg/providers/aws/cluster_network_provider_moq.go
+++ b/pkg/providers/aws/cluster_network_provider_moq.go
@@ -9,18 +9,6 @@ import (
 	"sync"
 )
 
-var (
-	lockNetworkManagerMockCreateNetwork               sync.RWMutex
-	lockNetworkManagerMockCreateNetworkConnection     sync.RWMutex
-	lockNetworkManagerMockCreateNetworkPeering        sync.RWMutex
-	lockNetworkManagerMockDeleteBundledCloudResources sync.RWMutex
-	lockNetworkManagerMockDeleteNetwork               sync.RWMutex
-	lockNetworkManagerMockDeleteNetworkConnection     sync.RWMutex
-	lockNetworkManagerMockDeleteNetworkPeering        sync.RWMutex
-	lockNetworkManagerMockGetClusterNetworkPeering    sync.RWMutex
-	lockNetworkManagerMockIsEnabled                   sync.RWMutex
-)
-
 // Ensure, that NetworkManagerMock does implement NetworkManager.
 // If this is not the case, regenerate this file with moq.
 var _ NetworkManager = &NetworkManagerMock{}
@@ -58,6 +46,12 @@ var _ NetworkManager = &NetworkManagerMock{}
 //             IsEnabledFunc: func(in1 context.Context) (bool, error) {
 // 	               panic("mock out the IsEnabled method")
 //             },
+//             getNonOverlappingDefaultCIDRFunc: func(in1 context.Context) (*net.IPNet, error) {
+// 	               panic("mock out the getNonOverlappingDefaultCIDR method")
+//             },
+//             validateStandaloneCidrBlockFunc: func(in1 context.Context, in2 *net.IPNet) error {
+// 	               panic("mock out the validateStandaloneCidrBlock method")
+//             },
 //         }
 //
 //         // use mockedNetworkManager in code that requires NetworkManager
@@ -91,6 +85,12 @@ type NetworkManagerMock struct {
 
 	// IsEnabledFunc mocks the IsEnabled method.
 	IsEnabledFunc func(in1 context.Context) (bool, error)
+
+	// getNonOverlappingDefaultCIDRFunc mocks the getNonOverlappingDefaultCIDR method.
+	getNonOverlappingDefaultCIDRFunc func(in1 context.Context) (*net.IPNet, error)
+
+	// validateStandaloneCidrBlockFunc mocks the validateStandaloneCidrBlock method.
+	validateStandaloneCidrBlockFunc func(in1 context.Context, in2 *net.IPNet) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -147,7 +147,30 @@ type NetworkManagerMock struct {
 			// In1 is the in1 argument value.
 			In1 context.Context
 		}
+		// getNonOverlappingDefaultCIDR holds details about calls to the getNonOverlappingDefaultCIDR method.
+		getNonOverlappingDefaultCIDR []struct {
+			// In1 is the in1 argument value.
+			In1 context.Context
+		}
+		// validateStandaloneCidrBlock holds details about calls to the validateStandaloneCidrBlock method.
+		validateStandaloneCidrBlock []struct {
+			// In1 is the in1 argument value.
+			In1 context.Context
+			// In2 is the in2 argument value.
+			In2 *net.IPNet
+		}
 	}
+	lockCreateNetwork                sync.RWMutex
+	lockCreateNetworkConnection      sync.RWMutex
+	lockCreateNetworkPeering         sync.RWMutex
+	lockDeleteBundledCloudResources  sync.RWMutex
+	lockDeleteNetwork                sync.RWMutex
+	lockDeleteNetworkConnection      sync.RWMutex
+	lockDeleteNetworkPeering         sync.RWMutex
+	lockGetClusterNetworkPeering     sync.RWMutex
+	lockIsEnabled                    sync.RWMutex
+	lockgetNonOverlappingDefaultCIDR sync.RWMutex
+	lockvalidateStandaloneCidrBlock  sync.RWMutex
 }
 
 // CreateNetwork calls CreateNetworkFunc.
@@ -162,9 +185,9 @@ func (mock *NetworkManagerMock) CreateNetwork(in1 context.Context, in2 *net.IPNe
 		In1: in1,
 		In2: in2,
 	}
-	lockNetworkManagerMockCreateNetwork.Lock()
+	mock.lockCreateNetwork.Lock()
 	mock.calls.CreateNetwork = append(mock.calls.CreateNetwork, callInfo)
-	lockNetworkManagerMockCreateNetwork.Unlock()
+	mock.lockCreateNetwork.Unlock()
 	return mock.CreateNetworkFunc(in1, in2)
 }
 
@@ -179,9 +202,9 @@ func (mock *NetworkManagerMock) CreateNetworkCalls() []struct {
 		In1 context.Context
 		In2 *net.IPNet
 	}
-	lockNetworkManagerMockCreateNetwork.RLock()
+	mock.lockCreateNetwork.RLock()
 	calls = mock.calls.CreateNetwork
-	lockNetworkManagerMockCreateNetwork.RUnlock()
+	mock.lockCreateNetwork.RUnlock()
 	return calls
 }
 
@@ -197,9 +220,9 @@ func (mock *NetworkManagerMock) CreateNetworkConnection(in1 context.Context, in2
 		In1: in1,
 		In2: in2,
 	}
-	lockNetworkManagerMockCreateNetworkConnection.Lock()
+	mock.lockCreateNetworkConnection.Lock()
 	mock.calls.CreateNetworkConnection = append(mock.calls.CreateNetworkConnection, callInfo)
-	lockNetworkManagerMockCreateNetworkConnection.Unlock()
+	mock.lockCreateNetworkConnection.Unlock()
 	return mock.CreateNetworkConnectionFunc(in1, in2)
 }
 
@@ -214,9 +237,9 @@ func (mock *NetworkManagerMock) CreateNetworkConnectionCalls() []struct {
 		In1 context.Context
 		In2 *Network
 	}
-	lockNetworkManagerMockCreateNetworkConnection.RLock()
+	mock.lockCreateNetworkConnection.RLock()
 	calls = mock.calls.CreateNetworkConnection
-	lockNetworkManagerMockCreateNetworkConnection.RUnlock()
+	mock.lockCreateNetworkConnection.RUnlock()
 	return calls
 }
 
@@ -232,9 +255,9 @@ func (mock *NetworkManagerMock) CreateNetworkPeering(in1 context.Context, in2 *N
 		In1: in1,
 		In2: in2,
 	}
-	lockNetworkManagerMockCreateNetworkPeering.Lock()
+	mock.lockCreateNetworkPeering.Lock()
 	mock.calls.CreateNetworkPeering = append(mock.calls.CreateNetworkPeering, callInfo)
-	lockNetworkManagerMockCreateNetworkPeering.Unlock()
+	mock.lockCreateNetworkPeering.Unlock()
 	return mock.CreateNetworkPeeringFunc(in1, in2)
 }
 
@@ -249,9 +272,9 @@ func (mock *NetworkManagerMock) CreateNetworkPeeringCalls() []struct {
 		In1 context.Context
 		In2 *Network
 	}
-	lockNetworkManagerMockCreateNetworkPeering.RLock()
+	mock.lockCreateNetworkPeering.RLock()
 	calls = mock.calls.CreateNetworkPeering
-	lockNetworkManagerMockCreateNetworkPeering.RUnlock()
+	mock.lockCreateNetworkPeering.RUnlock()
 	return calls
 }
 
@@ -265,9 +288,9 @@ func (mock *NetworkManagerMock) DeleteBundledCloudResources(in1 context.Context)
 	}{
 		In1: in1,
 	}
-	lockNetworkManagerMockDeleteBundledCloudResources.Lock()
+	mock.lockDeleteBundledCloudResources.Lock()
 	mock.calls.DeleteBundledCloudResources = append(mock.calls.DeleteBundledCloudResources, callInfo)
-	lockNetworkManagerMockDeleteBundledCloudResources.Unlock()
+	mock.lockDeleteBundledCloudResources.Unlock()
 	return mock.DeleteBundledCloudResourcesFunc(in1)
 }
 
@@ -280,9 +303,9 @@ func (mock *NetworkManagerMock) DeleteBundledCloudResourcesCalls() []struct {
 	var calls []struct {
 		In1 context.Context
 	}
-	lockNetworkManagerMockDeleteBundledCloudResources.RLock()
+	mock.lockDeleteBundledCloudResources.RLock()
 	calls = mock.calls.DeleteBundledCloudResources
-	lockNetworkManagerMockDeleteBundledCloudResources.RUnlock()
+	mock.lockDeleteBundledCloudResources.RUnlock()
 	return calls
 }
 
@@ -296,9 +319,9 @@ func (mock *NetworkManagerMock) DeleteNetwork(in1 context.Context) error {
 	}{
 		In1: in1,
 	}
-	lockNetworkManagerMockDeleteNetwork.Lock()
+	mock.lockDeleteNetwork.Lock()
 	mock.calls.DeleteNetwork = append(mock.calls.DeleteNetwork, callInfo)
-	lockNetworkManagerMockDeleteNetwork.Unlock()
+	mock.lockDeleteNetwork.Unlock()
 	return mock.DeleteNetworkFunc(in1)
 }
 
@@ -311,9 +334,9 @@ func (mock *NetworkManagerMock) DeleteNetworkCalls() []struct {
 	var calls []struct {
 		In1 context.Context
 	}
-	lockNetworkManagerMockDeleteNetwork.RLock()
+	mock.lockDeleteNetwork.RLock()
 	calls = mock.calls.DeleteNetwork
-	lockNetworkManagerMockDeleteNetwork.RUnlock()
+	mock.lockDeleteNetwork.RUnlock()
 	return calls
 }
 
@@ -329,9 +352,9 @@ func (mock *NetworkManagerMock) DeleteNetworkConnection(in1 context.Context, in2
 		In1: in1,
 		In2: in2,
 	}
-	lockNetworkManagerMockDeleteNetworkConnection.Lock()
+	mock.lockDeleteNetworkConnection.Lock()
 	mock.calls.DeleteNetworkConnection = append(mock.calls.DeleteNetworkConnection, callInfo)
-	lockNetworkManagerMockDeleteNetworkConnection.Unlock()
+	mock.lockDeleteNetworkConnection.Unlock()
 	return mock.DeleteNetworkConnectionFunc(in1, in2)
 }
 
@@ -346,9 +369,9 @@ func (mock *NetworkManagerMock) DeleteNetworkConnectionCalls() []struct {
 		In1 context.Context
 		In2 *NetworkPeering
 	}
-	lockNetworkManagerMockDeleteNetworkConnection.RLock()
+	mock.lockDeleteNetworkConnection.RLock()
 	calls = mock.calls.DeleteNetworkConnection
-	lockNetworkManagerMockDeleteNetworkConnection.RUnlock()
+	mock.lockDeleteNetworkConnection.RUnlock()
 	return calls
 }
 
@@ -362,9 +385,9 @@ func (mock *NetworkManagerMock) DeleteNetworkPeering(in1 *NetworkPeering) error 
 	}{
 		In1: in1,
 	}
-	lockNetworkManagerMockDeleteNetworkPeering.Lock()
+	mock.lockDeleteNetworkPeering.Lock()
 	mock.calls.DeleteNetworkPeering = append(mock.calls.DeleteNetworkPeering, callInfo)
-	lockNetworkManagerMockDeleteNetworkPeering.Unlock()
+	mock.lockDeleteNetworkPeering.Unlock()
 	return mock.DeleteNetworkPeeringFunc(in1)
 }
 
@@ -377,9 +400,9 @@ func (mock *NetworkManagerMock) DeleteNetworkPeeringCalls() []struct {
 	var calls []struct {
 		In1 *NetworkPeering
 	}
-	lockNetworkManagerMockDeleteNetworkPeering.RLock()
+	mock.lockDeleteNetworkPeering.RLock()
 	calls = mock.calls.DeleteNetworkPeering
-	lockNetworkManagerMockDeleteNetworkPeering.RUnlock()
+	mock.lockDeleteNetworkPeering.RUnlock()
 	return calls
 }
 
@@ -393,9 +416,9 @@ func (mock *NetworkManagerMock) GetClusterNetworkPeering(in1 context.Context) (*
 	}{
 		In1: in1,
 	}
-	lockNetworkManagerMockGetClusterNetworkPeering.Lock()
+	mock.lockGetClusterNetworkPeering.Lock()
 	mock.calls.GetClusterNetworkPeering = append(mock.calls.GetClusterNetworkPeering, callInfo)
-	lockNetworkManagerMockGetClusterNetworkPeering.Unlock()
+	mock.lockGetClusterNetworkPeering.Unlock()
 	return mock.GetClusterNetworkPeeringFunc(in1)
 }
 
@@ -408,9 +431,9 @@ func (mock *NetworkManagerMock) GetClusterNetworkPeeringCalls() []struct {
 	var calls []struct {
 		In1 context.Context
 	}
-	lockNetworkManagerMockGetClusterNetworkPeering.RLock()
+	mock.lockGetClusterNetworkPeering.RLock()
 	calls = mock.calls.GetClusterNetworkPeering
-	lockNetworkManagerMockGetClusterNetworkPeering.RUnlock()
+	mock.lockGetClusterNetworkPeering.RUnlock()
 	return calls
 }
 
@@ -424,9 +447,9 @@ func (mock *NetworkManagerMock) IsEnabled(in1 context.Context) (bool, error) {
 	}{
 		In1: in1,
 	}
-	lockNetworkManagerMockIsEnabled.Lock()
+	mock.lockIsEnabled.Lock()
 	mock.calls.IsEnabled = append(mock.calls.IsEnabled, callInfo)
-	lockNetworkManagerMockIsEnabled.Unlock()
+	mock.lockIsEnabled.Unlock()
 	return mock.IsEnabledFunc(in1)
 }
 
@@ -439,8 +462,74 @@ func (mock *NetworkManagerMock) IsEnabledCalls() []struct {
 	var calls []struct {
 		In1 context.Context
 	}
-	lockNetworkManagerMockIsEnabled.RLock()
+	mock.lockIsEnabled.RLock()
 	calls = mock.calls.IsEnabled
-	lockNetworkManagerMockIsEnabled.RUnlock()
+	mock.lockIsEnabled.RUnlock()
+	return calls
+}
+
+// getNonOverlappingDefaultCIDR calls getNonOverlappingDefaultCIDRFunc.
+func (mock *NetworkManagerMock) getNonOverlappingDefaultCIDR(in1 context.Context) (*net.IPNet, error) {
+	if mock.getNonOverlappingDefaultCIDRFunc == nil {
+		panic("NetworkManagerMock.getNonOverlappingDefaultCIDRFunc: method is nil but NetworkManager.getNonOverlappingDefaultCIDR was just called")
+	}
+	callInfo := struct {
+		In1 context.Context
+	}{
+		In1: in1,
+	}
+	mock.lockgetNonOverlappingDefaultCIDR.Lock()
+	mock.calls.getNonOverlappingDefaultCIDR = append(mock.calls.getNonOverlappingDefaultCIDR, callInfo)
+	mock.lockgetNonOverlappingDefaultCIDR.Unlock()
+	return mock.getNonOverlappingDefaultCIDRFunc(in1)
+}
+
+// getNonOverlappingDefaultCIDRCalls gets all the calls that were made to getNonOverlappingDefaultCIDR.
+// Check the length with:
+//     len(mockedNetworkManager.getNonOverlappingDefaultCIDRCalls())
+func (mock *NetworkManagerMock) getNonOverlappingDefaultCIDRCalls() []struct {
+	In1 context.Context
+} {
+	var calls []struct {
+		In1 context.Context
+	}
+	mock.lockgetNonOverlappingDefaultCIDR.RLock()
+	calls = mock.calls.getNonOverlappingDefaultCIDR
+	mock.lockgetNonOverlappingDefaultCIDR.RUnlock()
+	return calls
+}
+
+// validateStandaloneCidrBlock calls validateStandaloneCidrBlockFunc.
+func (mock *NetworkManagerMock) validateStandaloneCidrBlock(in1 context.Context, in2 *net.IPNet) error {
+	if mock.validateStandaloneCidrBlockFunc == nil {
+		panic("NetworkManagerMock.validateStandaloneCidrBlockFunc: method is nil but NetworkManager.validateStandaloneCidrBlock was just called")
+	}
+	callInfo := struct {
+		In1 context.Context
+		In2 *net.IPNet
+	}{
+		In1: in1,
+		In2: in2,
+	}
+	mock.lockvalidateStandaloneCidrBlock.Lock()
+	mock.calls.validateStandaloneCidrBlock = append(mock.calls.validateStandaloneCidrBlock, callInfo)
+	mock.lockvalidateStandaloneCidrBlock.Unlock()
+	return mock.validateStandaloneCidrBlockFunc(in1, in2)
+}
+
+// validateStandaloneCidrBlockCalls gets all the calls that were made to validateStandaloneCidrBlock.
+// Check the length with:
+//     len(mockedNetworkManager.validateStandaloneCidrBlockCalls())
+func (mock *NetworkManagerMock) validateStandaloneCidrBlockCalls() []struct {
+	In1 context.Context
+	In2 *net.IPNet
+} {
+	var calls []struct {
+		In1 context.Context
+		In2 *net.IPNet
+	}
+	mock.lockvalidateStandaloneCidrBlock.RLock()
+	calls = mock.calls.validateStandaloneCidrBlock
+	mock.lockvalidateStandaloneCidrBlock.RUnlock()
 	return calls
 }

--- a/pkg/providers/aws/config_moq.go
+++ b/pkg/providers/aws/config_moq.go
@@ -9,10 +9,6 @@ import (
 	"sync"
 )
 
-var (
-	lockConfigManagerMockReadStorageStrategy sync.RWMutex
-)
-
 // Ensure, that ConfigManagerMock does implement ConfigManager.
 // If this is not the case, regenerate this file with moq.
 var _ ConfigManager = &ConfigManagerMock{}
@@ -48,6 +44,7 @@ type ConfigManagerMock struct {
 			Tier string
 		}
 	}
+	lockReadStorageStrategy sync.RWMutex
 }
 
 // ReadStorageStrategy calls ReadStorageStrategyFunc.
@@ -64,9 +61,9 @@ func (mock *ConfigManagerMock) ReadStorageStrategy(ctx context.Context, rt provi
 		Rt:   rt,
 		Tier: tier,
 	}
-	lockConfigManagerMockReadStorageStrategy.Lock()
+	mock.lockReadStorageStrategy.Lock()
 	mock.calls.ReadStorageStrategy = append(mock.calls.ReadStorageStrategy, callInfo)
-	lockConfigManagerMockReadStorageStrategy.Unlock()
+	mock.lockReadStorageStrategy.Unlock()
 	return mock.ReadStorageStrategyFunc(ctx, rt, tier)
 }
 
@@ -83,8 +80,8 @@ func (mock *ConfigManagerMock) ReadStorageStrategyCalls() []struct {
 		Rt   providers.ResourceType
 		Tier string
 	}
-	lockConfigManagerMockReadStorageStrategy.RLock()
+	mock.lockReadStorageStrategy.RLock()
 	calls = mock.calls.ReadStorageStrategy
-	lockConfigManagerMockReadStorageStrategy.RUnlock()
+	mock.lockReadStorageStrategy.RUnlock()
 	return calls
 }

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -178,9 +178,9 @@ func (p *PostgresProvider) CreatePostgres(ctx context.Context, pg *v1alpha1.Post
 	//and a new vpc is created for all resources to be deployed in and peered with the cluster vpc
 	if isEnabled {
 		// get cidr block from _network strat map, based on tier from postgres cr
-		vpcCidrBlock, err := getNetworkProviderConfig(ctx, p.ConfigManager, pg.Spec.Tier, logger)
+		vpcCidrBlock, err := networkManager.ReconcileNetworkProviderConfig(ctx, p.ConfigManager, pg.Spec.Tier, logger)
 		if err != nil {
-			errMsg := "failed to get _network strategy config"
+			errMsg := "failed to reconcile network provider config"
 			return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
 		}
 		logger.Debug("standalone network provider enabled, reconciling standalone vpc")

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -141,7 +141,7 @@ func (p *RedisProvider) CreateRedis(ctx context.Context, r *v1alpha1.Redis) (*pr
 	//and a new vpc is created for all resources to be deployed in and peered with the cluster vpc
 	if isEnabled {
 		// get cidr block from _network strat map, based on tier from redis cr
-		vpcCidrBlock, err := getNetworkProviderConfig(ctx, p.ConfigManager, r.Spec.Tier, logger)
+		vpcCidrBlock, err := networkManager.ReconcileNetworkProviderConfig(ctx, p.ConfigManager, r.Spec.Tier, logger)
 		if err != nil {
 			errMsg := "failed to get _network strategy config"
 			return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)


### PR DESCRIPTION
adding logic to provide a default non overlapping cidr block for the standanlone network

## Overview

Jira: https://issues.redhat.com/browse/MGDAPI-582

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make run`

### Verify that the provided cidr in the _network block is used.

Check the config map that was created when preparing the cluster

`oc get configmaps cloud-resources-aws-strategies -n cloud-resource-operator -o json | jq '.data'`

```
{
  "_network": "{\"development\": { \"region\": \"\", \"createStrategy\": { \"CidrBlock\": \"10.1.0.0/16\" }, \"deleteStrategy\": {} }}\n",
  ........
}
```

Create a postgres cr
Run `make cluster/seed/managed/postgres`

Verify that the standalone vpc is created using the default

`aws ec2 describe-vpcs --filter "Name=tag-value,Values=RHMI Cloud Resource VPC"`

Expected Output (with extra values stripped out)
```
{
    "Vpcs": [
        {
            "CidrBlock": "10.1.0.0/16",
........
            "CidrBlockAssociationSet": [
                {
                    "CidrBlock": "10.1.0.0/16",
          ........
                {
                    "Key": "Name",
                    "Value": "RHMI Cloud Resource VPC"
                }
            ]
        }
    ]
}
```

### Verify that the default cidr block is created

Delete the postgres cr
`oc delete postgres example-postgres -n cloud-resource-operator`
Verify that the vpc is deleted


`aws ec2 describe-vpcs --filter "Name=tag-value,Values=RHMI Cloud Resource VPC"`

Expected Output
```
{
    "Vpcs": []
}

```
Patch the config map to have no default

```
oc patch configMap cloud-resources-aws-strategies -n cloud-resource-operator --type='json' -p '[{"op": "add", "path": "/data/_network", "value":"{ \"development\": { \"createStrategy\": { \"CidrBlock\": \"''\" } } }"}]'
```


Create a postgres cr
Run `make cluster/seed/managed/postgres`

Verify that the default cidr block has been generated and the vpc is created.

`aws ec2 describe-vpcs --filter "Name=tag-value,Values=RHMI Cloud Resource VPC"`

The expected cidr block will depend on the cluster cidr block. The options begin at 10.0.0.0/26. If you cluster machine cidr is _not_ that range then the vpc cidr would be 10.0.0.0/26. If not it will be 10.1.0.0/26.

Check the 

```{
    "Vpcs": [
        {
            "CidrBlock": "10.0.0.0/26",
     ......
            "CidrBlockAssociationSet": [
                {
                   ....
                    "CidrBlock": "10.0.0.0/26",
                    "CidrBlockState": {
                        "State": "associated"
                    }
                }
            ],
.....
            "Tags": [
                {
                    "Key": "Name",
                    "Value": "RHMI Cloud Resource VPC"
                },
      .......
}
```

## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below