### PR TITLE
replace cloud-resources.v0.24.1, skip cloud-resources.v0.25.0, version 0.26.0

### DIFF
--- a/packagemanifests/0.26.0/cloud-resource-operator.clusterserviceversion.yaml
+++ b/packagemanifests/0.26.0/cloud-resource-operator.clusterserviceversion.yaml
@@ -328,7 +328,7 @@ spec:
   maturity: alpha
   provider:
     name: Integreatly
-  replaces: cloud-resources.v0.25.0
+  replaces: cloud-resources.v0.24.1
   skips:
     - cloud-resources.v0.25.0
   version: 0.26.0


### PR DESCRIPTION
## Overview
change the 0.26.0 csv to replace cloud-resources.v0.24.1, skip cloud-resources.v0.25.0

fixes break in olm install

Jira: MGDAPI-1857

