### PR TITLE
MGDAPI-4625 : Add initial configuration for gosec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,3 +257,7 @@ coverage:
 .PHONY: setup/sts
 setup/sts:
 	NAMESPACE=$(NAMESPACE) ./scripts/sts/create-rhoam-policy.sh
+
+.PHONY: gosec
+gosec:
+	gosec -exclude=G601,G101,G402,G404 -exclude-dir=hack/redis ./...

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -12,3 +12,6 @@ RUN mkdir -p $GOPATH/src/github.com/operator-framework \
     && make install \
     && chmod -R 0777 $GOPATH \
     && rm -rf $GOPATH/.cache
+
+# install gosec
+RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $GOPATH/bin v2.11.0


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/MGDAPI-4625

Adds the initial support for gosec.

The hack/redis folder is being excluded as there is an issue with imports in the file. The fixing of those imports are out of scope for this work.

## Verification

- Clone this branch
- Run `make gosec`
- Ensure command runs with out error.
  - `echo $?` == 0
- Build the openshift-ci image.
- Ensure it builds with out error

## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below