### PR TITLE
MGDAPI-2906

### DIFF
--- a/pkg/providers/aws/cluster_network_provider.go
+++ b/pkg/providers/aws/cluster_network_provider.go
@@ -57,6 +57,7 @@ const (
 	defaultNumberOfExpectedSubnets       = 2
 	clusterOwnedTagKeyPrefix             = "kubernetes.io/cluster/"
 	clusterOwnedTagValue                 = "owned"
+	clusterSharedTagValue                = "shared"
 	//network peering
 	tagVpcPeeringNameValue = "RHMI Cloud Resource Peering Connection"
 	// filter names for vpc peering connections
@@ -359,18 +360,12 @@ func (n *NetworkProvider) CreateNetworkConnection(ctx context.Context, network *
 		return nil, errorUtil.Wrap(err, "failure while reconciling standalone security group")
 	}
 
-	// a tag for identifying cluster owned vpc resources
-	clusterVpcRouteTableTag, err := getClusterOwnerTag(ctx, n.Client)
-	if err != nil {
-		return nil, errorUtil.Wrap(err, "error building cluster owner tag")
-	}
-
-	// find cluter vpc route tables using cluster vpc route table tag
+	// find cluster vpc route tables using associated cluster subnets
 	// multiples route tables can exist for a single vpc (main and secondary)
-	logger.Info("finding cluster route table(s)")
-	clusterVpcRouteTables, err := n.getVPCRouteTable(clusterVpcRouteTableTag)
+	logger.Info("finding cluster route table(s) using associated cluster subnets")
+	clusterVpcRouteTables, err := n.getClusterRouteTables(ctx)
 	if err != nil {
-		return nil, errorUtil.Wrap(err, "failure while getting vpc route table")
+		return nil, errorUtil.Wrap(err, "failure while getting vpc route tables")
 	}
 	logger.Infof("found %d cluster vpc route tables", len(clusterVpcRouteTables))
 
@@ -408,15 +403,9 @@ func (n *NetworkProvider) CreateNetworkConnection(ctx context.Context, network *
 		}
 	}
 
-	// get croOwner tag to use in getting standalone vpc route tables
-	croOwnerTag, err := getCloudResourceOperatorOwnerTag(ctx, n.Client)
-	if err != nil {
-		return nil, errorUtil.Wrap(err, "error generating cloud resource owner tag")
-	}
-
 	// get standalone vpc route table using cro owner tag
 	logger.Info("finding standalone route table(s)")
-	standAloneVpcRouteTables, err := n.getVPCRouteTable(genericToEc2Tag(croOwnerTag))
+	standAloneVpcRouteTables, err := n.getCRORouteTables(ctx)
 	if err != nil {
 		return nil, errorUtil.Wrap(err, "error getting standalone vpc route tables")
 	}
@@ -479,16 +468,10 @@ func (n *NetworkProvider) DeleteNetworkConnection(ctx context.Context, networkPe
 		}
 	}
 
-	// a tag for identifying cluster owned vpc resources
-	clusterVpcRouteTableTag, err := getClusterOwnerTag(ctx, n.Client)
-	if err != nil {
-		return errorUtil.Wrap(err, "error building cluster owner tag")
-	}
-
-	// find cluster vpc route tables using cluster vpc route table tag
+	// find cluster vpc route tables using cluster vpcID
 	// multiple route tables can exist for a single vpc (main and secondary)
 	logger.Info("finding cluster route table(s)")
-	clusterVpcRouteTables, err := n.getVPCRouteTable(clusterVpcRouteTableTag)
+	clusterVpcRouteTables, err := n.getClusterRouteTables(ctx)
 	if err != nil {
 		return errorUtil.Wrap(err, "failure while getting vpc route table")
 	}
@@ -533,7 +516,7 @@ func (n *NetworkProvider) CreateNetworkPeering(ctx context.Context, network *Net
 
 	clusterVpc, err := getClusterVpc(ctx, n.Client, n.Ec2Api, n.Logger)
 	if err != nil {
-		return nil, errorUtil.Wrap(err, "failed to get cluster vpc")
+		return nil, errorUtil.Wrap(err, "failed to get cluster vpc, no vpc found")
 	}
 
 	peeringConnection, err := n.getNetworkPeering(ctx, network)
@@ -1176,9 +1159,37 @@ func (n *NetworkProvider) reconcileStandaloneVPCSubnets(ctx context.Context, log
 	return subs, nil
 }
 
-// getVPCRouteTable will return a list of route tables based on a route table tag
+func (n *NetworkProvider) getClusterRouteTables(ctx context.Context) ([]*ec2.RouteTable, error) {
+	routeTables, err := n.Ec2Api.DescribeRouteTables(&ec2.DescribeRouteTablesInput{})
+	if err != nil {
+		return nil, errorUtil.Wrap(err, "failed to get route tables")
+	}
+
+	clusterVPC, err := getClusterVpc(ctx, n.Client, n.Ec2Api, n.Logger)
+	if err != nil {
+		return nil, errorUtil.Wrap(err, "failed to get cluster vpc")
+	}
+	var foundRouteTables []*ec2.RouteTable
+	for _, routeTable := range routeTables.RouteTables {
+		if routeTable != nil && *routeTable.VpcId == *clusterVPC.VpcId {
+			foundRouteTables = append(foundRouteTables, routeTable)
+		}
+	}
+	if len(foundRouteTables) == 0 {
+		return nil, errorUtil.New(fmt.Sprintf("could not find any route table with the associated vpc id %s", aws.StringValue(clusterVPC.VpcId)))
+	}
+	return foundRouteTables, nil
+}
+
+// getCRORouteTables will return a list of route tables based on a route table tag
 // we expect there to be route tables, if none are found we return an error
-func (n *NetworkProvider) getVPCRouteTable(routeTableTag *ec2.Tag) ([]*ec2.RouteTable, error) {
+func (n *NetworkProvider) getCRORouteTables(ctx context.Context) ([]*ec2.RouteTable, error) {
+	// get croOwner tag to use in getting standalone vpc route tables
+	croOwnerTag, err := getCloudResourceOperatorOwnerTag(ctx, n.Client)
+	if err != nil {
+		return nil, errorUtil.Wrap(err, "error generating cloud resource owner tag")
+	}
+
 	routeTables, err := n.Ec2Api.DescribeRouteTables(&ec2.DescribeRouteTablesInput{})
 	if err != nil {
 		return nil, errorUtil.Wrap(err, "failed to get route tables")
@@ -1187,13 +1198,13 @@ func (n *NetworkProvider) getVPCRouteTable(routeTableTag *ec2.Tag) ([]*ec2.Route
 	var foundRouteTables []*ec2.RouteTable
 	for _, routeTable := range routeTables.RouteTables {
 		routeTableTags := ec2TagsToGeneric(routeTable.Tags)
-		if tagsContains(routeTableTags, aws.StringValue(routeTableTag.Key), aws.StringValue(routeTableTag.Value)) {
+		if tagsContains(routeTableTags, aws.StringValue(genericToEc2Tag(croOwnerTag).Key), aws.StringValue(genericToEc2Tag(croOwnerTag).Value)) {
 			foundRouteTables = append(foundRouteTables, routeTable)
 		}
 	}
 
 	if len(foundRouteTables) == 0 {
-		return nil, errorUtil.New(fmt.Sprintf("could not find any route table with the tag key: %s and value: %s", aws.StringValue(routeTableTag.Key), aws.StringValue(routeTableTag.Value)))
+		return nil, errorUtil.New(fmt.Sprintf("could not find any route table with the tag key: %s and value: %s", aws.StringValue(genericToEc2Tag(croOwnerTag).Key), aws.StringValue(genericToEc2Tag(croOwnerTag).Value)))
 	}
 	return foundRouteTables, nil
 }
@@ -1747,6 +1758,14 @@ func getCloudResourceOperatorOwnerTag(ctx context.Context, client client.Client)
 // denoted -> ` kubernetes.io/cluster/<cluster-id>=owned
 // this utility function builds and returns the tag
 func getClusterOwnerTag(ctx context.Context, client client.Client) (*ec2.Tag, error) {
+	return getClusterTag(ctx, client, clusterOwnedTagValue)
+}
+
+func getClusterSharedTag(ctx context.Context, client client.Client) (*ec2.Tag, error) {
+	return getClusterTag(ctx, client, clusterSharedTagValue)
+}
+
+func getClusterTag(ctx context.Context, client client.Client, tagValue string) (*ec2.Tag, error) {
 	clusterID, err := resources.GetClusterID(ctx, client)
 	if err != nil {
 		return nil, errorUtil.Wrap(err, "error getting clusterID")
@@ -1754,8 +1773,8 @@ func getClusterOwnerTag(ctx context.Context, client client.Client) (*ec2.Tag, er
 
 	// a tag for identifying cluster owned vpcs
 	return &ec2.Tag{
-		Key:   aws.String(fmt.Sprintf("%s%s", clusterOwnedTagKeyPrefix, clusterID)),
-		Value: aws.String(clusterOwnedTagValue),
+		Key:   aws.String(getOSDClusterTagKey(clusterID)),
+		Value: aws.String(tagValue),
 	}, nil
 }
 

--- a/pkg/providers/aws/cluster_vpc.go
+++ b/pkg/providers/aws/cluster_vpc.go
@@ -457,14 +457,27 @@ func getSubnets(ec2Svc ec2iface.EC2API) ([]*ec2.Subnet, error) {
 	return subs, nil
 }
 
+func getVPCIDByClusterSubnets(ec2Svc ec2iface.EC2API, clusterID string) (string, error) {
+	listOutput, err := ec2Svc.DescribeSubnets(&ec2.DescribeSubnetsInput{})
+	if err != nil {
+		return "", err
+	}
+
+	for _, sub := range listOutput.Subnets {
+		for _, tag := range sub.Tags {
+			if tag != nil && (*tag.Value == "owned" || *tag.Value == "shared") &&
+				*tag.Key == getOSDClusterTagKey(clusterID) {
+				return *sub.VpcId, nil
+			}
+		}
+	}
+	return "", errorUtil.New(fmt.Sprintf("failed to get cluster vpc id, no vpc found with osd cluster tag: could not find cluster associated subnets with clusterID %s", clusterID))
+}
+
 // function to get vpc of a cluster
 func getClusterVpc(ctx context.Context, c client.Client, ec2Svc ec2iface.EC2API, logger *logrus.Entry) (*ec2.Vpc, error) {
 	// first call to aws api from the network provider is to get cluster vpc
 	// polling to allow credential minter time to reconcile credentials
-	vpcs, err := ec2Svc.DescribeVpcs(&ec2.DescribeVpcsInput{})
-	if err != nil {
-		return nil, errorUtil.Wrap(err, "error getting vpcs")
-	}
 
 	// get cluster id
 	clusterID, err := resources.GetClusterID(ctx, c)
@@ -472,22 +485,24 @@ func getClusterVpc(ctx context.Context, c client.Client, ec2Svc ec2iface.EC2API,
 		return nil, errorUtil.Wrap(err, "error getting clusterID")
 	}
 
-	// find associated vpc to cluster
-	var foundVPC *ec2.Vpc
-	logger.Infof("searching for cluster %s vpc", clusterID)
-	for _, vpc := range vpcs.Vpcs {
-		for _, tag := range vpc.Tags {
-			if *tag.Value == fmt.Sprintf("%s-vpc", clusterID) {
-				foundVPC = vpc
-			}
-		}
+	vpcId, err := getVPCIDByClusterSubnets(ec2Svc, clusterID)
+	if err != nil {
+		return nil, errorUtil.Wrap(err, "error getting vpc id from associated subnets")
 	}
 
-	if foundVPC == nil {
+	vpcs, err := ec2Svc.DescribeVpcs(&ec2.DescribeVpcsInput{VpcIds: []*string{aws.String(vpcId)}})
+	if err != nil {
+		return nil, errorUtil.Wrap(err, fmt.Sprintf("error getting vpc with id %s", vpcId))
+	}
+
+	if len(vpcs.Vpcs) == 0 {
 		return nil, errorUtil.New("error, no vpc found")
 	}
-	logger.Infof("found cluster %s vpc %s", clusterID, *foundVPC.VpcId)
-	return foundVPC, nil
+	if len(vpcs.Vpcs) > 1 {
+		return nil, errorUtil.New("error, more than one vpc found associated with cluster subnets")
+	}
+	logger.Infof("found cluster %s vpc %s", clusterID, *vpcs.Vpcs[0].VpcId)
+	return vpcs.Vpcs[0], nil
 }
 
 // getSecurityGroup a utility function for returning cro resource security group
@@ -510,4 +525,8 @@ func getSecurityGroup(ec2Svc ec2iface.EC2API, secName string) (*ec2.SecurityGrou
 	}
 
 	return foundSecGroup, nil
+}
+
+func getOSDClusterTagKey(clusterID string) string {
+	return fmt.Sprintf("%s%s", clusterOwnedTagKeyPrefix, clusterID)
 }

--- a/pkg/providers/aws/cluster_vpc_test.go
+++ b/pkg/providers/aws/cluster_vpc_test.go
@@ -45,7 +45,7 @@ func Test_buildSubnetAddress(t *testing.T) {
 				logger: logrus.NewEntry(logrus.StandardLogger()),
 				vpc: &ec2.Vpc{
 					CidrBlock: aws.String("10.11.128.0/26"),
-					VpcId:     aws.String("test"),
+					VpcId:     aws.String(mockNetworkVpcId),
 				},
 			},
 			want: []string{
@@ -60,7 +60,7 @@ func Test_buildSubnetAddress(t *testing.T) {
 				logger: logrus.NewEntry(logrus.StandardLogger()),
 				vpc: &ec2.Vpc{
 					CidrBlock: aws.String("10.11.128.0/23"),
-					VpcId:     aws.String("test"),
+					VpcId:     aws.String(mockNetworkVpcId),
 				},
 			},
 			want: []string{

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -350,7 +350,16 @@ func Test_createRedisCluster(t *testing.T) {
 						return &elasticache.DescribeReplicationGroupsOutput{}, nil
 					}
 				}),
-				ec2Svc:                  &mockEc2Client{vpcs: buildVpcs(), subnets: buildValidBundleSubnets(), secGroups: buildSecurityGroups(secName)},
+				ec2Svc: &mockEc2Client{
+					vpcs:      buildVpcs(),
+					subnets:   buildValidBundleSubnets(),
+					secGroups: buildSecurityGroups(secName),
+					describeSubnetsFn: func(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
+						return &ec2.DescribeSubnetsOutput{
+							Subnets: buildValidBundleSubnets(),
+						}, nil
+					},
+				},
 				r:                       buildTestRedisCR(),
 				stsSvc:                  &mockStsClient{},
 				redisConfig:             &elasticache.CreateReplicationGroupInput{},
@@ -403,6 +412,11 @@ func Test_createRedisCluster(t *testing.T) {
 					ec2Client.vpcs = buildVpcs()
 					ec2Client.subnets = buildValidBundleSubnets()
 					ec2Client.secGroups = buildSecurityGroups(secName)
+					ec2Client.describeSubnetsFn = func(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
+						return &ec2.DescribeSubnetsOutput{
+							Subnets: buildValidBundleSubnets(),
+						}, nil
+					}
 				}),
 				r:                       buildTestRedisCR(),
 				stsSvc:                  &mockStsClient{},
@@ -440,6 +454,11 @@ func Test_createRedisCluster(t *testing.T) {
 					ec2Client.vpcs = buildVpcs()
 					ec2Client.subnets = buildValidBundleSubnets()
 					ec2Client.secGroups = buildSecurityGroups(secName)
+					ec2Client.describeSubnetsFn = func(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
+						return &ec2.DescribeSubnetsOutput{
+							Subnets: buildValidBundleSubnets(),
+						}, nil
+					}
 				}),
 				r:                       buildTestRedisCR(),
 				stsSvc:                  &mockStsClient{},
@@ -495,6 +514,11 @@ func Test_createRedisCluster(t *testing.T) {
 					ec2Client.vpcs = buildVpcs()
 					ec2Client.subnets = buildValidBundleSubnets()
 					ec2Client.secGroups = buildSecurityGroups(secName)
+					ec2Client.describeSubnetsFn = func(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
+						return &ec2.DescribeSubnetsOutput{
+							Subnets: buildValidBundleSubnets(),
+						}, nil
+					}
 				}),
 				redisConfig:             &elasticache.CreateReplicationGroupInput{ReplicationGroupId: aws.String("test-id")},
 				stratCfg:                &StrategyConfig{Region: "test"},
@@ -548,6 +572,11 @@ func Test_createRedisCluster(t *testing.T) {
 					ec2Client.vpcs = buildVpcs()
 					ec2Client.subnets = buildValidBundleSubnets()
 					ec2Client.secGroups = buildSecurityGroups(secName)
+					ec2Client.describeSubnetsFn = func(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
+						return &ec2.DescribeSubnetsOutput{
+							Subnets: buildValidBundleSubnets(),
+						}, nil
+					}
 				}),
 				redisConfig: &elasticache.CreateReplicationGroupInput{
 					ReplicationGroupId:     aws.String("test-id"),


### PR DESCRIPTION
# Changes Included in this pr
Refactor to how cro finds cluster vpc and route tables to handle case where the vpc and route tables are not labled with
shared/owned cluster tags - this happens in the case of an osd byovpc cluster installation
This approach should be compatible with non byovpc cases, e.g ccs and non ccs as the tags with be in place with either owned or shared

Instead of getting the cluster VPC by the tag, get the VPC ID from the associated subnets using either the owned or shared tag.
Instead of getting the cluster Route Tables by the tag, get the RouteTables associated with the Cluster VPC ID from above.

# Overview
Jira: https://issues.redhat.com/browse/MGDAPI-2906

# Verification
Please make sure there are no other instances of CRO running in the clusters you are testing.
Verification steps for BYOCVPC and non-BYOCVPC are identical. The only difference is a configuration of the aws resources (tags in particular).

Below you will find instructions on how to verify that VPC setup is as expected. After this you will find two sections with instructions on how to verify install and upgrade. 

Ideally you should do booth (install and upgrade) on each of the clusters (BYOCVPC and non-BYOCVPC)

## Case BYOVPC
Against a BYOC OSD - contact me or Maksym Vavilov for setting up byocvpc cluster

Verify there is no tags on the cluster VPC and Route Table
Cluster VPC (you might want to replace `mvavilov-vpc` with the name of your vpc):
```
aws ec2 describe-vpcs --filter Name=tag:Name,Values=mvavilov-vpc --output json | jq '.Vpcs[0].Tags'
```
Route Table (you might want to replace `mvavilov-vpc` with the name of your vpc):
```
VPC_ID=$(aws ec2 describe-vpcs --filter Name=tag:Name,Values=mvavilov-vpc --output json | jq '.Vpcs[0].VpcId')
aws ec2 describe-route-tables --filters "Name=vpc-id,Values=$VPC_ID" --output json | grep Tags
```
Tags should be empty and VPC should not have a cluster-assiciated tag. 

## CASE non-BYOVPC
Against a CCS OSD

Verify there IS a tag on the cluster VPC and Route Table

## Install
For the install we would go with the "local" approach. The main goal here is to check the logic. 
1. Checkout this branch
2. Run the `make cluster/prepare` 
3. Run `make run` to run the CRO. Keep an eye on the logs untill the end to ensure that there are no errors about the network, errors about credentials are acceptable a couple of times but should resolve.
4. Run `make test/e2e/local` in a separate terminal and ensure tests are suceeding 



## Upgrade
For an upgrade we will go with "bundles" approach. You can create your own bundles or use existing. 
Existing are located at [this repository](https://quay.io/repository/mvavilov/cloud-resource-operator?tab=tags) 
For the install you could use [v0.32.0](https://quay.io/repository/mvavilov/cloud-resource-operator?tag=index-v0.32.0&tab=tags) that was build from the master and as an upgrade version you can use [v0.33.1](https://quay.io/repository/mvavilov/cloud-resource-operator?tag=index-v0.33.1&tab=tags) that was build from this branch. 

1. Login to the cluster and run `make cluster/prepare` - this will create namespace for the CRO to be installed in
2. Create CatalogSource CR that would reference initial CRO. Here is a `cro-operators.yaml` template that could be reused along with `oc apply -f cro-operators.yaml`:
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: cro-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/mvavilov/cloud-resource-operator:index-v0.32.0
```
> Note, that is you want to use own bundles you might want to
> replace the `image` field with you own index
3. Go to your cluster to the Operators -> Operators Hub and search for `Cloud Resource Operator`
4. Double check the referenced image before clicking `install`. In the `Installation mode` fields select `A specific namespace on the cluster` and then `cloud-resource-operator` from the dropdown. That namespace should be present after the wery first step. Set the `Update approval` to `Manual` - this will make verification faster
6. Populate cluster with redis and postgres by
```
make cluster/seed/managed/postgres
make cluster/seed/managed/redis
```
5. Ensure they (redis and postgres) after some time go into completed stage. While they are processing we will prepare the upgrade
6. Go the Operators -> Installed Operators -> Cloud Resource Operator -> Subscription. Locate the CatalogSource and edit the yaml so it (catalog source) point to a new version of CRO. In case you went with existing bundles it would be  `quay.io/mvavilov/cloud-resource-operator:index-v0.33.1`. After this field is updated you should see that upgrade is available.
7. Once Redis and Postgres CRs reporting the `complete` stage, initiate an upgrade 
8. During the upgrade you would see a new `cloud-resoure-operator-` pod go live. Open its logs and ensure that there are no errors about the network, errors about credentials are acceptable a couple of times but should resolve.
9. Delete them and make sure they aren't causing any troubles. 
10. Uninstall CRO and verify it cleans up it's resources:
```
aws ec2 describe-vpcs --output json | jq '.Vpcs[] | .Tags[0].Value'
```
This command will output names of all existing VPCs. If there is not VPC starting with `RHMI...` - CRO cleaned up it's resources. 

## Checklist
- [ ] This PR includes a change to an instance type, I have used script hack/<provider>/supported_types.sh and attached the result below