### PR TITLE
MGDAPI-3664 / sorting CIDR ranges

### DIFF
--- a/pkg/providers/aws/cluster_network_provider.go
+++ b/pkg/providers/aws/cluster_network_provider.go
@@ -74,6 +74,11 @@ type Network struct {
 	Subnets []*ec2.Subnet
 }
 
+type cidrList struct {
+	cidr       string
+	defaultVal string
+}
+
 // used to map expected ip addresses to availability zones
 type NetworkAZSubnet struct {
 	IP net.IPNet
@@ -1578,12 +1583,19 @@ func (n *NetworkProvider) getNonOverlappingDefaultCIDR(ctx context.Context) (*ne
 		return nil, errorUtil.Wrap(err, "error parsing cluster cidr block")
 	}
 
-	// this map is used to loop through the available options for a vpc cidr range in aws
+	// this list is used to loop through the available options for a vpc cidr range in aws
 	// See aws docs https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html#vpc-sizing-ipv4
-	cidrRanges := map[string]string{
-		"10.255.255.255/8":  fmt.Sprintf("10.0.0.0/%s", defaultCIDRMask),
-		"172.31.255.255/12": fmt.Sprintf("172.16.0.0/%s", defaultCIDRMask),
+	cidrRanges := []*cidrList{
+		{
+			"10.255.255.255/8",
+			fmt.Sprintf("10.0.0.0/%s", defaultCIDRMask),
+		},
+		{
+			"172.31.255.255/12",
+			fmt.Sprintf("172.16.0.0/%s", defaultCIDRMask),
+		},
 	}
+
 	//getting the network cr called from the cluster
 	networkConf := &v12.Network{}
 	err = n.Client.Get(ctx, client.ObjectKey{Name: "cluster"}, networkConf)
@@ -1608,13 +1620,13 @@ func (n *NetworkProvider) getNonOverlappingDefaultCIDR(ctx context.Context) (*ne
 	//
 	// the current logic checks that the cidr block does not overlap with the cluster machine,
 	//  pod and service cidr range
-	for cidrRange, potentialDefault := range cidrRanges {
-		_, cidrRangeNet, err := net.ParseCIDR(cidrRange)
+	for _, cidrList := range cidrRanges {
+		_, cidrRangeNet, err := net.ParseCIDR(cidrList.cidr)
 		if err != nil {
 			fmt.Println("error parsing cidr range for default cidr block", err)
 		}
 		// our potential default
-		potentialDefaultIP, _, err := net.ParseCIDR(potentialDefault)
+		potentialDefaultIP, _, err := net.ParseCIDR(cidrList.defaultVal)
 		if err != nil {
 			fmt.Println("error parsing potential default cidr range for default cidr block", err)
 		}


### PR DESCRIPTION
## Overview

Jira:[ MGDAPI-3664](https://issues.redhat.com/browse/MGDAPI-3664)

#What
Sorting CIDR ranges In order to stop flakiness of [TestNetworkProvider_ReconcileNetworkProviderConfig()](https://github.com/integr8ly/cloud-resource-operator/blob/master/pkg/providers/aws/cluster_network_provider_test.go#L1319)

#Test
Run the test a couple of times cleaning test cache with `go clean -testcache` after each run and make sure test passes.