### PR TITLE
MGDAPI-3656 - Set default values for service metric labels

### DIFF
--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -1153,18 +1153,23 @@ func (p *PostgresProvider) setPostgresServiceMaintenanceMetric(ctx context.Conte
 
 		for _, pma := range su.PendingMaintenanceActionDetails {
 
+			// set default values for metric labels in case these were not retrieved from aws
 			metricEpochTimestamp := time.Now().Unix()
+			autoAppliedAfterDate := ""
+			currentApplyDate := ""
 
 			if pma.AutoAppliedAfterDate != nil && !pma.AutoAppliedAfterDate.IsZero() {
-				metricLabels["AutoAppliedAfterDate"] = strconv.FormatInt((*pma.AutoAppliedAfterDate).Unix(), 10)
+				autoAppliedAfterDate = strconv.FormatInt((*pma.AutoAppliedAfterDate).Unix(), 10)
 				metricEpochTimestamp = (*pma.AutoAppliedAfterDate).Unix()
 			}
 
 			if pma.CurrentApplyDate != nil && !pma.CurrentApplyDate.IsZero() {
-				metricLabels["CurrentApplyDate"] = strconv.FormatInt((*pma.CurrentApplyDate).Unix(), 10)
+				currentApplyDate = strconv.FormatInt((*pma.CurrentApplyDate).Unix(), 10)
 				metricEpochTimestamp = (*pma.CurrentApplyDate).Unix()
 			}
 
+			metricLabels["AutoAppliedAfterDate"] = autoAppliedAfterDate
+			metricLabels["CurrentApplyDate"] = currentApplyDate
 			metricLabels["Description"] = *pma.Description
 
 			resources.SetMetric(resources.DefaultPostgresMaintenanceMetricName, metricLabels, float64(metricEpochTimestamp))


### PR DESCRIPTION
## Overview

Jira: [MGDAPI-3656](https://issues.redhat.com/browse/MGDAPI-3656)

## Changes

By setting the default value of the labels to an empty string we ensure that the service maintenance metric is created with the correct number of labels. This results in the labels `AutoAppliedAfterDate` and `CurrentApplyDate` from being present, defaulting to an empty string for all service maintenance metrics.

## Verification

- Passing tests and code review should be sufficient for this change
    - Without access to a cluster with pending service updates there is no information to pull from AWS to test the maintenance metric behaviour

## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below