### PR TITLE
MGDAPI-4554 - update expected file structure of sts secret and remove needing token file path field

### DIFF
--- a/pkg/providers/aws/credentials_sts_manager.go
+++ b/pkg/providers/aws/credentials_sts_manager.go
@@ -14,7 +14,7 @@ import (
 const (
 	defaultSTSCredentialSecretName = "sts-credentials"
 	defaultRoleARNKeyName          = "role_arn"
-	defaultTokenPathKeyName        = "web_identity_token_file"
+	defaultTokenPath               = "/var/run/secrets/openshift/serviceaccount/token"
 )
 
 var _ CredentialManager = (*STSCredentialManager)(nil)
@@ -38,15 +38,13 @@ func (m *STSCredentialManager) ReconcileProviderCredentials(ctx context.Context,
 	if err != nil {
 		return nil, errorUtil.Wrapf(err, "failed to get aws sts credentials secret %s", defaultSTSCredentialSecretName)
 	}
+
 	credentials := &Credentials{
 		RoleArn:       string(secret.Data[defaultRoleARNKeyName]),
-		TokenFilePath: string(secret.Data[defaultTokenPathKeyName]),
+		TokenFilePath: defaultTokenPath,
 	}
 	if credentials.RoleArn == "" {
 		return nil, errorUtil.New(fmt.Sprintf("%s key is undefined in secret %s", defaultRoleARNKeyName, secret.Name))
-	}
-	if credentials.TokenFilePath == "" {
-		return nil, errorUtil.New(fmt.Sprintf("%s key is undefined in secret %s", defaultTokenPathKeyName, secret.Name))
 	}
 	return credentials, nil
 }

--- a/pkg/providers/aws/credentials_sts_manager_test.go
+++ b/pkg/providers/aws/credentials_sts_manager_test.go
@@ -41,13 +41,12 @@ func TestSTSCredentialManager_ReconcileProviderCredentials(t *testing.T) {
 					Namespace: ns,
 				},
 				Data: map[string][]byte{
-					defaultRoleARNKeyName:   []byte("ROLE_ARN"),
-					defaultTokenPathKeyName: []byte("TOKEN_PATH"),
+					defaultRoleARNKeyName: []byte("ROLE_ARN"),
 				},
 			}),
 			wantErr:           false,
 			expectedRoleARN:   "ROLE_ARN",
-			expectedTokenPath: "TOKEN_PATH",
+			expectedTokenPath: defaultTokenPath,
 		},
 		{
 			name: "undefined role arn key in sts credentials secret",
@@ -57,27 +56,11 @@ func TestSTSCredentialManager_ReconcileProviderCredentials(t *testing.T) {
 					Namespace: ns,
 				},
 				Data: map[string][]byte{
-					defaultRoleARNKeyName:   []byte(""),
-					defaultTokenPathKeyName: []byte("TOKEN_PATH"),
+					defaultRoleARNKeyName: []byte(""),
 				},
 			}),
 			wantErr:        true,
 			expectedErrMsg: fmt.Sprintf("%s key is undefined in secret %s", defaultRoleARNKeyName, defaultSTSCredentialSecretName),
-		},
-		{
-			name: "undefined token path key in sts credentials secret",
-			client: fake.NewFakeClientWithScheme(scheme, &v12.Secret{
-				ObjectMeta: controllerruntime.ObjectMeta{
-					Name:      defaultSTSCredentialSecretName,
-					Namespace: ns,
-				},
-				Data: map[string][]byte{
-					defaultRoleARNKeyName:   []byte("ROLE_ARN"),
-					defaultTokenPathKeyName: []byte(""),
-				},
-			}),
-			wantErr:        true,
-			expectedErrMsg: fmt.Sprintf("%s key is undefined in secret %s", defaultTokenPathKeyName, defaultSTSCredentialSecretName),
 		},
 	}
 	for _, tc := range cases {
@@ -133,8 +116,7 @@ func TestSTSCredentialManager_ReconcileBucketOwnerCredentials(t *testing.T) {
 					Namespace: ns,
 				},
 				Data: map[string][]byte{
-					defaultRoleARNKeyName:   []byte("ROLE_ARN"),
-					defaultTokenPathKeyName: []byte("TOKEN_PATH"),
+					defaultRoleARNKeyName: []byte("ROLE_ARN"),
 				},
 			}),
 			wantErr: false,

--- a/scripts/sts/sts-secret.yaml
+++ b/scripts/sts/sts-secret.yaml
@@ -1,7 +1,10 @@
 apiVersion: v1
 stringData:
+  credentials: |
+    [default]
+    role_arn = ROLE_ARN
+    web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
   role_arn: "ROLE_ARN"
-  web_identity_token_file: "/var/run/secrets/openshift/serviceaccount/token"
 kind: Secret
 metadata:
   name: sts-credentials


### PR DESCRIPTION
## Overview
* Update the expected sts secret format
* Remove the need for token file path as it's hardcoded in the pod template anyway
  * https://github.com/integr8ly/cloud-resource-operator/blob/master/config/manager/manager.yaml#L36-L38

Jira: https://issues.redhat.com/browse/MGDAPI-4554

## Verification
* Passing prow checks should do

## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below