### PR TITLE
MGDAPI-4655 add priorityClassName field to cr specs

### DIFF
--- a/apis/integreatly/v1alpha1/types/types.go
+++ b/apis/integreatly/v1alpha1/types/types.go
@@ -30,6 +30,8 @@ type ResourceTypeSpec struct {
 	ApplyImmediately  bool       `json:"applyImmediately,omitempty"`
 	MaintenanceWindow bool       `json:"maintenanceWindow,omitempty"`
 	SecretRef         *SecretRef `json:"secretRef"`
+	// PriorityClassName defines priority class for the postgres/redis deployment (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption)
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
 type StatusPhase string

--- a/config/crd/bases/integreatly.org_blobstorages.yaml
+++ b/config/crd/bases/integreatly.org_blobstorages.yaml
@@ -40,6 +40,10 @@ spec:
                 type: boolean
               maintenanceWindow:
                 type: boolean
+              priorityClassName:
+                description: PriorityClassName defines priority class for the postgres/redis
+                  deployment (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption)
+                type: string
               secretRef:
                 properties:
                   name:

--- a/config/crd/bases/integreatly.org_postgres.yaml
+++ b/config/crd/bases/integreatly.org_postgres.yaml
@@ -40,6 +40,10 @@ spec:
                 type: boolean
               maintenanceWindow:
                 type: boolean
+              priorityClassName:
+                description: PriorityClassName defines priority class for the postgres/redis
+                  deployment (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption)
+                type: string
               secretRef:
                 properties:
                   name:

--- a/config/crd/bases/integreatly.org_redis.yaml
+++ b/config/crd/bases/integreatly.org_redis.yaml
@@ -40,6 +40,10 @@ spec:
                 type: boolean
               maintenanceWindow:
                 type: boolean
+              priorityClassName:
+                description: PriorityClassName defines priority class for the postgres/redis
+                  deployment (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption)
+                type: string
               secretRef:
                 properties:
                   name:

--- a/pkg/providers/openshift/provider_postgres.go
+++ b/pkg/providers/openshift/provider_postgres.go
@@ -419,7 +419,8 @@ func buildDefaultPostgresDeployment(ps *v1alpha1.Postgres) *appsv1.Deployment {
 							},
 						},
 					},
-					Containers: buildDefaultPostgresPodContainers(ps),
+					Containers:        buildDefaultPostgresPodContainers(ps),
+					PriorityClassName: ps.Spec.PriorityClassName,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/MGDAPI-4655

## What

The new field `priorityClassName` is added for use by anyone using CRO that wants to set a specific priority to Redis/Postgres deployments. More info on the priority class name here: https://docs.openshift.com/container-platform/4.11/nodes/pods/nodes-pods-priority.html

## Verification

- Provision an OSD cluster
- Prepare the cluster:
```
make cluster/prepare 
```
- Create a PriorityClass CR:
```
cat << EOF | oc create -f -
apiVersion: scheduling.k8s.io/v1
kind: PriorityClass
metadata:
  name: rhoam-pod-priority
description: 'Priority Class for managed-api'
globalDefault: false
value: 1000000000
EOF
```
- Create a Postgres or Redis CR with `priorityClassName` specified:
```
cat << EOF | oc create -f -
apiVersion: integreatly.org/v1alpha1
kind: Postgres
metadata:
  name: example-postgres
  namespace: cloud-resource-operator
  labels:
    productName: productName
spec:
  secretRef:
    name: example-postgres-sec
  tier: development
  type: workshop
  maintenanceWindow: false
  priorityClassName: rhoam-pod-priority
EOF
```
- Wait until CRO reconciles Postgres and verify the deployment has a priorityClassName of `rhoam-pod-priority`:
```
oc get deployment example-postgres -n cloud-resource-operator -o json | jq -r '.spec.template.spec.priorityClassName'
```