### PR TITLE
MGDAPI-3810 change versions redis 6.2 postgres 13.4

### DIFF
--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -44,7 +44,7 @@ const (
 	defaultAwsDBInstanceClass            = "db.t3.small"
 	defaultAwsDeleteAutomatedBackups     = true
 	defaultAwsEngine                     = "postgres"
-	defaultAwsEngineVersion              = "13.3"
+	defaultAwsEngineVersion              = "13.4"
 	defaultAwsIdentifierLength           = 40
 	defaultAwsMaxAllocatedStorage        = 100
 	defaultAwsMultiAZ                    = true
@@ -62,7 +62,7 @@ const (
 )
 
 var (
-	defaultSupportedEngineVersions = []string{"13.3", "10.18", "10.16", "10.15", "10.13", "10.6", "9.6", "9.5"}
+	defaultSupportedEngineVersions = []string{"13.4", "10.18", "10.16", "10.15", "10.13", "10.6", "9.6", "9.5"}
 	healthyAWSDBInstanceStatuses   = []string{
 		"backtracking",
 		"available",
@@ -783,6 +783,7 @@ func buildRDSUpdateStrategy(rdsConfig *rds.CreateDBInstanceInput, foundConfig *r
 		if engineUpgradeNeeded {
 			logrus.Info(fmt.Sprintf("Engine upgrade found, the current EngineVersion is %s and is upgrading to %s", *foundConfig.EngineVersion, *rdsConfig.EngineVersion))
 			mi.EngineVersion = rdsConfig.EngineVersion
+			mi.AllowMajorVersionUpgrade = aws.Bool(true)
 			if cr.Spec.ApplyImmediately {
 				mi.ApplyImmediately = aws.Bool(cr.Spec.ApplyImmediately)
 			}

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -44,7 +44,7 @@ const (
 	defaultAwsDBInstanceClass            = "db.t3.small"
 	defaultAwsDeleteAutomatedBackups     = true
 	defaultAwsEngine                     = "postgres"
-	defaultAwsEngineVersion              = "10.18"
+	defaultAwsEngineVersion              = "13.3"
 	defaultAwsIdentifierLength           = 40
 	defaultAwsMaxAllocatedStorage        = 100
 	defaultAwsMultiAZ                    = true
@@ -62,7 +62,7 @@ const (
 )
 
 var (
-	defaultSupportedEngineVersions = []string{"10.18", "10.16", "10.15", "10.13", "10.6", "9.6", "9.5"}
+	defaultSupportedEngineVersions = []string{"13.3", "10.18", "10.16", "10.15", "10.13", "10.6", "9.6", "9.5"}
 	healthyAWSDBInstanceStatuses   = []string{
 		"backtracking",
 		"available",

--- a/pkg/providers/aws/provider_postgres_test.go
+++ b/pkg/providers/aws/provider_postgres_test.go
@@ -1959,6 +1959,7 @@ func Test_buildRDSUpdateStrategy(t *testing.T) {
 			want: &rds.ModifyDBInstanceInput{
 				ApplyImmediately:           aws.Bool(true),
 				AutoMinorVersionUpgrade:    aws.Bool(false),
+				AllowMajorVersionUpgrade:   aws.Bool(true),
 				DeletionProtection:         aws.Bool(false),
 				BackupRetentionPeriod:      aws.Int64(0),
 				DBInstanceClass:            aws.String("newValue"),

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -40,7 +40,7 @@ const (
 	defaultAtRestEncryption = true
 	defaultCacheNodeType    = "cache.t3.micro"
 	defaultDescription      = "A Redis replication group"
-	defaultEngineVersion    = "5.0.6"
+	defaultEngineVersion    = "6.2"
 	// 3scale does not support in transit encryption (redis with tls)
 	defaultInTransitEncryption = false
 	defaultNumCacheClusters    = 2

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -778,11 +778,13 @@ func buildElasticacheUpdateStrategy(ec2Client ec2iface.EC2API, elasticacheConfig
 	for _, foundCacheCluster := range replicationGroupClusters {
 		// check if the redis compatibility version requires an update.
 		if elasticacheConfig.EngineVersion != nil {
+
 			engineUpgradeNeeded, err := resources.VerifyVersionUpgradeNeeded(*foundCacheCluster.EngineVersion, *elasticacheConfig.EngineVersion)
 			if err != nil {
 				return nil, errorUtil.Wrap(err, "invalid redis version")
 			}
 			if engineUpgradeNeeded {
+				modifyInput.SetApplyImmediately(true)
 				modifyInput.EngineVersion = elasticacheConfig.EngineVersion
 				updateFound = true
 			}

--- a/pkg/providers/aws/provider_redis_test.go
+++ b/pkg/providers/aws/provider_redis_test.go
@@ -2112,6 +2112,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 				SnapshotWindow:             aws.String("newValue"),
 				ReplicationGroupId:         aws.String("test-id"),
 				EngineVersion:              aws.String(defaultEngineVersion),
+				ApplyImmediately:           aws.Bool(true),
 			},
 		},
 		{
@@ -2179,6 +2180,7 @@ func Test_buildElasticacheUpdateStrategy(t *testing.T) {
 				SnapshotWindow:             aws.String("newValue"),
 				ReplicationGroupId:         aws.String("test-id"),
 				EngineVersion:              aws.String(defaultEngineVersion),
+				ApplyImmediately:           aws.Bool(true),
 			},
 		},
 	}


### PR DESCRIPTION
## Overview
Change the redis engine version to 6.2 and postgres engine version to 13.4
Jira: https://issues.redhat.com/browse/MGDAPI-3810, https://issues.redhat.com/browse/MGDAPI-4273

## Verification 
Require a CCS cluster to test
- checkout branch 
- Install and run the operator on cluster
```bash
make cluster/prepare
make run
```
- create a postgres CR
```bash
make cluster/seed/managed/postgres
```
- wait for the install to complete and check the CR status for the version 13.3 and the message has `is as expected, aws rds status is available`
```
oc get postgres example-postgres -oyaml | yq '.status'
# e.g.
message: rds instance rhmicloudsccsx28fhcloudresourceoper-7yu3 is as expected, aws rds status is available
phase: complete
provider: aws-rds
secretRef:
  name: example-postgres-sec
strategy: aws
version: "13.4"
```
- If you have aws console access you can confirm the version in the ui
![image](https://user-images.githubusercontent.com/16667688/177167736-71c5c97a-fc8d-44cf-ac12-f73e951844e5.png)

- create a redis CR
```bash
make cluster/seed/managed/redis
```
-- wait for the install to complete and check the CR status for the version 6.2.6 and the message has `successfully created and tagged, aws elasticache status is available`
```bash
oc get redis example-redis -oyaml | yq '.status'
# e.g.
message: successfully created and tagged, aws elasticache status is available
phase: complete
provider: aws-elasticache
secretRef:
  name: example-redis-sec
strategy: aws
version: 6.2.6
```

- If you have aws console access you can confirm the version in the ui
![image](https://user-images.githubusercontent.com/16667688/176693718-f55a9f03-beae-492a-ac1c-71c1769ab647.png)

## Test Upgrade on RHOAM
- uninstall CRO by deleting the postgres and redis CR's
- Stop the CRO operator running locally
- Do a clean up on cluster
```bash
make cluster/clean
```
- prepare the cluster and add the rhoam CR with use cluster storage false
```bash
INSTALLATION_TYPE=managed-api make cluster/prepare/local
INSTALLATION_TYPE=managed-api USE_CLUSTER_STORAGE=false make deploy/integreatly-rhmi-cr.yml
```
- apply the master index for v1.24.0
quay.io/austincunningham/managed-api-service-index:1.24.0
```bash
INSTALLATION_TYPE=managed-api make cluster/prepare/local
oc apply -f - <<EOF
---             
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhmi-operators
  namespace: openshift-marketplace
spec:
  image: 'quay.io/austincunningham/managed-api-service-index:1.24.0'
  sourceType: grpc
EOF
```
- wait for the install to finish 
- check the redis and posgres CR's version
```bash
# redis should be 5.0.6
oc get redis threescale-backend-redis-rhoam -oyaml |  yq '.status.version' 
oc get redis threescale-redis-rhoam -oyaml |  yq '.status.version'
oc get redis ratelimit-service-redis-rhoam -oyaml |  yq '.status.version'
5.0.6
# postgres should be 10.18
oc get postgres.integreatly.org threescale-postgres-rhoam  -oyaml |  yq '.status.version'
oc get postgres rhsso-postgres-rhoam  -oyaml |  yq '.status.version'                                                           
oc get postgres rhssouser-postgres-rhoam  -oyaml |  yq '.status.version'
10.18
```
- Install the workload web app by following the readme https://github.com/integr8ly/workload-web-app#rhoam-clusters

- change the catalogsource to the v1.25.0 image
quay.io/austincunningham/managed-api-service-index:1.25.0
- Go to Operator Hub and install RHOAM
- Create RHMI CR
```bash
INSTALLATION_TYPE=managed-api USE_CLUSTER_STORAGE=true make deploy/integreatly-rhmi-cr.yml
```
- Once installed, trigger upgrade
```bash
oc patch catalogsources rhmi-operators  -n openshift-marketplace  --type=json -p='[{"op": "replace", "path": "/spec/image", "value": "quay.io/austincunningham/managed-api-service-index:1.25.0"}]'
```
- Approve the installPlan in the operator hub
- Verify operator upgrades successfully 
- wait for the install to finish 
- check the redis and posgres CR's version
```bash
# redis should be 6.2.6
oc get redis threescale-backend-redis-rhoam -oyaml |  yq '.status.version' 
oc get redis threescale-redis-rhoam -oyaml |  yq '.status.version'
oc get redis ratelimit-service-redis-rhoam -oyaml |  yq '.status.version'
6.2.6
# postgres should be 13.4
oc get postgres.integreatly.org threescale-postgres-rhoam  -oyaml |  yq '.status.version'
oc get postgres rhsso-postgres-rhoam  -oyaml |  yq '.status.version'                                                           
oc get postgres rhssouser-postgres-rhoam  -oyaml |  yq '.status.version'
13.4
```
- confirm the downtime during the upgrade by checking the workload-web-app grafana dasboard 
![image](https://user-images.githubusercontent.com/16667688/177157781-5c9488c4-c2b4-4ec0-a30a-d2922e9c18f1.png)



