### PR TITLE
MGDAPI-4387 - tag VPC on creation for all cluster types

### DIFF
--- a/pkg/providers/aws/cluster_network_provider.go
+++ b/pkg/providers/aws/cluster_network_provider.go
@@ -183,13 +183,12 @@ func (n *NetworkProvider) CreateNetwork(ctx context.Context, vpcCidrBlock *net.I
 		vpcConfig := &ec2.CreateVpcInput{
 			CidrBlock: aws.String(vpcCidrBlock.String()),
 		}
-		if n.IsSTSCluster {
-			tagSpec, err := getDefaultTagSpec(ctx, n.Client, &tag{key: tagDisplayName, value: defaultVpcNameTagValue}, ec2.ResourceTypeVpc)
-			if err != nil {
-				return nil, errorUtil.Wrap(err, "failed to get default tag spec")
-			}
-			vpcConfig.SetTagSpecifications(tagSpec)
+
+		tagSpec, err := getDefaultTagSpec(ctx, n.Client, &tag{key: tagDisplayName, value: defaultVpcNameTagValue}, ec2.ResourceTypeVpc)
+		if err != nil {
+			return nil, errorUtil.Wrap(err, "failed to get default tag spec")
 		}
+		vpcConfig.SetTagSpecifications(tagSpec)
 
 		// create vpc using cidr string from _network
 		createVpcOutput, err := n.Ec2Api.CreateVpc(vpcConfig)
@@ -234,14 +233,6 @@ func (n *NetworkProvider) CreateNetwork(ctx context.Context, vpcCidrBlock *net.I
 
 		// vpc created, reset metric
 		resources.ResetVpcAction()
-
-		// do not reconcile tags in STS mode
-		if !n.IsSTSCluster {
-			// ensure standalone vpc has correct tags
-			if err = n.reconcileVPCTags(ctx, createVpcOutput.Vpc); err != nil {
-				return nil, errorUtil.Wrapf(err, "unexpected error while reconciling vpc tags")
-			}
-		}
 
 		return &Network{
 			Vpc:     createVpcOutput.Vpc,

--- a/pkg/providers/aws/cluster_network_provider.go
+++ b/pkg/providers/aws/cluster_network_provider.go
@@ -269,8 +269,10 @@ func (n *NetworkProvider) CreateNetwork(ctx context.Context, vpcCidrBlock *net.I
 	}
 
 	// ensure standalone vpc has correct tags
-	if err = n.reconcileVPCTags(ctx, foundVpc); err != nil {
-		return nil, errorUtil.Wrapf(err, "unexpected error while reconciling vpc tags")
+	if !n.IsSTSCluster {
+		if err = n.reconcileVPCTags(ctx, foundVpc); err != nil {
+			return nil, errorUtil.Wrapf(err, "unexpected error while reconciling vpc tags")
+		}
 	}
 
 	return &Network{


### PR DESCRIPTION
## Overview

[MGDAPI-4387](https://issues.redhat.com/browse/MGDAPI-4387)

- We no longer check whether we are in STS cluster or not and create the VPC initially with tags
- Fixed a regression where we would try to reconcile tags onto STS clusters

## Verification

- Provision a CCS cluster
- From 1.24.0
	- Create at least 2 CR's in quick succession
	- See that two VPCs are created in AWS
- Do the same from this PR
- Verify that only a single VPC is created, and tagged on creation

## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below