### PR TITLE
MGDAPI-4119 - ensure index creation script exits on failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,14 +219,13 @@ code/audit:
 	gosec ./...
 
 .PHONY: code/gen
-code/gen: setup/moq apis/integreatly/v1alpha1/zz_generated.deepcopy.go apis/config/v1/zz_generated.deepcopy.go
+code/gen: setup/moq vendor/fix apis/integreatly/v1alpha1/zz_generated.deepcopy.go apis/config/v1/zz_generated.deepcopy.go
 	$(CONTROLLER_GEN) rbac:roleName=manager-role webhook paths="./..."
 	@go generate ./...
 
 .PHONY: setup/moq
 setup/moq:
 	go get github.com/matryer/moq
-	go mod vendor
 
 .PHONY: create/olm/bundle
 create/olm/bundle:

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ setup/moq:
 
 .PHONY: create/olm/bundle
 create/olm/bundle:
-	@CHANNEL=$(CHANNEL) PREV_VERSION=$(PREV_VERSION) PREVIOUS_OPERATOR_VERSIONS=$(PREVIOUS_OPERATOR_VERSIONS) ./scripts/create-olm-bundle.sh
+	@PREV_VERSION=$(PREV_VERSION) PREVIOUS_OPERATOR_VERSIONS=$(PREVIOUS_OPERATOR_VERSIONS) ./scripts/create-olm-bundle.sh
 
 .PHONY: release/prepare
 release/prepare: gen/csv image/push create/olm/bundle


### PR DESCRIPTION
## Overview

[MGDAPI-4119](https://issues.redhat.com/browse/MGDAPI-4119)

## What

- Removed unused `CHANNEL` in Makefile
- Fixed `make code/gen` to use a `vendor/fix`
- Set `create-olm-bundle` to exit on first failure
	- This required changes so that the `yq` commands no longer return exit code for validation
- Now that we have a initial file-based index we can now build each index from the previous, appending the new bundle - adjusted to render index
-  One of the errors we saw looked like it might be caused by using a combination of `podman` and `docker` for creation of the bundle and subsequent validation of the bundle - updated the validate command to leverage `BUILD_TOOL`

## Verification
Check that we can still create an index for a new release:
- Update Makefile to point to new `VERSION` 0.40.0, `PREV_VERSION` 0.39.0, and add 0.39.0 to `PREVIOUS_OPERATOR_VERSIONS`
- Mirror the index to your own quay org
```
docker tag quay.io/integreatly/cloud-resource-operator:index-v0.39.0 quay.io/acatterm/cloud-resource-operator:index-v0.39.0
```
- Run release/prepare
```
IMAGE_ORG=acatterm make release/prepare
```
- Bundle and index for v0.40.0 should be created succesfully
- Check index/index.yaml
	- `olm.channel` entries list should contain new bundle (as well as original values)
	- The bundle entry for existing versions and new v0.40.0 should be there