### PR TITLE
MGDAPI-4844 addition of leader election and rbacs required

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -18,6 +18,8 @@ spec:
       - name: cloud-resource-operator
         command:
         - cloud-resource-operator
+        args:
+        - --enable-leader-election
         image: controller
         imagePullPolicy: Always
         env:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -22,6 +22,15 @@ rules:
   - list
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
   - integreatly.org
   resources:
   - postgres

--- a/controllers/postgres/postgres_controller.go
+++ b/controllers/postgres/postgres_controller.go
@@ -113,6 +113,7 @@ func (r *PostgresReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups="",resources=persistentvolumes;configmaps,verbs="*"
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=prometheusrules,verbs="*"
 // +kubebuilder:rbac:groups=integreatly.org,resources=postgres;postgressnapshots;redis;redissnapshots,verbs=list;watch
+// +kubebuilder:rbac:groups="coordination.k8s.io",resources=leases,verbs=create;get;list;update
 
 // Role permissions
 

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8383", "The address the metric endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()


### PR DESCRIPTION
## Overview
https://issues.redhat.com/browse/MGDAPI-4844

## Verification
- Install CRO via OLM by either using this index image: `quay.io/mstoklus/cloud-resource-operator:index-v0.42.0` or create your own one from this branch
- When CRO pod starts, observe at the top of the logs that there is a leader election being established
```
I1103 12:22:45.541490 1 leaderelection.go:248] attempting to acquire leader lease test/ce8de7ea.integreatly.org...
1.6674781655414956e+09 INFO Starting server {"path": "/metrics", "kind": "metrics", "addr": "[::]:8383"}
I1103 12:22:45.550002 1 leaderelection.go:258] successfully acquired lease test/ce8de7ea.integreatly.org
```