### PR TITLE
MGDAPI-1857: Add the ApplyImmediately flag to rds db engine upgrades

### DIFF
--- a/apis/integreatly/v1alpha1/types/types.go
+++ b/apis/integreatly/v1alpha1/types/types.go
@@ -23,10 +23,12 @@ type SecretRef struct {
 
 // +kubebuilder:object:generate=true
 type ResourceTypeSpec struct {
-	Type       string     `json:"type"`
-	Tier       string     `json:"tier"`
-	SkipCreate bool       `json:"skipCreate,omitempty"`
-	SecretRef  *SecretRef `json:"secretRef"`
+	Type       string `json:"type"`
+	Tier       string `json:"tier"`
+	SkipCreate bool   `json:"skipCreate,omitempty"`
+	// ApplyImmediately is only available to Postgres cr, for blobstorage and redis cr's currently does nothing
+	ApplyImmediately bool       `json:"applyImmediately,omitempty"`
+	SecretRef        *SecretRef `json:"secretRef"`
 }
 
 type StatusPhase string

--- a/config/crd/bases/integreatly.org_blobstorages.yaml
+++ b/config/crd/bases/integreatly.org_blobstorages.yaml
@@ -35,6 +35,8 @@ spec:
             type: object
           spec:
             properties:
+              applyImmediately:
+                type: boolean
               secretRef:
                 properties:
                   name:

--- a/config/crd/bases/integreatly.org_postgres.yaml
+++ b/config/crd/bases/integreatly.org_postgres.yaml
@@ -35,6 +35,8 @@ spec:
             type: object
           spec:
             properties:
+              applyImmediately:
+                type: boolean
               secretRef:
                 properties:
                   name:

--- a/config/crd/bases/integreatly.org_redis.yaml
+++ b/config/crd/bases/integreatly.org_redis.yaml
@@ -35,6 +35,8 @@ spec:
             type: object
           spec:
             properties:
+              applyImmediately:
+                type: boolean
               secretRef:
                 properties:
                   name:


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/MGDAPI-1857

## Verification

- Clone this branch
- Edit the engine version on line https://github.com/integr8ly/cloud-resource-operator/blob/master/pkg/providers/aws/provider_postgres.go#L55 to `"10.13"`
- Run `make cluster/prepare`
- Run `make run`
- Run `make cluster/seed/managed/postgres`
- Edit the example-postgres cr and add applyImmediately: true to the spec
```yaml
spec:
  applyImmediately: true
  secretRef:
    name: example-postgres-sec
  tier: development
  type: managed
```
- Wait for rds to finish provisioning
- Stop `make run` ctrl-c
- Edit the engine version on line https://github.com/integr8ly/cloud-resource-operator/blob/master/pkg/providers/aws/provider_postgres.go#L55 to `"10.15"`
- `make run` again
- Confirm that the version change is applied immediately either in the aws console or with aws cli [describe-db-instances](https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-instances.html)
```bash
# This returns the instance Identifier
oc get postgres example-postgres -o json | jq '.metadata.annotations.resourceIdentifier'
"mwcollabbyocf88tpcloudresourceopera-tquz"
# Check the status to see , should go to `upgrading` after re-running the operator and then `available` once its finished upgrading  
$ aws rds describe-db-instances --db-instance-identifier=mwcollabbyocf88tpcloudresourceopera-tquz --region=eu-west-2 |  jq '.DBInstances[0].DBInstanceStatus'
# This returns the info on the rds instance engine version
$ aws rds describe-db-instances --db-instance-identifier=mwcollabbyocf88tpcloudresourceopera-tquz --region=eu-west-2 |  jq '.DBInstances[0].EngineVersion'
```
## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below