### PR TITLE
MGDAPI-3203 - emit metric around vpc limits hit

### DIFF
--- a/pkg/providers/aws/provider_postgres_test.go
+++ b/pkg/providers/aws/provider_postgres_test.go
@@ -90,6 +90,7 @@ type mockEc2Client struct {
 	describeRouteTablesFn           func(*ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error)
 	createRouteFn                   func(*ec2.CreateRouteInput) (*ec2.CreateRouteOutput, error)
 	deleteRouteFn                   func(*ec2.DeleteRouteInput) (*ec2.DeleteRouteOutput, error)
+	createVpcFn                     func(*ec2.CreateVpcInput) (*ec2.CreateVpcOutput, error)
 	deleteVpcFn                     func(*ec2.DeleteVpcInput) (*ec2.DeleteVpcOutput, error)
 	describeInstanceTypeOfferingsFn func(input *ec2.DescribeInstanceTypeOfferingsInput) (*ec2.DescribeInstanceTypeOfferingsOutput, error)
 	WaitUntilVpcExistsFn            func(*ec2.DescribeVpcsInput) error
@@ -288,10 +289,13 @@ func (m *mockEc2Client) WaitUntilVpcExists(input *ec2.DescribeVpcsInput) error {
 	return m.WaitUntilVpcExistsFn(input)
 }
 
-func (m *mockEc2Client) CreateVpc(*ec2.CreateVpcInput) (*ec2.CreateVpcOutput, error) {
-	return &ec2.CreateVpcOutput{
-		Vpc: m.vpc,
-	}, nil
+func (m *mockEc2Client) CreateVpc(input *ec2.CreateVpcInput) (*ec2.CreateVpcOutput, error) {
+	if m.createVpcFn == nil {
+		return &ec2.CreateVpcOutput{
+			Vpc: m.vpc,
+		}, nil
+	}
+	return m.createVpcFn(input)
 }
 
 func (m *mockEc2Client) DeleteVpc(input *ec2.DeleteVpcInput) (*ec2.DeleteVpcOutput, error) {

--- a/pkg/resources/custom_metrics.go
+++ b/pkg/resources/custom_metrics.go
@@ -38,6 +38,7 @@ const (
 	DefaultRedisSnapshotNotAvailable          = "cro_redis_snapshot_not_found"
 	DefaultPostgresSnapshotNotAvailable       = "cro_postgres_snapshot_not_found"
 	DefaultBlobStorageStatusMetricName        = "cro_blobstorage_status_phase"
+	DefaultVpcActionMetricName                = "cro_vpc_action"
 
 	BytesInGibiBytes = 1073741824
 )
@@ -106,6 +107,23 @@ func SetMetric(name string, labels map[string]string, value float64) {
 //SetMetricCurrentTime Set current time wraps set metric
 func SetMetricCurrentTime(name string, labels map[string]string) {
 	SetMetric(name, labels, float64(time.Now().UnixNano())/1e9)
+}
+
+// SetVpcAction sets cro_vpc_action metric
+func SetVpcAction(action string, status string, err string, code float64) {
+	SetMetric(DefaultVpcActionMetricName,
+		map[string]string{
+			"action": action,
+			"status": status,
+			"error":  err,
+		}, code)
+}
+
+// ResetVpcAction resets cro_vpc_action metric
+func ResetVpcAction() {
+	if val, ok := MetricVecs[DefaultVpcActionMetricName]; ok {
+		val.Reset()
+	}
 }
 
 // CreatePrometheusRule will create a PrometheusRule object


### PR DESCRIPTION
## Overview

Jira: [MGDAPI-3203](https://issues.redhat.com/browse/MGDAPI-3203)

## Verification

Against a CCS OpenShift cluster which has no space for more VPC's:
- Clone this branch
- Run `make cluster/prepare`
- Run `make run`
- Run `make cluster/seed/managed/postgres`
- See metric emitted `cro_vpc_action{action='create', status='failed', error='VpcLimitExceeded'} 1`


## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below