### PR TITLE
[MGDAPI-1725] feat: allow running sts auth locally against sts cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,7 +95,8 @@ operator-sdk-v1.2.0
 !vendor/**/zz_generated.*
 
 # editor and IDE paraphernalia
-.idea
 *.swp
 *.swo
-*~
+
+# Generated roles
+rhoam_role.json

--- a/Makefile
+++ b/Makefile
@@ -257,4 +257,4 @@ coverage:
 
 .PHONY: setup/sts
 setup/sts:
-	sed "s|ROLE_ARN|$(ROLE_ARN)|g" scripts/sts/sts-secret.yaml | oc apply -f - -n $(NAMESPACE)
+	NAMESPACE=$(NAMESPACE) ./scripts/sts/create-rhoam-policy.sh

--- a/internal/k8sutil/k8sutil.go
+++ b/internal/k8sutil/k8sutil.go
@@ -34,8 +34,8 @@ var ErrRunLocal = fmt.Errorf("operator run mode forced to local")
 
 // GetOperatorNamespace returns the namespace the operator should be running in.
 func GetOperatorNamespace() (string, error) {
-	if isRunModeLocal() {
-		return "", ErrRunLocal
+	if IsRunModeLocal() {
+		return GetWatchNamespace() // Return the watched namespace for when running locally
 	}
 	nsBytes, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
@@ -67,7 +67,7 @@ func GetGVKsFromAddToScheme(addToSchemeFunc func(*runtime.Scheme) error) ([]sche
 	return ownGVKs, nil
 }
 
-func isRunModeLocal() bool {
+func IsRunModeLocal() bool {
 	return !isRunModeCluster()
 }
 

--- a/scripts/sts/create-rhoam-policy.sh
+++ b/scripts/sts/create-rhoam-policy.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# USAGE
+# NAMESPACE=cloud-resource-operator ./create-rhoam-policy.sh
+#
+# Creates the RHOAM role for CRO to assume on STS cluster
+#
+# PREREQUISITES
+# - jq
+# - awscli (logged in at the cmd line in order to get the account id)
+
+# Prevents aws cli from opening editor on responses - https://github.com/aws/aws-cli/issues/4992
+export AWS_PAGER=""
+ROLE_NAME="rhoam_role"
+
+# Gets the local aws account id
+get_account_id () {
+  local ACCOUNT_ID=$(aws sts get-caller-identity | jq -r .Account)
+  echo "$ACCOUNT_ID"
+}
+
+get_role_arn () {
+  echo "arn:aws:iam::$(get_account_id):role/$ROLE_NAME"
+}
+
+# Delete policy and role
+# TODO - detach policy with only the required permissions by CRO
+aws iam detach-role-policy --role-name $ROLE_NAME --policy-arn arn:aws:iam::aws:policy/AdministratorAccess || true
+aws iam delete-role --role-name $ROLE_NAME || true
+
+# Create policy and role
+# Allows osdCcsAdmin IAM user to assume this role
+cat << EOM > "$ROLE_NAME.json"
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+          "AWS": [
+              "arn:aws:iam::$(get_account_id):user/osdCcsAdmin"
+          ]
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {}
+    }
+  ]
+}
+EOM
+aws iam create-role --role-name $ROLE_NAME --assume-role-policy-document "file://$ROLE_NAME.json" || true
+# TODO - attach policy with only the required permissions by CRO
+aws iam attach-role-policy --role-name $ROLE_NAME --policy-arn arn:aws:iam::aws:policy/AdministratorAccess || true
+
+sed "s|ROLE_ARN|$(get_role_arn)|g" scripts/sts/sts-secret.yaml | oc apply -f - -n $NAMESPACE


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/MGDAPI-1725

## Verification

- Provision a ROSA STS cluster
- Clone this branch
- Run `make cluster/prepare`
- Run `make setup/sts`
- Run `make run`
- Create rds instance
```
make cluster/seed/managed/postgres
```
- Ensure provision of rds instance is successful

- Create redis instance 
```
make cluster/seed/managed/redis 
```
- Ensure redis instance is successful
- Delete rds and redis instance CRs
- Ensure rds and redis instance is deleted successully

## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below