### PR TITLE
MGDAPI-3616 Added check to confirm that standalone VPC exists before deleting it

### DIFF
--- a/pkg/providers/aws/cluster_network_provider.go
+++ b/pkg/providers/aws/cluster_network_provider.go
@@ -711,20 +711,7 @@ func (n *NetworkProvider) IsEnabled(ctx context.Context) (bool, error) {
 		}
 	}
 	logger.Infof("found %d bundled vpc subnets in cluster vpc", len(validBundledVPCSubnets))
-
-	// Confirm that a standalone VPC actually exists before returning true
-	isUsingStandaloneVPC := false
-	if len(validBundledVPCSubnets) == 0 {
-		saVpc, err := getStandaloneVpc(ctx, n.Client, n.Ec2Api, logger)
-		if err != nil {
-			return isUsingStandaloneVPC, err
-		}
-		if saVpc != nil {
-			isUsingStandaloneVPC = true
-		}
-	}
-
-	return isUsingStandaloneVPC, nil
+	return len(validBundledVPCSubnets) == 0, nil
 }
 
 // DeleteBundledCloudResources returns an error on any error deleting of the following resources

--- a/pkg/providers/aws/cluster_network_provider_test.go
+++ b/pkg/providers/aws/cluster_network_provider_test.go
@@ -1819,7 +1819,7 @@ func TestNetworkProvider_GetClusterNetworkPeering(t *testing.T) {
 		fields  fields
 		args    args
 		want    *NetworkPeering
-		wantErr bool
+		wantErr string
 	}{
 		{
 			name: "fails when cannot get standalone vpc",
@@ -1834,7 +1834,7 @@ func TestNetworkProvider_GetClusterNetworkPeering(t *testing.T) {
 			args: args{
 				ctx: context.TODO(),
 			},
-			wantErr: true,
+			wantErr: "failed to get standalone vpc: error getting vpcs: ec2 get vpcs error",
 		},
 		{
 			name: "fails when cannot get vpc peering connection",
@@ -1855,7 +1855,7 @@ func TestNetworkProvider_GetClusterNetworkPeering(t *testing.T) {
 			args: args{
 				ctx: context.TODO(),
 			},
-			wantErr: true,
+			wantErr: "failed to get network peering: failed to get cluster vpc: error, no vpc found",
 		},
 		{
 			name: "success when network peering found",
@@ -1886,7 +1886,6 @@ func TestNetworkProvider_GetClusterNetworkPeering(t *testing.T) {
 			want: &NetworkPeering{
 				PeeringConnection: buildMockVpcPeeringConnection(nil),
 			},
-			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
@@ -1899,7 +1898,7 @@ func TestNetworkProvider_GetClusterNetworkPeering(t *testing.T) {
 				Logger:         tt.fields.Logger,
 			}
 			got, err := n.GetClusterNetworkPeering(tt.args.ctx)
-			if (err != nil) != tt.wantErr {
+			if err != nil && err.Error() != tt.wantErr {
 				t.Errorf("GetClusterNetworkPeering() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}

--- a/pkg/providers/aws/cluster_network_provider_test.go
+++ b/pkg/providers/aws/cluster_network_provider_test.go
@@ -492,33 +492,8 @@ func TestNetworkProvider_IsEnabled(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			//if no rhmi subnets exist in the cluster vpc then isEnabled will return true ONLY if a valid standalone vpc also exists
-			name: "verify isEnabled is true, no bundle subnets found in cluster vpc and valid standalone vpc exists",
-			args: args{
-				ctx: context.TODO(),
-			},
-			fields: fields{
-				Logger: logrus.NewEntry(logrus.StandardLogger()),
-				Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(buildTestInfra()).Build(),
-				Ec2Api: buildMockEc2Client(func(ec2Client *mockEc2Client) {
-					ec2Client.vpcs = []*ec2.Vpc{buildValidStandaloneVPC(validCIDRTwentySix)}
-					ec2Client.describeSubnetsFn = func(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
-						return &ec2.DescribeSubnetsOutput{
-							Subnets: []*ec2.Subnet{
-								buildSubnet(defaultStandaloneVpcId, defaultSubnetIdOne, defaultAzIdOne, defaultValidSubnetMaskOneA),
-								buildSubnet(defaultStandaloneVpcId, defaultSubnetIdTwo, defaultAzIdTwo, defaultValidSubnetMaskOneB),
-							},
-						}, nil
-					}
-
-				}),
-			},
-			want:    true,
-			wantErr: false,
-		},
-		{
-			//if no rhmi subnets exist in the cluster vpc, isEnabled will still return false if no valid standalone vpc exists
-			name: "verify isEnabled is false, no bundle subnets found in cluster vpc and no standalone vpc exists",
+			//if no rhmi subnets exist in the cluster vpc then isEnabled will return true
+			name: "verify isEnabled is true, no bundle subnets found in cluster vpc",
 			args: args{
 				ctx: context.TODO(),
 			},
@@ -534,10 +509,9 @@ func TestNetworkProvider_IsEnabled(t *testing.T) {
 							},
 						}, nil
 					}
-
 				}),
 			},
-			want:    false,
+			want:    true,
 			wantErr: false,
 		},
 		{
@@ -752,12 +726,6 @@ func TestNetworkProvider_CreateNetwork(t *testing.T) {
 				RdsApi: &mockRdsClient{},
 				Ec2Api: buildMockEc2Client(func(ec2Client *mockEc2Client) {
 					ec2Client.vpcs = buildValidClusterVPC(defaultNonOverlappingCidr)
-					ec2Client.vpc = buildValidStandaloneVPC(validCIDRTwentySeven)
-					ec2Client.describeSubnetsFn = func(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
-						return &ec2.DescribeSubnetsOutput{
-							Subnets: buildStandaloneSubnets(),
-						}, nil
-					}
 				}),
 				ElasticacheApi: &mockElasticacheClient{},
 				Logger:         logrus.NewEntry(logrus.StandardLogger()),

--- a/pkg/providers/aws/provider_postgres_test.go
+++ b/pkg/providers/aws/provider_postgres_test.go
@@ -3,13 +3,14 @@ package aws
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	errorUtil "github.com/pkg/errors"
 	"reflect"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	errorUtil "github.com/pkg/errors"
 
 	v12 "github.com/integr8ly/cloud-resource-operator/apis/config/v1"
 
@@ -1283,12 +1284,16 @@ func TestAWSPostgresProvider_deletePostgresInstance(t *testing.T) {
 		{
 			name: "test successful delete with no postgres and deletion of standalone network",
 			args: args{
-				postgresDeleteConfig:    &rds.DeleteDBInstanceInput{},
-				postgresCreateConfig:    &rds.CreateDBInstanceInput{},
-				pg:                      buildTestPostgresCR(),
-				networkManager:          buildMockNetworkManager(),
-				instanceSvc:             &mockRdsClient{dbInstances: []*rds.DBInstance{}},
-				ec2Svc:                  &mockEc2Client{},
+				postgresDeleteConfig: &rds.DeleteDBInstanceInput{},
+				postgresCreateConfig: &rds.CreateDBInstanceInput{},
+				pg:                   buildTestPostgresCR(),
+				networkManager:       buildMockNetworkManager(),
+				instanceSvc:          &mockRdsClient{dbInstances: []*rds.DBInstance{}},
+				ec2Svc: buildMockEc2Client(func(ec2Client *mockEc2Client) {
+					ec2Client.vpcs = []*ec2.Vpc{
+						buildValidStandaloneVPC(validCIDRSixteen),
+					}
+				}),
 				standaloneNetworkExists: true,
 				isLastResource:          true,
 			},

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -750,9 +750,9 @@ func TestAWSRedisProvider_deleteRedisCluster(t *testing.T) {
 		CredentialManager CredentialManager
 		ConfigManager     ConfigManager
 		CacheSvc          elasticacheiface.ElastiCacheAPI
+		Ec2Svc            ec2iface.EC2API
 	}
 	type args struct {
-		cacheSvc                elasticacheiface.ElastiCacheAPI
 		networkManager          NetworkManager
 		redisCreateConfig       *elasticache.CreateReplicationGroupInput
 		redisDeleteConfig       *elasticache.DeleteReplicationGroupInput
@@ -883,6 +883,11 @@ func TestAWSRedisProvider_deleteRedisCluster(t *testing.T) {
 						return &elasticache.DescribeReplicationGroupsOutput{}, nil
 					}
 				}),
+				Ec2Svc: buildMockEc2Client(func(ec2Client *mockEc2Client) {
+					ec2Client.vpcs = []*ec2.Vpc{
+						buildValidStandaloneVPC(validCIDRSixteen),
+					}
+				}),
 			},
 			wantErr: false,
 		}, {
@@ -918,7 +923,7 @@ func TestAWSRedisProvider_deleteRedisCluster(t *testing.T) {
 				ConfigManager:     tt.fields.ConfigManager,
 				CacheSvc:          tt.fields.CacheSvc,
 			}
-			if _, err := p.deleteElasticacheCluster(tt.args.ctx, tt.args.networkManager, tt.fields.CacheSvc, tt.args.redisCreateConfig, tt.args.redisDeleteConfig, tt.args.redis, tt.args.standaloneNetworkExists, tt.args.isLastResource); (err != nil) != tt.wantErr {
+			if _, err := p.deleteElasticacheCluster(tt.args.ctx, tt.args.networkManager, tt.fields.CacheSvc, tt.fields.Ec2Svc, tt.args.redisCreateConfig, tt.args.redisDeleteConfig, tt.args.redis, tt.args.standaloneNetworkExists, tt.args.isLastResource); (err != nil) != tt.wantErr {
 				t.Errorf("deleteElasticacheCluster() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/MGDAPI-3616

This PR adds a check to the IsEnabled() function to confirm that a valid standalone VPC actually exists before returning that it does. This is required in order to fix the deletion logic for incomplete installations of the RHOAM operator where the installation got stuck because the user's VPC limit was already reached before the installation started. In this scenario, the RHOAM operator will get stuck in the Authentication stage because CRO can't create a VPC since the limit is already reached. If the user then tried to delete the RHMI CR, the uninstall would get stuck because CRO would attempt to delete a standalone VPC that doesn't exist which throws a nil pointer dereference error.

## Verification
- [Provision](https://qaprodauth.cloud.redhat.com/) a CCS cluster (requires AWS credentials) in an empty region that doesn't have any existing clusters
- Once the cluster is provisioned, log into the [AWS dashboard](https://console.aws.amazon.com/) (requires an AWS account unique to you, reach out to me with any questions) and max out the number of VPCs in the region you provisioned the cluster. The default max number of VPCs is 5 so if 3 already exist, then you only need to create 2 more
- Next target the cluster and attempt to install the RHOAM operator from the master branch of the [integreatly-operator repo](https://github.com/integr8ly/integreatly-operator)
- Verify that the installation gets stuck in the `authentication` stage because RHSSO is `awaiting cloud resources`
- Next try to delete the RHMI CR either through the GUI or by running `oc delete rhmi rhoam` from the command line
- After a few seconds/minutes the logs in the CRO operator pod should be firing a nil pointer dereference error
- Next update the yaml for the Cloud Resource Operator (Operators->Installed Operators->Cloud Resource Operator->YAML) by changing the `containerImage` and `image` fields with `quay.io/ckyrillo/cloud-resource-operator:v0.37.1` instead of `quay.io/integreatly/cloud-resource-operator:v0.37.1`
- Confirm that the RHOAM operator finishes uninstalling and that the RHMI CR is deleted

