### PR TITLE
MGDAPI-3294 - add replaces into new manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ gen/csv:
 	@yq e -i '.metadata.name="cloud-resources.v${VERSION}"' config/manifests/bases/cloud-resource-operator.clusterserviceversion.yaml
 	@yq e -i '.metadata.annotations.containerImage="${OPERATOR_IMG}"' config/manifests/bases/cloud-resource-operator.clusterserviceversion.yaml
 	@yq e -i '.spec.version="${VERSION}"' config/manifests/bases/cloud-resource-operator.clusterserviceversion.yaml
+	@yq e -i '.spec.replaces="cloud-resources.v${PREV_VERSION}"' packagemanifests/${VERSION}/cloud-resource-operator.clusterserviceversion.yaml
 	@yq e -i '.spec.installModes[0].supported=$(shell yq e -o=json ./config/manifests/bases/cloud-resource-operator.clusterserviceversion.yaml | jq '.spec.installModes[0].supported')' packagemanifests/${VERSION}/cloud-resource-operator.clusterserviceversion.yaml
 	@yq e -i '.spec.installModes[1].supported=$(shell yq e -o=json ./config/manifests/bases/cloud-resource-operator.clusterserviceversion.yaml | jq '.spec.installModes[1].supported')' packagemanifests/${VERSION}/cloud-resource-operator.clusterserviceversion.yaml
 	@yq e -i '.spec.installModes[2].supported=$(shell yq e -o=json ./config/manifests/bases/cloud-resource-operator.clusterserviceversion.yaml | jq '.spec.installModes[2].supported')' packagemanifests/${VERSION}/cloud-resource-operator.clusterserviceversion.yaml


### PR DESCRIPTION
## Overview

Jira: [MGDAPI-3294](https://issues.redhat.com/browse/MGDAPI-3294)

## Verification

- Checkout latest release
- Make new release
- See no `replaces` field in manifest
</br>

- Clone this branch
- Make new release
- See `replaces` field set to `PREV_VERSION`

## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below