### PR TITLE
MGDAPI-3376 reinstate rds tagging

### DIFF
--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -338,6 +338,15 @@ func (p *PostgresProvider) reconcileRDSInstance(ctx context.Context, cr *v1alpha
 		}
 		msg = fmt.Sprintf("rds instance %s is as expected", *foundInstance.DBInstanceIdentifier)
 		logger.Infof(msg)
+
+		croStatus, err := p.TagRDSPostgres(ctx, cr, rdsSvc, foundInstance)
+		if err != nil {
+			errMsg := fmt.Sprintf("failed to add tags to rds: %s", croStatus)
+			return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
+		}
+
+		msg = fmt.Sprintf("rds instance %s is as expected", *foundInstance.DBInstanceIdentifier)
+		logger.Infof(msg)
 		pdd := &providers.PostgresDeploymentDetails{
 			Username: *foundInstance.MasterUsername,
 			Password: postgresPass,

--- a/pkg/providers/aws/provider_postgres_test.go
+++ b/pkg/providers/aws/provider_postgres_test.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	errorUtil "github.com/pkg/errors"
 	"reflect"
 	"strconv"
@@ -841,6 +843,19 @@ func TestAWSPostgresProvider_createPostgresInstance(t *testing.T) {
 			args: args{
 				rdsSvc: buildMockRdsClient(func(rdsClient *mockRdsClient) {
 					rdsClient.dbInstances = buildAvailableDBInstance(testIdentifier)
+					rdsClient.addTagsToResourceFn = func(input *rds.AddTagsToResourceInput) (*rds.AddTagsToResourceOutput, error) {
+						return &rds.AddTagsToResourceOutput{}, nil
+					}
+					rdsClient.describeDBSnapshotsFn = func(input *rds.DescribeDBSnapshotsInput) (*rds.DescribeDBSnapshotsOutput, error) {
+						return &rds.DescribeDBSnapshotsOutput{
+							DBSnapshots: []*rds.DBSnapshot{
+								&rds.DBSnapshot{
+									DBSnapshotArn:        &snapshotARN,
+									DBSnapshotIdentifier: &snapshotIdentifier,
+								},
+							},
+						}, nil
+					}
 				}),
 				ec2Svc: &mockEc2Client{
 					vpcs:      buildVpcs(),
@@ -911,7 +926,22 @@ func TestAWSPostgresProvider_createPostgresInstance(t *testing.T) {
 		{
 			name: "test rds exists and status is available and needs to be modified (valid cluster bundle subnets)",
 			args: args{
-				rdsSvc: &mockRdsClient{dbInstances: buildAvailableDBInstance(testIdentifier)},
+				rdsSvc: buildMockRdsClient(func(rdsClient *mockRdsClient) {
+					rdsClient.dbInstances = buildAvailableDBInstance(testIdentifier)
+					rdsClient.addTagsToResourceFn = func(input *rds.AddTagsToResourceInput) (*rds.AddTagsToResourceOutput, error) {
+						return nil, awserr.New(rds.ErrCodeDBSnapshotNotFoundFault, rds.ErrCodeDBSnapshotNotFoundFault, fmt.Errorf("%v", rds.ErrCodeDBSnapshotNotFoundFault))
+					}
+					rdsClient.describeDBSnapshotsFn = func(input *rds.DescribeDBSnapshotsInput) (*rds.DescribeDBSnapshotsOutput, error) {
+						return &rds.DescribeDBSnapshotsOutput{
+							DBSnapshots: []*rds.DBSnapshot{
+								&rds.DBSnapshot{
+									DBSnapshotArn:        &snapshotARN,
+									DBSnapshotIdentifier: &snapshotIdentifier,
+								},
+							},
+						}, nil
+					}
+				}),
 				ec2Svc: &mockEc2Client{
 					vpcs:      buildVpcs(),
 					subnets:   buildValidBundleSubnets(),
@@ -941,7 +971,22 @@ func TestAWSPostgresProvider_createPostgresInstance(t *testing.T) {
 		{
 			name: "test rds exists and status is available and does not need to be modified (valid cluster bundle subnets)",
 			args: args{
-				rdsSvc: &mockRdsClient{dbInstances: buildAvailableDBInstance(testIdentifier)},
+				rdsSvc: buildMockRdsClient(func(rdsClient *mockRdsClient) {
+					rdsClient.dbInstances = buildAvailableDBInstance(testIdentifier)
+					rdsClient.addTagsToResourceFn = func(input *rds.AddTagsToResourceInput) (*rds.AddTagsToResourceOutput, error) {
+						return &rds.AddTagsToResourceOutput{}, nil
+					}
+					rdsClient.describeDBSnapshotsFn = func(input *rds.DescribeDBSnapshotsInput) (*rds.DescribeDBSnapshotsOutput, error) {
+						return &rds.DescribeDBSnapshotsOutput{
+							DBSnapshots: []*rds.DBSnapshot{
+								&rds.DBSnapshot{
+									DBSnapshotArn:        &snapshotARN,
+									DBSnapshotIdentifier: &snapshotIdentifier,
+								},
+							},
+						}, nil
+					}
+				}),
 				ec2Svc: &mockEc2Client{
 					vpcs:      buildVpcs(),
 					subnets:   buildValidBundleSubnets(),
@@ -971,7 +1016,22 @@ func TestAWSPostgresProvider_createPostgresInstance(t *testing.T) {
 		{
 			name: "test rds exists and status is available and needs to be modified but maintenance is pending (valid cluster bundle subnets)",
 			args: args{
-				rdsSvc: &mockRdsClient{dbInstances: buildPendingModifiedDBInstance(testIdentifier)},
+				rdsSvc: buildMockRdsClient(func(rdsClient *mockRdsClient) {
+					rdsClient.dbInstances = buildAvailableDBInstance(testIdentifier)
+					rdsClient.addTagsToResourceFn = func(input *rds.AddTagsToResourceInput) (*rds.AddTagsToResourceOutput, error) {
+						return nil, awserr.New(rds.ErrCodeDBSnapshotNotFoundFault, rds.ErrCodeDBSnapshotNotFoundFault, fmt.Errorf("%v", rds.ErrCodeDBSnapshotNotFoundFault))
+					}
+					rdsClient.describeDBSnapshotsFn = func(input *rds.DescribeDBSnapshotsInput) (*rds.DescribeDBSnapshotsOutput, error) {
+						return &rds.DescribeDBSnapshotsOutput{
+							DBSnapshots: []*rds.DBSnapshot{
+								&rds.DBSnapshot{
+									DBSnapshotArn:        &snapshotARN,
+									DBSnapshotIdentifier: &snapshotIdentifier,
+								},
+							},
+						}, nil
+					}
+				}),
 				ec2Svc: &mockEc2Client{
 					vpcs:      buildVpcs(),
 					subnets:   buildValidBundleSubnets(),
@@ -1001,7 +1061,22 @@ func TestAWSPostgresProvider_createPostgresInstance(t *testing.T) {
 		{
 			name: "test rds exists and status is available and needs to update pending maintenance (valid cluster bundle subnets)",
 			args: args{
-				rdsSvc: &mockRdsClient{dbInstances: buildPendingModifiedDBInstance(testIdentifier)},
+				rdsSvc: buildMockRdsClient(func(rdsClient *mockRdsClient) {
+					rdsClient.dbInstances = buildAvailableDBInstance(testIdentifier)
+					rdsClient.addTagsToResourceFn = func(input *rds.AddTagsToResourceInput) (*rds.AddTagsToResourceOutput, error) {
+						return nil, awserr.New(rds.ErrCodeDBSnapshotNotFoundFault, rds.ErrCodeDBSnapshotNotFoundFault, fmt.Errorf("%v", rds.ErrCodeDBSnapshotNotFoundFault))
+					}
+					rdsClient.describeDBSnapshotsFn = func(input *rds.DescribeDBSnapshotsInput) (*rds.DescribeDBSnapshotsOutput, error) {
+						return &rds.DescribeDBSnapshotsOutput{
+							DBSnapshots: []*rds.DBSnapshot{
+								&rds.DBSnapshot{
+									DBSnapshotArn:        &snapshotARN,
+									DBSnapshotIdentifier: &snapshotIdentifier,
+								},
+							},
+						}, nil
+					}
+				}),
 				ec2Svc: &mockEc2Client{
 					vpcs:      buildVpcs(),
 					subnets:   buildValidBundleSubnets(),
@@ -1031,7 +1106,22 @@ func TestAWSPostgresProvider_createPostgresInstance(t *testing.T) {
 		{
 			name: "test rds is exists and is available (valid cluster standalone subnets)",
 			args: args{
-				rdsSvc: &mockRdsClient{dbInstances: buildAvailableDBInstance(testIdentifier)},
+				rdsSvc: buildMockRdsClient(func(rdsClient *mockRdsClient) {
+					rdsClient.dbInstances = buildAvailableDBInstance(testIdentifier)
+					rdsClient.addTagsToResourceFn = func(input *rds.AddTagsToResourceInput) (*rds.AddTagsToResourceOutput, error) {
+						return &rds.AddTagsToResourceOutput{}, nil
+					}
+					rdsClient.describeDBSnapshotsFn = func(input *rds.DescribeDBSnapshotsInput) (*rds.DescribeDBSnapshotsOutput, error) {
+						return &rds.DescribeDBSnapshotsOutput{
+							DBSnapshots: []*rds.DBSnapshot{
+								&rds.DBSnapshot{
+									DBSnapshotArn:        &snapshotARN,
+									DBSnapshotIdentifier: &snapshotIdentifier,
+								},
+							},
+						}, nil
+					}
+				}),
 				ec2Svc: &mockEc2Client{secGroups: buildSecurityGroups(secName)},
 				ctx:    context.TODO(),
 				cr:     buildTestPostgresCR(),


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/MGDAPI-3315

## Verification

- Clone this branch, need a CCS cluster to verify
- Run 
```bash
make cluster/prepare
make run
make cluster/seed/managed/postgres
# wait until the CR's `status.phase: complete`
oc get postgres example-postgres -ojson | jq .'status.phase' 
"complete"
```
- Ensure the rds instance is tagged e.g.
```bash
# Get the ARN
aws rds describe-db-instances --region us-east-2 | grep DBInstanceArn
 "DBInstanceArn": "arn:aws:rds:us-east-2:<redacted>:db:rhmicloudsccsdqqdpcloudresourceoper-lbot",
# Use the ARN to list tags
aws rds list-tags-for-resource --resource-name arn:aws:rds:us-east-2:<redacted>:db:rhmicloudsccsdqqdpcloudresourceoper-lbot --region us-east-2
{
    "TagList": [
        {
            "Key": "integreatly.org/resource-name",
            "Value": "example-postgres"
        },
        {
            "Key": "integreatly.org/product-name",
            "Value": "productName"
        },
        {
            "Key": "integreatly.org/resource-type",
            "Value": "managed"
        },
        {
            "Key": "integreatly.org/clusterID",
            "Value": "rhmi-clouds-ccs-dqqdp"
        }
    ]
}
```


## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below