### PR TITLE
MGDAPI-3207

### DIFF
--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -270,7 +270,8 @@ func (p *RedisProvider) createElasticacheCluster(ctx context.Context, r *v1alpha
 	}
 	var replicationGroupClusters []elasticache.CacheCluster
 	for _, checkedCluster := range cacheClustersOutput.CacheClusters {
-		if *checkedCluster.ReplicationGroupId == *foundCache.ReplicationGroupId {
+		cluster := *checkedCluster
+		if resources.SafeStringDereference(cluster.ReplicationGroupId) == *foundCache.ReplicationGroupId {
 			replicationGroupClusters = append(replicationGroupClusters, *checkedCluster)
 		}
 	}


### PR DESCRIPTION
refactor to how the replicationid is checked on clusters which don't contain one
solving a nil pointer dereference

## Overview

Jira:https://issues.redhat.com/browse/MGDAPI-3207

## Verification

First reproduce the issue
- Check out master
- Run `make cluster/prepare`
- Run `make run`
- Run `make cluster/seed/managed/redis`
- Go to aws and create a memcached elasticache via create 
- Selections -> Memcached -> Amazon Cloud -> provide a name -> number of nodes 1 -> subnet group - select one belonging to the vpc your cluster is deployed to > Use other defaults -> click create

- See that the error mentioned in the JIRA is now present.

- Clone and checkout this branch
- Stop the operator and re Run using `make run`
- The error should no longer be present



## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below