### PR TITLE
MGDAPI-4472 CRO can reconnect in the case of a postgres cr recreation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ cluster/seed/managed/postgressnapshot:
 
 .PHONY: cluster/clean
 cluster/clean:
-	@$(KUSTOMIZE) build config/crd | kubectl delete -f -
+	@$(KUSTOMIZE) build config/crd | oc delete -f -
 	@$(KUSTOMIZE) build config/rbac | oc delete --force -f -	
 	oc delete project $(NAMESPACE)
 


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/MGDAPI-4472

## WHAT
If a postgres is removed from the cluster in a case where the RDS is still in place, recreation of a postgres cr could reconnect with the RDS and CRO puts back in place the requried connection details into the cluster for applications to reconnect.

### SCENARIO

Install CRO, install a Postgres cr, Delete the namespace which removes CRO and the postgres but not the DB because the CRO controller wont have time to cleanup.

Reinstall CRO and the Postgres cr. Does it put back the connection secret etc. If not update the logic in CRO to cover this.

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make run`
- Follow as in Scenario


## Checklist
Please see Scenario - CRO recovers Postgres CR after deletion