### PR TITLE
MGDAPI-1732 - add user-defined tags from Infrastructure CR

### DIFF
--- a/apis/config/v1/infrastructure_types.go
+++ b/apis/config/v1/infrastructure_types.go
@@ -120,6 +120,34 @@ type PlatformStatus struct {
 type AWSPlatformStatus struct {
 	// region holds the default AWS region for new AWS resources created by the cluster.
 	Region string `json:"region"`
+
+	// resourceTags is a list of additional tags to apply to AWS resources created for the cluster.
+	// See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources.
+	// AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags
+	// available for the user.
+	// +kubebuilder:validation:MaxItems=25
+	// +optional
+	ResourceTags []AWSResourceTag `json:"resourceTags,omitempty"`
+}
+
+// AWSResourceTag is a tag to apply to AWS resources created for the cluster.
+type AWSResourceTag struct {
+	// key is the key of the tag
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=128
+	// +kubebuilder:validation:Pattern=`^[0-9A-Za-z_.:/=+-@]+$`
+	// +required
+	Key string `json:"key"`
+	// value is the value of the tag.
+	// Some AWS service do not support empty values. Since tags are added to resources in many services, the
+	// length of the tag value must meet the requirements of all services.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=256
+	// +kubebuilder:validation:Pattern=`^[0-9A-Za-z_.:/=+-@]+$`
+	// +required
+	Value string `json:"value"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/providers/aws/cluster_network_provider.go
+++ b/pkg/providers/aws/cluster_network_provider.go
@@ -1809,8 +1809,8 @@ func getCloudResourceOperatorOwnerTag(ctx context.Context, client client.Client)
 	return genericTag, nil
 }
 
-func getDefaultTagSpec(ctx context.Context, client client.Client, t *tag, resourceType string) ([]*ec2.TagSpecification, error) {
-	tags, err := getDefaultNetworkTags(ctx, client, t)
+func getDefaultTagSpec(ctx context.Context, client client.Client, customTag *tag, resourceType string) ([]*ec2.TagSpecification, error) {
+	tags, err := getDefaultNetworkTags(ctx, client, customTag)
 	if err != nil {
 		return nil, err
 	}
@@ -1823,24 +1823,31 @@ func getDefaultTagSpec(ctx context.Context, client client.Client, t *tag, resour
 }
 
 // Used to retrieve a set of default tag values for network resources
-// the tag passed in is used to generate a specific tag for the resource type
-// if t is provided it is the first tag in the list
-func getDefaultNetworkTags(ctx context.Context, client client.Client, t *tag) ([]*tag, error) {
+// the customTag passed in is used to generate a specific tag for the resource type
+func getDefaultNetworkTags(ctx context.Context, client client.Client, customTag *tag) ([]*tag, error) {
 	croTag, err := getCloudResourceOperatorOwnerTag(ctx, client)
 	if err != nil {
 		return nil, errorUtil.Wrap(err, "failed to build default tags")
 	}
-	if t != nil {
-		return []*tag{
-			t,
-			croTag,
-			buildManagedTag(),
-		}, nil
-	}
-	return []*tag{
+	tags := []*tag{
 		croTag,
 		buildManagedTag(),
-	}, nil
+	}
+	if customTag != nil {
+		tags = append(tags, customTag)
+	}
+
+	infraTags, err := getUserInfraTags(ctx, client)
+	if err != nil {
+		msg := "Failed to get user infrastructure tags"
+		return nil, errorUtil.Wrapf(err, msg)
+	}
+	if infraTags != nil {
+		// merge tags into single array, where any duplicate
+		// values in infra are discarded in favour of the default tags
+		tags = mergeTags(tags, infraTags)
+	}
+	return tags, nil
 }
 
 // resources such as cluster vpc route tables are tagged with a cluster owner tag

--- a/pkg/providers/aws/cluster_network_provider_test.go
+++ b/pkg/providers/aws/cluster_network_provider_test.go
@@ -350,14 +350,14 @@ func buildValidClusterVPC(cidrBlock string) []*ec2.Vpc {
 func buildValidStandaloneVPCTags() []*ec2.Tag {
 	return []*ec2.Tag{
 		{
-			Key:   aws.String(tagDisplayName),
-			Value: aws.String(DefaultRHMIVpcNameTagValue),
-		},
-		{
 			Key:   aws.String(defaultRHMISubnetTag),
 			Value: aws.String(defaultInfraName),
 		},
 		genericToEc2Tag(buildManagedTag()),
+		{
+			Key:   aws.String(tagDisplayName),
+			Value: aws.String(DefaultRHMIVpcNameTagValue),
+		},
 	}
 }
 

--- a/pkg/providers/aws/tags_test.go
+++ b/pkg/providers/aws/tags_test.go
@@ -350,6 +350,121 @@ func Test_tagsContains(t *testing.T) {
 	}
 }
 
+func Test_mergeTags(t *testing.T) {
+	type args struct {
+		tags1 []*tag
+		tags2 []*tag
+	}
+	tests := []struct {
+		name string
+		args args
+		want []*tag
+	}{
+		{
+			name: "test success",
+			args: args{
+				tags1: []*tag{
+					{
+						key:   "testKey",
+						value: "testVal",
+					},
+				},
+				tags2: []*tag{
+					{
+						key:   "testKey2",
+						value: "testVal2",
+					},
+				},
+			},
+			want: []*tag{
+				{
+					key:   "testKey",
+					value: "testVal",
+				},
+				{
+					key:   "testKey2",
+					value: "testVal2",
+				},
+			},
+		},
+		{
+			name: "test duplicate tag retrieves first value",
+			args: args{
+				tags1: []*tag{
+					{
+						key:   "testKey",
+						value: "testVal",
+					},
+				},
+				tags2: []*tag{
+					{
+						key:   "testKey",
+						value: "testVal2",
+					},
+					{
+						key:   "testKey3",
+						value: "testVal3",
+					},
+				},
+			},
+			want: []*tag{
+				{
+					key:   "testKey",
+					value: "testVal",
+				},
+				{
+					key:   "testKey3",
+					value: "testVal3",
+				},
+			},
+		},
+		{
+			name: "test empty first array",
+			args: args{
+				tags1: []*tag{},
+				tags2: []*tag{
+					{
+						key:   "testKey",
+						value: "testVal",
+					},
+				},
+			},
+			want: []*tag{
+				{
+					key:   "testKey",
+					value: "testVal",
+				},
+			},
+		},
+		{
+			name: "test empty second array",
+			args: args{
+				tags1: []*tag{
+					{
+						key:   "testKey",
+						value: "testVal",
+					},
+				},
+				tags2: []*tag{},
+			},
+			want: []*tag{
+				{
+					key:   "testKey",
+					value: "testVal",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeTags(tt.args.tags1, tt.args.tags2)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("mergeTags() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_tagsContainsAll(t *testing.T) {
 	type args struct {
 		tags1 []*tag


### PR DESCRIPTION
## Overview

Jira: [MGDAPI-1732](https://issues.redhat.com/browse/MGDAPI-1732)


## Changes

- Add to the types to extract the tags from infrastructure CR
- Merge the default CRO tags and the user-defined tags found within the CR
    - In the case the same key exists in both the value from CRO takes precedence 

## Verification

- Create a new CCS cluster
- Check the tags on the infrastructure CR - `oc get infrastructure cluster -o json | jq`
- Deploy a managed postgres/redis/blobstorage instance
- See the default tags from the infrastructure CR are added, along with default tags to the AWS resources


## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below