### PR TITLE
MGDAPI-3322 Fixes bundle-rhmi-operators script to support docker.

### DIFF
--- a/scripts/bundle-rhmi-operators.sh
+++ b/scripts/bundle-rhmi-operators.sh
@@ -63,8 +63,8 @@ generate_bundles() {
       --package rhmi-cloud-resources --output-dir bundle \
       --default $CHANNEL
 
-  podman build -f bundle.Dockerfile -t $REG/$ORG/cloud-resource-operator:bundle-v$LATEST_VERSION .
-  podman push $REG/$ORG/cloud-resource-operator:bundle-v$LATEST_VERSION
+  ${BUILD_TOOL} build -f bundle.Dockerfile -t $REG/$ORG/cloud-resource-operator:bundle-v$LATEST_VERSION .
+  ${BUILD_TOOL} push $REG/$ORG/cloud-resource-operator:bundle-v$LATEST_VERSION
   operator-sdk bundle validate $REG/$ORG/cloud-resource-operator:bundle-v$LATEST_VERSION
   cd ..
 }
@@ -88,7 +88,7 @@ push_index() {
 
   printf 'Pushing index image:'$INDEX_IMAGE'\n'
 
-  podman push $INDEX_IMAGE
+  ${BUILD_TOOL} push $INDEX_IMAGE
 }
 
 # cleans up the working space


### PR DESCRIPTION
## Overview
This PR fixes the [bundle-rhmi-operators.sh](https://github.com/integr8ly/cloud-resource-operator/blob/master/scripts/bundle-rhmi-operators.sh) script to support passing in `docker` as the `BUILD_TOOL` on the command line.

Jira Link: https://issues.redhat.com/browse/MGDAPI-3322

## Verification
- Checkout this PR
- Update the `IMAGE_ORG` value in the [Makefile](https://github.com/integr8ly/cloud-resource-operator/blob/master/Makefile#L2) to your quay.io repo.
- Update the `VERSION` value in the [Makefile](https://github.com/integr8ly/cloud-resource-operator/blob/master/Makefile#L8) to `10.0.0`
- Update the `UPGRADE` value in the [Makefile](https://github.com/integr8ly/cloud-resource-operator/blob/master/Makefile#L10) to `false`
- Update the `PREVIOUS_OPERATOR_VERSIONS` in the [Makefile](https://github.com/integr8ly/cloud-resource-operator/blob/master/Makefile#L13) to `""`
- Run `BUILD_TOOL=docker make release/prepare`
- Ensure that the command finishes successfully and that the images are pushed to your quay.io repo.