### PR TITLE
refactor to report the status of the postgres, if nil is returned fro…

### DIFF
--- a/controllers/postgres/postgres_controller.go
+++ b/controllers/postgres/postgres_controller.go
@@ -195,7 +195,7 @@ func (r *PostgresReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error
 		}
 
 		// create the postgres instance
-		ps, msg, err := p.CreatePostgres(ctx, instance)
+		ps, msg, err := p.ReconcilePostgres(ctx, instance)
 		if err != nil {
 			instance.Status.SecretRef = &croType.SecretRef{}
 			if updateErr := resources.UpdatePhase(ctx, r.Client, instance, croType.PhaseFailed, msg.WrapError(err)); updateErr != nil {
@@ -204,7 +204,7 @@ func (r *PostgresReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error
 			return ctrl.Result{}, err
 		}
 		if ps == nil {
-			r.logger.Info("secret data is still reconciling, postgres instance is nil")
+			r.logger.Info(msg)
 			instance.Status.SecretRef = &croType.SecretRef{}
 			if err = resources.UpdatePhase(ctx, r.Client, instance, croType.PhaseInProgress, msg); err != nil {
 				return ctrl.Result{}, err

--- a/pkg/providers/openshift/provider_postgres.go
+++ b/pkg/providers/openshift/provider_postgres.go
@@ -87,7 +87,7 @@ func (p *PostgresProvider) GetReconcileTime(pg *v1alpha1.Postgres) time.Duration
 	return resources.GetForcedReconcileTimeOrDefault(defaultReconcileTime)
 }
 
-func (p *PostgresProvider) CreatePostgres(ctx context.Context, ps *v1alpha1.Postgres) (*providers.PostgresInstance, croType.StatusMessage, error) {
+func (p *PostgresProvider) ReconcilePostgres(ctx context.Context, ps *v1alpha1.Postgres) (*providers.PostgresInstance, croType.StatusMessage, error) {
 	// handle provider-specific finalizer
 	if err := resources.CreateFinalizer(ctx, p.Client, ps, DefaultFinalizer); err != nil {
 		errMsg := "failed to set finalizer"

--- a/pkg/providers/openshift/provider_postgres_test.go
+++ b/pkg/providers/openshift/provider_postgres_test.go
@@ -209,13 +209,13 @@ func TestOpenShiftPostgresProvider_CreatePostgres(t *testing.T) {
 				ConfigManager: tt.fields.ConfigManager,
 				PodCommander:  tt.fields.PodCommander,
 			}
-			got, _, err := p.CreatePostgres(tt.args.ctx, tt.args.postgres)
+			got, _, err := p.ReconcilePostgres(tt.args.ctx, tt.args.postgres)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("CreatePostgres() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ReconcilePostgres() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("CreatePostgres() got = %+v, want %+v", got.DeploymentDetails, tt.want.DeploymentDetails)
+				t.Errorf("ReconcilePostgres() got = %+v, want %+v", got.DeploymentDetails, tt.want.DeploymentDetails)
 			}
 		})
 	}
@@ -415,7 +415,7 @@ func TestOpenShiftPostgresProvider_overrideDefaults(t *testing.T) {
 				Logger:        tt.fields.Logger,
 				ConfigManager: tt.fields.ConfigManager,
 			}
-			_, _, err := p.CreatePostgres(tt.args.ctx, tt.args.postgres)
+			_, _, err := p.ReconcilePostgres(tt.args.ctx, tt.args.postgres)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("overrideDefaults() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/providers/types.go
+++ b/pkg/providers/types.go
@@ -68,7 +68,7 @@ type PostgresProvider interface {
 	GetName() string
 	SupportsStrategy(s string) bool
 	GetReconcileTime(ps *v1alpha1.Postgres) time.Duration
-	CreatePostgres(ctx context.Context, ps *v1alpha1.Postgres) (*PostgresInstance, croType.StatusMessage, error)
+	ReconcilePostgres(ctx context.Context, ps *v1alpha1.Postgres) (*PostgresInstance, croType.StatusMessage, error)
 	DeletePostgres(ctx context.Context, ps *v1alpha1.Postgres) (croType.StatusMessage, error)
 }
 


### PR DESCRIPTION
…m the reconcile function, report the msg as returned, this covers secret, rds updates and service updates

## Overview

Jira: <jira-id>

## Verification

Upgrade

- Checkout this branch
- Run `make cluster/prepare`
- Checkout tag v0.30.0 
- Run `make cluster/seed/managed/postgres`
- Wait for the postgres to become available
- Checkout this branch
- Update postgres cr spec.applyImmediatley to true
- Run `make run`
- Watch the status of the rds in aws using `watch -n 1 "aws rds describe-db-instances --region=<region> | jq '.DBInstances[].DBInstanceStatus'"` vs the status of the cr. It should get updated to upgrading during the engine version upgrade and to maintenance when the service-update gets reflected to the cr with status
- `reconcileRDSInstance() in progress, current aws rds resource status is
    maintenance`

Install
- Run installation of this branch
- Verify Engine Version is 10.16
- Verify that serviceUpdate is applied
- Verify that the status of the aws gets reflected back to the cr during installation

## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below