### PR TITLE
add the applyImmediately flag

### DIFF
--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -276,7 +276,7 @@ func (p *RedisProvider) createElasticacheCluster(ctx context.Context, r *v1alpha
 	}
 
 	// check if any modifications are required to bring the elasticache instance up to date with the strategy map.
-	modifyInput, err := buildElasticacheUpdateStrategy(ec2Svc, elasticacheConfig, foundCache, replicationGroupClusters, logger)
+	modifyInput, err := buildElasticacheUpdateStrategy(ec2Svc, elasticacheConfig, foundCache, replicationGroupClusters, logger, r.Spec.ApplyImmediately)
 	if err != nil {
 		errMsg := "failed to build elasticache modify strategy"
 		return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
@@ -644,7 +644,7 @@ func (p *RedisProvider) isLastResource(ctx context.Context, namespace string) (b
 // if modifications are required, a modify input struct will be returned with all proposed changes.
 //
 // if no modifications are required, nil will be returned.
-func buildElasticacheUpdateStrategy(ec2Client ec2iface.EC2API, elasticacheConfig *elasticache.CreateReplicationGroupInput, foundConfig *elasticache.ReplicationGroup, replicationGroupClusters []elasticache.CacheCluster, logger *logrus.Entry) (*elasticache.ModifyReplicationGroupInput, error) {
+func buildElasticacheUpdateStrategy(ec2Client ec2iface.EC2API, elasticacheConfig *elasticache.CreateReplicationGroupInput, foundConfig *elasticache.ReplicationGroup, replicationGroupClusters []elasticache.CacheCluster, logger *logrus.Entry, applyImmediately bool) (*elasticache.ModifyReplicationGroupInput, error) {
 	// setup logger.
 	actionLogger := resources.NewActionLogger(logger, "buildElasticacheUpdateStrategy")
 	actionLogger.Infof("verifying that %s configuration is as expected", *foundConfig.ReplicationGroupId)
@@ -740,6 +740,10 @@ func buildElasticacheUpdateStrategy(ec2Client ec2iface.EC2API, elasticacheConfig
 		if elasticacheConfig.SnapshotWindow != nil && *elasticacheConfig.SnapshotWindow != *foundCacheCluster.SnapshotWindow {
 			modifyInput.SnapshotWindow = elasticacheConfig.SnapshotWindow
 			updateFound = true
+		}
+
+		if applyImmediately{
+			modifyInput.ApplyImmediately = aws.Bool(applyImmediately)
 		}
 	}
 
@@ -1011,7 +1015,7 @@ func (p *RedisProvider) setRedisServiceMaintenanceMetric(ctx context.Context, ca
 		return
 	}
 
-	logrus.Infof("there are elasticache service update actions: %d available", len(output.UpdateActions))
+	logrus.Infof("there are elasticache service update actions %d available : %s", len(output.UpdateActions), output.UpdateActions)
 	for _, updateAction := range output.UpdateActions {
 		metricLabels := map[string]string{}
 		metricLabels["clusterID"] = clusterID

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -742,7 +742,7 @@ func buildElasticacheUpdateStrategy(ec2Client ec2iface.EC2API, elasticacheConfig
 			updateFound = true
 		}
 
-		if applyImmediately{
+		if applyImmediately {
 			modifyInput.ApplyImmediately = aws.Bool(applyImmediately)
 		}
 	}

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -742,9 +742,8 @@ func buildElasticacheUpdateStrategy(ec2Client ec2iface.EC2API, elasticacheConfig
 			updateFound = true
 		}
 
-		if applyImmediately {
-			modifyInput.ApplyImmediately = aws.Bool(applyImmediately)
-		}
+		// ApplyImmediately flag is controlled by the redis cr.Spec.applyImmediately flag
+		modifyInput.ApplyImmediately = aws.Bool(applyImmediately)
 	}
 
 	if updateFound {

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -916,7 +916,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 		foundConfig              *elasticache.ReplicationGroup
 		replicationGroupClusters []elasticache.CacheCluster
 		logger                   *logrus.Entry
-		applyImmediately		 bool
+		applyImmediately         bool
 	}
 	tests := []struct {
 		name    string
@@ -947,7 +947,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 						SnapshotWindow:             aws.String("test"),
 					},
 				},
-				logger: testLogger,
+				logger:           testLogger,
 				applyImmediately: false,
 			},
 			want: nil,
@@ -975,7 +975,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 						SnapshotWindow:             aws.String("test"),
 					},
 				},
-				logger: testLogger,
+				logger:           testLogger,
 				applyImmediately: false,
 			},
 			want: nil,
@@ -1003,7 +1003,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 						SnapshotWindow:             aws.String("test"),
 					},
 				},
-				logger: testLogger,
+				logger:           testLogger,
 				applyImmediately: false,
 			},
 			want:    nil,
@@ -1032,7 +1032,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 						SnapshotWindow:             aws.String("test"),
 					},
 				},
-				logger: testLogger,
+				logger:           testLogger,
 				applyImmediately: false,
 			},
 			want:    nil,
@@ -1072,7 +1072,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 						PreferredAvailabilityZone:  aws.String("test"),
 					},
 				},
-				logger: testLogger,
+				logger:           testLogger,
 				applyImmediately: true,
 			},
 			want: &elasticache.ModifyReplicationGroupInput{
@@ -1104,7 +1104,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 				},
 				replicationGroupClusters: []elasticache.CacheCluster{},
 				logger:                   testLogger,
-				applyImmediately: false,
+				applyImmediately:         false,
 			},
 			want:    nil,
 			wantErr: "failed to get instance type offerings for type cache.test2: test",
@@ -1143,7 +1143,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 						PreferredAvailabilityZone:  aws.String("test2"),
 					},
 				},
-				logger: testLogger,
+				logger:           testLogger,
 				applyImmediately: false,
 			},
 			want: &elasticache.ModifyReplicationGroupInput{

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -1147,7 +1147,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 				applyImmediately: false,
 			},
 			want: &elasticache.ModifyReplicationGroupInput{
-				ApplyImmediately:			aws.Bool(false),
+				ApplyImmediately:           aws.Bool(false),
 				SnapshotRetentionLimit:     aws.Int64(50),
 				PreferredMaintenanceWindow: aws.String("newValue"),
 				SnapshotWindow:             aws.String("newValue"),

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -1147,6 +1147,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 				applyImmediately: false,
 			},
 			want: &elasticache.ModifyReplicationGroupInput{
+				ApplyImmediately:			aws.Bool(false),
 				SnapshotRetentionLimit:     aws.Int64(50),
 				PreferredMaintenanceWindow: aws.String("newValue"),
 				SnapshotWindow:             aws.String("newValue"),

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -916,6 +916,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 		foundConfig              *elasticache.ReplicationGroup
 		replicationGroupClusters []elasticache.CacheCluster
 		logger                   *logrus.Entry
+		applyImmediately		 bool
 	}
 	tests := []struct {
 		name    string
@@ -947,6 +948,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 					},
 				},
 				logger: testLogger,
+				applyImmediately: false,
 			},
 			want: nil,
 		},
@@ -974,6 +976,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 					},
 				},
 				logger: testLogger,
+				applyImmediately: false,
 			},
 			want: nil,
 		},
@@ -1001,6 +1004,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 					},
 				},
 				logger: testLogger,
+				applyImmediately: false,
 			},
 			want:    nil,
 			wantErr: "invalid redis version: failed to parse desired version: Malformed version: some invalid value",
@@ -1029,6 +1033,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 					},
 				},
 				logger: testLogger,
+				applyImmediately: false,
 			},
 			want:    nil,
 			wantErr: "invalid redis version: failed to parse current version: Malformed version: some invalid value",
@@ -1068,6 +1073,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 					},
 				},
 				logger: testLogger,
+				applyImmediately: true,
 			},
 			want: &elasticache.ModifyReplicationGroupInput{
 				CacheNodeType:              aws.String("cache.newValue"),
@@ -1076,6 +1082,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 				SnapshotWindow:             aws.String("newValue"),
 				ReplicationGroupId:         aws.String("test-id"),
 				EngineVersion:              aws.String(defaultEngineVersion),
+				ApplyImmediately:           aws.Bool(true),
 			},
 		},
 		{
@@ -1097,6 +1104,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 				},
 				replicationGroupClusters: []elasticache.CacheCluster{},
 				logger:                   testLogger,
+				applyImmediately: false,
 			},
 			want:    nil,
 			wantErr: "failed to get instance type offerings for type cache.test2: test",
@@ -1136,6 +1144,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 					},
 				},
 				logger: testLogger,
+				applyImmediately: false,
 			},
 			want: &elasticache.ModifyReplicationGroupInput{
 				SnapshotRetentionLimit:     aws.Int64(50),
@@ -1148,7 +1157,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := buildElasticacheUpdateStrategy(tt.args.ec2Client, tt.args.elasticacheConfig, tt.args.foundConfig, tt.args.replicationGroupClusters, tt.args.logger)
+			got, err := buildElasticacheUpdateStrategy(tt.args.ec2Client, tt.args.elasticacheConfig, tt.args.foundConfig, tt.args.replicationGroupClusters, tt.args.logger, tt.args.applyImmediately)
 			if tt.wantErr != "" && err.Error() != tt.wantErr {
 				t.Errorf("createElasticacheCluster() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
## Overview

Jira: MGDAPI-2253

Add the applyImmediately flag to redis 

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make cluster/seed/managed/redis`
- Change the defaultEngineVersion to 5.0.3 on [/pkg/providers/aws/provider_redis.go](https://github.com/integr8ly/cloud-resource-operator/blob/master/pkg/providers/aws/provider_redis.go#L45)
```go
	defaultEngineVersion     = "5.0.3"
```
- Run `make run`
- Wait for redis to provision 
- Stop the Operator running locally
- Change the defaultEngineVersion back to 5.0.6
- Add the applyImmediately flag to the redis cr
```yaml
spec:
  applyImmediately: true
  secretRef:
    name: example-redis-sec
  tier: development
  type: managed
```
-  Run `make run`
- The redis should upgrade the engin version to 5.0.6 and you should see that the serviceUpdate has been applied in the logs . You should see the **UpdateActionStatus** is **complete** and the **ServiceUpdateName** is **elasticache-20210615-002**
```bash
INFO[0217] there are elasticache service update actions 1 available : [{
  Engine: "redis",
  NodesUpdated: "2/2",
  ReplicationGroupId: "mwcollabbyoc7rk2xcloudresourceopera-4poh",
  ServiceUpdateName: "elasticache-20210615-002",
  ServiceUpdateRecommendedApplyByDate: 2021-06-30 15:59:59 +0000 UTC,
  ServiceUpdateReleaseDate: 2021-06-23 16:00:00 +0000 UTC,
  ServiceUpdateSeverity: "critical",
  ServiceUpdateStatus: "available",
  ServiceUpdateType: "security-update",
  SlaMet: "n/a",
  UpdateActionAvailableDate: 2021-07-06 09:25:35.668 +0000 UTC,
  UpdateActionStatus: "complete",
  UpdateActionStatusModifiedDate: 2021-07-06 09:25:35.73 +0000 UTC
}] 

```
Also in the aws console you should see that redis `Update Action Status` is up to date 
![image](https://user-images.githubusercontent.com/16667688/124584339-07857680-de4c-11eb-9236-12c07115fa9d.png)

