### PR TITLE
make isLastResource namespaced scoped so multiple cro operator can uninstall

### DIFF
--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/integr8ly/cloud-resource-operator/internal/k8sutil"
-
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 
@@ -473,13 +471,7 @@ func (p *PostgresProvider) DeletePostgres(ctx context.Context, r *v1alpha1.Postg
 		return croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
 	}
 
-	namespace, err := k8sutil.GetWatchNamespace()
-	if err != nil {
-		errMsg := "Failed to get watch namespace"
-		return croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
-	}
-
-	isLastResource, err := p.isLastResource(ctx, namespace)
+	isLastResource, err := p.isLastResource(ctx)
 	if err != nil {
 		errMsg := "failed to check if this cr is the last cr of type postgres and redis"
 		return croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
@@ -669,7 +661,7 @@ func (p *PostgresProvider) getRDSConfig(ctx context.Context, r *v1alpha1.Postgre
 	return rdsCreateConfig, rdsDeleteConfig, rdsServiceUpdates, stratCfg, nil
 }
 
-func (p *PostgresProvider) isLastResource(ctx context.Context, namespace string) (bool, error) {
+func (p *PostgresProvider) isLastResource(ctx context.Context) (bool, error) {
 	listOptions := client.ListOptions{
 		Namespace: "",
 	}

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -671,7 +671,7 @@ func (p *PostgresProvider) getRDSConfig(ctx context.Context, r *v1alpha1.Postgre
 
 func (p *PostgresProvider) isLastResource(ctx context.Context, namespace string) (bool, error) {
 	listOptions := client.ListOptions{
-		Namespace: namespace,
+		Namespace: "",
 	}
 	var postgresList = &v1alpha1.PostgresList{}
 	if err := p.Client.List(ctx, postgresList, &listOptions); err != nil {

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -495,13 +495,7 @@ func (p *RedisProvider) DeleteRedis(ctx context.Context, r *v1alpha1.Redis) (cro
 		return croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
 	}
 
-	namespace, err := k8sutil.GetWatchNamespace()
-	if err != nil {
-		errMsg := "Failed to get watch namespace"
-		return croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
-	}
-
-	isLastResource, err := p.isLastResource(ctx, namespace)
+	isLastResource, err := p.isLastResource(ctx)
 	if err != nil {
 		errMsg := "failed to check if this cr is the last cr of type postgres and redis"
 		return croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
@@ -651,7 +645,7 @@ func (p *RedisProvider) getElasticacheConfig(ctx context.Context, r *v1alpha1.Re
 	return elasticacheCreateConfig, elasticacheDeleteConfig, elasticacheServiceUpdates, stratCfg, nil
 }
 
-func (p *RedisProvider) isLastResource(ctx context.Context, namespace string) (bool, error) {
+func (p *RedisProvider) isLastResource(ctx context.Context) (bool, error) {
 	listOptions := client.ListOptions{
 		Namespace: "",
 	}

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/integr8ly/cloud-resource-operator/internal/k8sutil"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -653,7 +653,7 @@ func (p *RedisProvider) getElasticacheConfig(ctx context.Context, r *v1alpha1.Re
 
 func (p *RedisProvider) isLastResource(ctx context.Context, namespace string) (bool, error) {
 	listOptions := client.ListOptions{
-		Namespace: namespace,
+		Namespace: "",
 	}
 	var postgresList = &v1alpha1.PostgresList{}
 	if err := p.Client.List(ctx, postgresList, &listOptions); err != nil {


### PR DESCRIPTION
## Overview

Jira: [MGDAPI-3024](https://issues.redhat.com/browse/MGDAPI-3024) 

## Verification

- Clone this branch
- Run the following commands to provision redis and posgres in the `cloud-resources-operator` namespace
```bash
make cluster/prepare
make cluster/seed/managed/postgres
make cluster/seed/managed/redis
make run
```
- We need to run both operators at the same time locally to start the second instance of the operator
- Edit the port number on to 8384 on line 61 of main.go https://github.com/integr8ly/cloud-resource-operator/blob/master/main.go#L61
- Edit the namespace env var to `cloud-resources-operator2` in the makefile https://github.com/integr8ly/cloud-resource-operator/blob/master/Makefile#L6
- In a new terminal Run the following to provision redis and postgres in `cloud-resources-operator2` namespace
```bash
make cluster/prepare
make cluster/seed/managed/postgres
make cluster/seed/managed/redis
make run
```
- Wait for the redis and posgres to be installed
- Delete the Redis and Posgres CR in the `cloud-resources-operator2` namespace
- Confirm that the resources are removed and there are no errors around deleting network resources 
- Delete the Redis and Posgres CR in the `cloud-resources-operator` namespace
- Confirm that the resources are removed and there are no errors around deleting network resources 
 
Index for rhoam upgrade test 
quay.io/austincunningham/integreatly-index:v1.15.2
quay.io/austincunningham/integreatly-index:v1.16.0

## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below