### PR TITLE
[MGDAPI-3909] include isSTSCluster struct property to NetworkProvider in CRO

### DIFF
--- a/pkg/providers/aws/cluster_network_provider_test.go
+++ b/pkg/providers/aws/cluster_network_provider_test.go
@@ -49,7 +49,6 @@ const (
 	defaultSecurityGroupName      = "testsecuritygroup"
 	defaultSecurityGroupId        = "testSecurityGroupId"
 	defaultStandaloneRouteTableId = "testRouteTableId"
-	defaultClusterName            = "kubernetes.io/cluster/test"
 )
 
 func buildMockNetwork(modifyFn func(n *Network)) *Network {
@@ -625,9 +624,10 @@ func TestNetworkProvider_IsEnabled(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			n := &NetworkProvider{
-				Logger: tt.fields.Logger,
-				Client: tt.fields.Client,
-				Ec2Api: tt.fields.Ec2Api,
+				Logger:       tt.fields.Logger,
+				Client:       tt.fields.Client,
+				Ec2Api:       tt.fields.Ec2Api,
+				IsSTSCluster: false,
 			}
 			got, err := n.IsEnabled(tt.args.ctx)
 			if (err != nil) != tt.wantErr {
@@ -1305,6 +1305,7 @@ func TestNetworkProvider_CreateNetwork(t *testing.T) {
 				Ec2Api:         tt.fields.Ec2Api,
 				ElasticacheApi: tt.fields.ElasticacheApi,
 				Logger:         tt.fields.Logger,
+				IsSTSCluster:   false,
 			}
 			got, err := n.CreateNetwork(tt.args.ctx, tt.args.CIDR)
 			if (err != nil) != tt.wantErr {
@@ -1433,6 +1434,7 @@ func TestNetworkProvider_DeleteNetwork(t *testing.T) {
 				Ec2Api:         tt.fields.Ec2Api,
 				ElasticacheApi: tt.fields.ElasticacheApi,
 				Logger:         tt.fields.Logger,
+				IsSTSCluster:   false,
 			}
 			if err := n.DeleteNetwork(tt.args.ctx); (err != nil) != tt.wantErr {
 				t.Errorf("DeleteNetwork() error = %v, wantErr %v", err, tt.wantErr)
@@ -1680,6 +1682,7 @@ func TestNetworkProvider_ReconcileNetworkProviderConfig(t *testing.T) {
 				Ec2Api:         tt.fields.Ec2Api,
 				ElasticacheApi: tt.fields.ElasticacheApi,
 				Logger:         tt.fields.Logger,
+				IsSTSCluster:   false,
 			}
 			got, err := n.ReconcileNetworkProviderConfig(tt.args.ctx, tt.args.configManager, tt.args.tier, tt.args.logger)
 			if (err != nil) != tt.wantErr {
@@ -1910,9 +1913,10 @@ func TestNetworkProvider_CreateNetworkPeering(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			n := &NetworkProvider{
-				Ec2Api: tt.fields.ec2Client,
-				Client: tt.fields.kubeClient,
-				Logger: tt.fields.logger,
+				Ec2Api:       tt.fields.ec2Client,
+				Client:       tt.fields.kubeClient,
+				Logger:       tt.fields.logger,
+				IsSTSCluster: false,
 			}
 			got, err := n.CreateNetworkPeering(tt.args.ctx, tt.args.network)
 			if err != nil && err.Error() != tt.wantErr {
@@ -2023,6 +2027,7 @@ func TestNetworkProvider_GetClusterNetworkPeering(t *testing.T) {
 				Ec2Api:         tt.fields.Ec2Api,
 				ElasticacheApi: tt.fields.ElasticacheApi,
 				Logger:         tt.fields.Logger,
+				IsSTSCluster:   false,
 			}
 			got, err := n.GetClusterNetworkPeering(tt.args.ctx)
 			if err != nil && err.Error() != tt.wantErr {
@@ -2148,6 +2153,7 @@ func TestNetworkProvider_DeleteNetworkPeering(t *testing.T) {
 				Ec2Api:         tt.fields.Ec2Api,
 				ElasticacheApi: tt.fields.ElasticacheApi,
 				Logger:         tt.fields.Logger,
+				IsSTSCluster:   false,
 			}
 			if err := n.DeleteNetworkPeering(tt.args.peering); err != nil && err.Error() != tt.wantErr {
 				t.Errorf("DeleteNetworkPeering() error = %v, wantErr %v", err, tt.wantErr)
@@ -2582,6 +2588,7 @@ func TestNetworkProvider_CreateNetworkConnection(t *testing.T) {
 				Ec2Api:         tt.fields.Ec2Api,
 				ElasticacheApi: tt.fields.ElasticacheApi,
 				Logger:         tt.fields.Logger,
+				IsSTSCluster:   false,
 			}
 			got, err := n.CreateNetworkConnection(tt.args.ctx, tt.args.network)
 			if (err != nil) != tt.wantErr {
@@ -2912,6 +2919,7 @@ func TestNetworkProvider_DeleteNetworkConnection(t *testing.T) {
 				Ec2Api:         tt.fields.Ec2Api,
 				ElasticacheApi: tt.fields.ElasticacheApi,
 				Logger:         tt.fields.Logger,
+				IsSTSCluster:   false,
 			}
 			if err := n.DeleteNetworkConnection(tt.args.ctx, tt.args.networkPeering); (err != nil) != tt.wantErr {
 				t.Errorf("DeleteNetworkConnection() error = %v, wantErr %v", err, tt.wantErr)
@@ -3188,6 +3196,7 @@ func TestNetworkProvider_DeleteBundledCloudResources(t *testing.T) {
 				Ec2Api:         tt.fields.Ec2Api,
 				ElasticacheApi: tt.fields.ElasticacheApi,
 				Logger:         tt.fields.Logger,
+				IsSTSCluster:   false,
 			}
 			if err := n.DeleteBundledCloudResources(tt.args.ctx); (err != nil) != tt.wantErr {
 				t.Errorf("NetworkProvider.DeleteBundledCloudResources() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -161,7 +161,7 @@ func (p *PostgresProvider) ReconcilePostgres(ctx context.Context, pg *v1alpha1.P
 	}
 
 	// check is a standalone network is required
-	networkManager := NewNetworkManager(sess, p.Client, logger)
+	networkManager := NewNetworkManager(sess, p.Client, logger, isSTSCluster(ctx, p.Client))
 	isEnabled, err := networkManager.IsEnabled(ctx)
 	if err != nil {
 		errMsg := "failed to check cluster vpc subnets"
@@ -491,7 +491,7 @@ func (p *PostgresProvider) DeletePostgres(ctx context.Context, r *v1alpha1.Postg
 	}
 
 	// network manager required for cleaning up network vpc, subnet and subnet groups.
-	networkManager := NewNetworkManager(sess, p.Client, logger)
+	networkManager := NewNetworkManager(sess, p.Client, logger, isSTSCluster(ctx, p.Client))
 
 	isEnabled, err := networkManager.IsEnabled(ctx)
 	if err != nil {

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -130,7 +130,7 @@ func (p *RedisProvider) CreateRedis(ctx context.Context, r *v1alpha1.Redis) (*pr
 	}
 
 	// check if a standalone network is required
-	networkManager := NewNetworkManager(sess, p.Client, logger)
+	networkManager := NewNetworkManager(sess, p.Client, logger, isSTSCluster(ctx, p.Client))
 	isEnabled, err := networkManager.IsEnabled(ctx)
 	if err != nil {
 		errMsg := "failed to check cluster vpc subnets"
@@ -501,7 +501,7 @@ func (p *RedisProvider) DeleteRedis(ctx context.Context, r *v1alpha1.Redis) (cro
 	}
 
 	// network manager required for cleaning up network.
-	networkManager := NewNetworkManager(sess, p.Client, logger)
+	networkManager := NewNetworkManager(sess, p.Client, logger, isSTSCluster(ctx, p.Client))
 
 	isEnabled, err := networkManager.IsEnabled(ctx)
 	if err != nil {


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/MGDAPI-3909

## Verification
This PR isn't changing any workflows, it's simply a performance/code readability change. It should be sufficient if all prow checks pass.
If someone wants to verify CRO is working as expected in STS mode on ROSA, they can follow the verification steps from this PR: https://github.com/integr8ly/cloud-resource-operator/pull/375

## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below