### PR TITLE
MGDAPI-4992 implement gcp redis update/upgrade logic

### DIFF
--- a/pkg/providers/aws/cluster_network_provider.go
+++ b/pkg/providers/aws/cluster_network_provider.go
@@ -184,7 +184,7 @@ func (n *NetworkProvider) CreateNetwork(ctx context.Context, vpcCidrBlock *net.I
 			CidrBlock: aws.String(vpcCidrBlock.String()),
 		}
 
-		tagSpec, err := getDefaultTagSpec(ctx, n.Client, &tag{key: tagDisplayName, value: defaultVpcNameTagValue}, ec2.ResourceTypeVpc)
+		tagSpec, err := getDefaultTagSpec(ctx, n.Client, &resources.Tag{Key: resources.TagDisplayName, Value: defaultVpcNameTagValue}, ec2.ResourceTypeVpc)
 		if err != nil {
 			return nil, errorUtil.Wrap(err, "failed to get default tag spec")
 		}
@@ -552,7 +552,7 @@ func (n *NetworkProvider) CreateNetworkPeering(ctx context.Context, network *Net
 			VpcId:     network.Vpc.VpcId,
 		}
 		if n.IsSTSCluster {
-			tagSpec, err := getDefaultTagSpec(ctx, n.Client, &tag{key: tagDisplayName, value: defaultVpcPeeringConnectionNameTagValue}, ec2.ResourceTypeVpcPeeringConnection)
+			tagSpec, err := getDefaultTagSpec(ctx, n.Client, &resources.Tag{Key: resources.TagDisplayName, Value: defaultVpcPeeringConnectionNameTagValue}, ec2.ResourceTypeVpcPeeringConnection)
 			if err != nil {
 				return nil, errorUtil.Wrap(err, "failed to get default tag spec")
 			}
@@ -570,14 +570,14 @@ func (n *NetworkProvider) CreateNetworkPeering(ctx context.Context, network *Net
 	// once we have the peering connection, tag it, so it's identifiable as belonging to this operator
 	// this helps with cleaning up resources
 	if !n.IsSTSCluster {
-		defaultTags, err := getDefaultNetworkTags(ctx, n.Client, &tag{key: tagDisplayName, value: defaultVpcPeeringConnectionNameTagValue})
+		defaultTags, err := getDefaultNetworkTags(ctx, n.Client, &resources.Tag{Key: resources.TagDisplayName, Value: defaultVpcPeeringConnectionNameTagValue})
 		if err != nil {
 			return nil, errorUtil.Wrap(err, "failed to get default tags for peering connection")
 		}
 
 		logger.Infof("checking tags on peering connection")
 		peeringConnectionTags := ec2TagsToGeneric(peeringConnection.Tags)
-		if !tagsContainsAll(defaultTags, peeringConnectionTags) {
+		if !resources.TagsContainsAll(defaultTags, peeringConnectionTags) {
 			logger.Info("creating tags on peering connection")
 			_, err = n.Ec2Api.CreateTags(&ec2.CreateTagsInput{
 				Resources: []*string{peeringConnection.VpcPeeringConnectionId},
@@ -872,7 +872,7 @@ func (n *NetworkProvider) reconcileStandaloneSecurityGroup(ctx context.Context, 
 		}
 
 		if n.IsSTSCluster {
-			tagSpec, err := getDefaultTagSpec(ctx, n.Client, &tag{key: tagDisplayName, value: defaultSecurityGroupNameTagValue}, ec2.ResourceTypeSecurityGroup)
+			tagSpec, err := getDefaultTagSpec(ctx, n.Client, &resources.Tag{Key: resources.TagDisplayName, Value: defaultSecurityGroupNameTagValue}, ec2.ResourceTypeSecurityGroup)
 			if err != nil {
 				return nil, errorUtil.Wrap(err, "failed to get default tag spec")
 			}
@@ -907,12 +907,12 @@ func (n *NetworkProvider) reconcileStandaloneSecurityGroup(ctx context.Context, 
 	if !n.IsSTSCluster {
 		// ensure standalone vpc has correct tags
 		// we require the subnet group to be tagged with the cro owner tag
-		defaultTags, err := getDefaultNetworkTags(ctx, n.Client, &tag{key: tagDisplayName, value: defaultSecurityGroupNameTagValue})
+		defaultTags, err := getDefaultNetworkTags(ctx, n.Client, &resources.Tag{Key: resources.TagDisplayName, Value: defaultSecurityGroupNameTagValue})
 		if err != nil {
 			return nil, errorUtil.Wrap(err, "failed to get default tags for security group")
 		}
 		securityGroupTags := ec2TagsToGeneric(standaloneSecGroup.Tags)
-		if !tagsContainsAll(defaultTags, securityGroupTags) {
+		if !resources.TagsContainsAll(defaultTags, securityGroupTags) {
 			logger.Infof("tagging security group %s", aws.StringValue(standaloneSecGroup.GroupId))
 			_, err := n.Ec2Api.CreateTags(&ec2.CreateTagsInput{
 				Resources: []*string{
@@ -985,13 +985,13 @@ func (n *NetworkProvider) reconcileStandaloneRouteTableTags(ctx context.Context,
 		return errorUtil.New(fmt.Sprint("did not find any route associated with vpc %", vpc.VpcId))
 	}
 
-	defaultTags, err := getDefaultNetworkTags(ctx, n.Client, &tag{key: tagDisplayName, value: defaultRouteTableNameTagValue})
+	defaultTags, err := getDefaultNetworkTags(ctx, n.Client, &resources.Tag{Key: resources.TagDisplayName, Value: defaultRouteTableNameTagValue})
 	if err != nil {
 		return errorUtil.Wrap(err, "failed to get default tags for route table")
 	}
 	for _, routeTable := range routeTables {
 		routeTableTags := ec2TagsToGeneric(routeTable.Tags)
-		if !tagsContainsAll(defaultTags, routeTableTags) {
+		if !resources.TagsContainsAll(defaultTags, routeTableTags) {
 			_, err := n.Ec2Api.CreateTags(&ec2.CreateTagsInput{
 				Resources: []*string{
 					aws.String(*routeTable.RouteTableId),
@@ -1184,7 +1184,7 @@ func (n *NetworkProvider) reconcileStandaloneVPCSubnets(ctx context.Context, log
 		// ensure subnets have the correct tags
 		for _, sub := range subs {
 			logger.Infof("validating subnet %s", *sub.SubnetId)
-			if !tagsContainsAll(ec2TagsToGeneric(subnetTags), ec2TagsToGeneric(sub.Tags)) {
+			if !resources.TagsContainsAll(ec2TagsToGeneric(subnetTags), ec2TagsToGeneric(sub.Tags)) {
 				if err := tagPrivateSubnet(ctx, n.Client, n.Ec2Api, sub, logger); err != nil {
 					return nil, errorUtil.Wrap(err, "failed to tag subnet")
 				}
@@ -1234,13 +1234,13 @@ func (n *NetworkProvider) getCRORouteTables(ctx context.Context) ([]*ec2.RouteTa
 	var foundRouteTables []*ec2.RouteTable
 	for _, routeTable := range routeTables.RouteTables {
 		routeTableTags := ec2TagsToGeneric(routeTable.Tags)
-		if tagsContains(routeTableTags, croOwnerTag.key, croOwnerTag.value) {
+		if resources.TagsContains(routeTableTags, croOwnerTag.Key, croOwnerTag.Value) {
 			foundRouteTables = append(foundRouteTables, routeTable)
 		}
 	}
 
 	if len(foundRouteTables) == 0 {
-		return nil, errorUtil.New(fmt.Sprintf("could not find any route table with the tag key: %s and value: %s", croOwnerTag.key, croOwnerTag.value))
+		return nil, errorUtil.New(fmt.Sprintf("could not find any route table with the tag key: %s and value: %s", croOwnerTag.Key, croOwnerTag.Value))
 	}
 	return foundRouteTables, nil
 }
@@ -1252,12 +1252,12 @@ func (n *NetworkProvider) getCRORouteTables(ctx context.Context) ([]*ec2.RouteTa
 func (n *NetworkProvider) reconcileVPCTags(ctx context.Context, vpc *ec2.Vpc) error {
 	logger := n.Logger.WithField("action", "reconcileVPCTags")
 
-	defaultTags, err := getDefaultNetworkTags(ctx, n.Client, &tag{key: tagDisplayName, value: defaultVpcNameTagValue})
+	defaultTags, err := getDefaultNetworkTags(ctx, n.Client, &resources.Tag{Key: resources.TagDisplayName, Value: defaultVpcNameTagValue})
 	if err != nil {
 		return errorUtil.Wrap(err, "failed to get default tags for vpc")
 	}
 	vpcTags := ec2TagsToGeneric(vpc.Tags)
-	if !tagsContainsAll(defaultTags, vpcTags) {
+	if !resources.TagsContainsAll(defaultTags, vpcTags) {
 		_, err := n.Ec2Api.CreateTags(&ec2.CreateTagsInput{
 			Resources: []*string{
 				aws.String(*vpc.VpcId),
@@ -1338,7 +1338,7 @@ func (n *NetworkProvider) reconcileRDSVpcConfiguration(ctx context.Context, priv
 
 			// ensure tags exist on rds subnet group
 			subnetTags := rdsTagstoGeneric(tags.TagList)
-			if !tagsContainsAll(defaultTags, subnetTags) {
+			if !resources.TagsContainsAll(defaultTags, subnetTags) {
 				err := n.updateRdsSubnetGroupTags(foundSubnetGroup, genericToRdsTags(defaultTags))
 				if err != nil {
 					return errorUtil.Wrap(err, "error updating subnet group tags")
@@ -1483,7 +1483,7 @@ func getStandaloneVpc(ctx context.Context, client client.Client, ec2Svc ec2iface
 	var foundVPC *ec2.Vpc
 	for _, vpc := range vpcs.Vpcs {
 		for _, tag := range vpc.Tags {
-			if *tag.Key == croOwnerTag.key && *tag.Value == croOwnerTag.value {
+			if *tag.Key == croOwnerTag.Key && *tag.Value == croOwnerTag.Value {
 				logger.Infof("found vpc: %s", *vpc.VpcId)
 				foundVPC = vpc
 			}
@@ -1787,7 +1787,7 @@ func validateStandaloneCidrBlock(validateCIDR *net.IPNet, clusterCIDR *net.IPNet
 // all network provider resources are to be tagged with a cloud resource operator owner tag
 // denoted -> `integreatly.org/clusterID=<infrastructure-id>`
 // this utility function returns a build owner tag
-func getCloudResourceOperatorOwnerTag(ctx context.Context, client client.Client) (*tag, error) {
+func getCloudResourceOperatorOwnerTag(ctx context.Context, client client.Client) (*resources.Tag, error) {
 	clusterID, err := resources.GetClusterID(ctx, client)
 	if err != nil {
 		return nil, errorUtil.Wrap(err, "error getting clusterID")
@@ -1800,7 +1800,7 @@ func getCloudResourceOperatorOwnerTag(ctx context.Context, client client.Client)
 	return genericTag, nil
 }
 
-func getDefaultTagSpec(ctx context.Context, client client.Client, customTag *tag, resourceType string) ([]*ec2.TagSpecification, error) {
+func getDefaultTagSpec(ctx context.Context, client client.Client, customTag *resources.Tag, resourceType string) ([]*ec2.TagSpecification, error) {
 	tags, err := getDefaultNetworkTags(ctx, client, customTag)
 	if err != nil {
 		return nil, err
@@ -1815,20 +1815,20 @@ func getDefaultTagSpec(ctx context.Context, client client.Client, customTag *tag
 
 // Used to retrieve a set of default tag values for network resources
 // the customTag passed in is used to generate a specific tag for the resource type
-func getDefaultNetworkTags(ctx context.Context, client client.Client, customTag *tag) ([]*tag, error) {
+func getDefaultNetworkTags(ctx context.Context, client client.Client, customTag *resources.Tag) ([]*resources.Tag, error) {
 	croTag, err := getCloudResourceOperatorOwnerTag(ctx, client)
 	if err != nil {
 		return nil, errorUtil.Wrap(err, "failed to build default tags")
 	}
-	tags := []*tag{
+	tags := []*resources.Tag{
 		croTag,
-		buildManagedTag(),
+		resources.BuildManagedTag(),
 	}
 	if customTag != nil {
 		tags = append(tags, customTag)
 	}
 
-	infraTags, err := getUserInfraTags(ctx, client)
+	infraTags, err := resources.GetUserInfraTags(ctx, client)
 	if err != nil {
 		msg := "Failed to get user infrastructure tags"
 		return nil, errorUtil.Wrapf(err, msg)
@@ -1836,7 +1836,7 @@ func getDefaultNetworkTags(ctx context.Context, client client.Client, customTag 
 	if infraTags != nil {
 		// merge tags into single array, where any duplicate
 		// values in infra are discarded in favour of the default tags
-		tags = mergeTags(tags, infraTags)
+		tags = resources.MergeTags(tags, infraTags)
 	}
 	return tags, nil
 }

--- a/pkg/providers/aws/cluster_network_provider_test.go
+++ b/pkg/providers/aws/cluster_network_provider_test.go
@@ -198,10 +198,10 @@ func buildSubnet(vpcID, subnetId, azId, cidrBlock string) *ec2.Subnet {
 				Value: aws.String("test"),
 			},
 			{
-				Key:   aws.String(tagDisplayName),
+				Key:   aws.String(resources.TagDisplayName),
 				Value: aws.String(defaultSubnetNameTagValue),
 			},
-			genericToEc2Tag(buildManagedTag()),
+			genericToEc2Tag(resources.BuildManagedTag()),
 		},
 	}
 }
@@ -319,7 +319,7 @@ func buildValidClusterVPC(cidrBlock string) []*ec2.Vpc {
 					Key:   aws.String(getOSDClusterTagKey(defaultInfraName)),
 					Value: aws.String(clusterOwnedTagValue),
 				},
-				genericToEc2Tag(buildManagedTag()),
+				genericToEc2Tag(resources.BuildManagedTag()),
 			},
 			State: aws.String(ec2.VpcStateAvailable),
 		},
@@ -331,9 +331,9 @@ func buildValidStandaloneVPCTags() []*ec2.Tag {
 			Key:   aws.String(defaultSubnetTag),
 			Value: aws.String(defaultInfraName),
 		},
-		genericToEc2Tag(buildManagedTag()),
+		genericToEc2Tag(resources.BuildManagedTag()),
 		{
-			Key:   aws.String(tagDisplayName),
+			Key:   aws.String(resources.TagDisplayName),
 			Value: aws.String(defaultVpcNameTagValue),
 		},
 	}
@@ -1435,7 +1435,7 @@ func TestNetworkProvider_CreateNetwork(t *testing.T) {
 						return &ec2.DescribeRouteTablesOutput{
 							RouteTables: []*ec2.RouteTable{
 								buildMockEc2RouteTable(func(table *ec2.RouteTable) {
-									tags, _ := getDefaultTagSpec(context.TODO(), fake.NewFakeClientWithScheme(scheme, buildTestInfra()), &tag{key: tagDisplayName, value: defaultRouteTableNameTagValue}, ec2.ResourceTypeRouteTable)
+									tags, _ := getDefaultTagSpec(context.TODO(), fake.NewFakeClientWithScheme(scheme, buildTestInfra()), &resources.Tag{Key: resources.TagDisplayName, Value: defaultRouteTableNameTagValue}, ec2.ResourceTypeRouteTable)
 									table.Tags = tags[0].Tags
 								}),
 							},
@@ -2560,7 +2560,7 @@ func TestNetworkProvider_CreateNetworkConnection(t *testing.T) {
 								vpc.CidrBlock = aws.String(validCIDRTwentySix)
 								vpc.Tags = []*ec2.Tag{
 									buildMockEc2Tag(func(e *ec2.Tag) {
-										e.Key = aws.String(tagDisplayName)
+										e.Key = aws.String(resources.TagDisplayName)
 										e.Value = aws.String(defaultVpcNameTagValue)
 									}),
 									buildMockEc2Tag(func(e *ec2.Tag) {}),
@@ -2658,7 +2658,7 @@ func TestNetworkProvider_CreateNetworkConnection(t *testing.T) {
 								vpc.CidrBlock = aws.String(validCIDRTwentySix)
 								vpc.Tags = []*ec2.Tag{
 									buildMockEc2Tag(func(e *ec2.Tag) {
-										e.Key = aws.String(tagDisplayName)
+										e.Key = aws.String(resources.TagDisplayName)
 										e.Value = aws.String(defaultVpcNameTagValue)
 									}),
 									buildMockEc2Tag(func(e *ec2.Tag) {}),
@@ -2716,7 +2716,7 @@ func TestNetworkProvider_CreateNetworkConnection(t *testing.T) {
 								vpc.CidrBlock = aws.String(validCIDRTwentySix)
 								vpc.Tags = []*ec2.Tag{
 									buildMockEc2Tag(func(e *ec2.Tag) {
-										e.Key = aws.String(tagDisplayName)
+										e.Key = aws.String(resources.TagDisplayName)
 										e.Value = aws.String(defaultVpcNameTagValue)
 									}),
 									buildMockEc2Tag(func(e *ec2.Tag) {}),
@@ -2803,7 +2803,7 @@ func TestNetworkProvider_CreateNetworkConnection(t *testing.T) {
 								vpc.CidrBlock = aws.String(validCIDRTwentySix)
 								vpc.Tags = []*ec2.Tag{
 									buildMockEc2Tag(func(e *ec2.Tag) {
-										e.Key = aws.String(tagDisplayName)
+										e.Key = aws.String(resources.TagDisplayName)
 										e.Value = aws.String(defaultVpcNameTagValue)
 									}),
 									buildMockEc2Tag(func(e *ec2.Tag) {}),
@@ -2818,7 +2818,7 @@ func TestNetworkProvider_CreateNetworkConnection(t *testing.T) {
 									group.Tags = []*ec2.Tag{
 										buildMockEc2Tag(func(e *ec2.Tag) {}),
 										buildMockEc2Tag(func(e *ec2.Tag) {
-											e.Key = aws.String(tagDisplayName)
+											e.Key = aws.String(resources.TagDisplayName)
 											e.Value = aws.String(defaultVpcNameTagValue)
 										}),
 									}
@@ -2885,7 +2885,7 @@ func TestNetworkProvider_CreateNetworkConnection(t *testing.T) {
 					group.Tags = []*ec2.Tag{
 						buildMockEc2Tag(func(e *ec2.Tag) {}),
 						buildMockEc2Tag(func(e *ec2.Tag) {
-							e.Key = aws.String(tagDisplayName)
+							e.Key = aws.String(resources.TagDisplayName)
 							e.Value = aws.String(defaultVpcNameTagValue)
 						}),
 					}
@@ -2906,7 +2906,7 @@ func TestNetworkProvider_CreateNetworkConnection(t *testing.T) {
 								vpc.CidrBlock = aws.String(validCIDRTwentySix)
 								vpc.Tags = []*ec2.Tag{
 									buildMockEc2Tag(func(e *ec2.Tag) {
-										e.Key = aws.String(tagDisplayName)
+										e.Key = aws.String(resources.TagDisplayName)
 										e.Value = aws.String(defaultVpcNameTagValue)
 									}),
 									buildMockEc2Tag(func(e *ec2.Tag) {}),
@@ -2921,7 +2921,7 @@ func TestNetworkProvider_CreateNetworkConnection(t *testing.T) {
 									group.Tags = []*ec2.Tag{
 										buildMockEc2Tag(func(e *ec2.Tag) {}),
 										buildMockEc2Tag(func(e *ec2.Tag) {
-											e.Key = aws.String(tagDisplayName)
+											e.Key = aws.String(resources.TagDisplayName)
 											e.Value = aws.String(defaultVpcNameTagValue)
 										}),
 									}
@@ -2991,7 +2991,7 @@ func TestNetworkProvider_CreateNetworkConnection(t *testing.T) {
 					group.Tags = []*ec2.Tag{
 						buildMockEc2Tag(func(e *ec2.Tag) {}),
 						buildMockEc2Tag(func(e *ec2.Tag) {
-							e.Key = aws.String(tagDisplayName)
+							e.Key = aws.String(resources.TagDisplayName)
 							e.Value = aws.String(defaultVpcNameTagValue)
 						}),
 					}
@@ -3082,7 +3082,7 @@ func TestNetworkProvider_DeleteNetworkConnection(t *testing.T) {
 								vpc.CidrBlock = aws.String(validCIDRTwentySix)
 								vpc.Tags = []*ec2.Tag{
 									buildMockEc2Tag(func(e *ec2.Tag) {
-										e.Key = aws.String(tagDisplayName)
+										e.Key = aws.String(resources.TagDisplayName)
 										e.Value = aws.String(defaultVpcNameTagValue)
 									}),
 									buildMockEc2Tag(func(e *ec2.Tag) {}),
@@ -3127,7 +3127,7 @@ func TestNetworkProvider_DeleteNetworkConnection(t *testing.T) {
 									group.Tags = []*ec2.Tag{
 										buildMockEc2Tag(func(e *ec2.Tag) {}),
 										buildMockEc2Tag(func(e *ec2.Tag) {
-											e.Key = aws.String(tagDisplayName)
+											e.Key = aws.String(resources.TagDisplayName)
 											e.Value = aws.String(defaultVpcNameTagValue)
 										}),
 									}
@@ -3159,7 +3159,7 @@ func TestNetworkProvider_DeleteNetworkConnection(t *testing.T) {
 								vpc.CidrBlock = aws.String(validCIDRTwentySix)
 								vpc.Tags = []*ec2.Tag{
 									buildMockEc2Tag(func(e *ec2.Tag) {
-										e.Key = aws.String(tagDisplayName)
+										e.Key = aws.String(resources.TagDisplayName)
 										e.Value = aws.String(defaultVpcNameTagValue)
 									}),
 									buildMockEc2Tag(func(e *ec2.Tag) {}),
@@ -3224,7 +3224,7 @@ func TestNetworkProvider_DeleteNetworkConnection(t *testing.T) {
 								vpc.CidrBlock = aws.String(validCIDRTwentySix)
 								vpc.Tags = []*ec2.Tag{
 									buildMockEc2Tag(func(e *ec2.Tag) {
-										e.Key = aws.String(tagDisplayName)
+										e.Key = aws.String(resources.TagDisplayName)
 										e.Value = aws.String(defaultVpcNameTagValue)
 									}),
 									buildMockEc2Tag(func(e *ec2.Tag) {}),
@@ -3268,7 +3268,7 @@ func TestNetworkProvider_DeleteNetworkConnection(t *testing.T) {
 								buildMockEc2SecurityGroup(func(group *ec2.SecurityGroup) {
 									group.Tags = []*ec2.Tag{
 										buildMockEc2Tag(func(e *ec2.Tag) {
-											e.Key = aws.String(tagDisplayName)
+											e.Key = aws.String(resources.TagDisplayName)
 											e.Value = aws.String(defaultVpcNameTagValue)
 										}),
 									}
@@ -3303,7 +3303,7 @@ func TestNetworkProvider_DeleteNetworkConnection(t *testing.T) {
 								vpc.CidrBlock = aws.String(validCIDRTwentySix)
 								vpc.Tags = []*ec2.Tag{
 									buildMockEc2Tag(func(e *ec2.Tag) {
-										e.Key = aws.String(tagDisplayName)
+										e.Key = aws.String(resources.TagDisplayName)
 										e.Value = aws.String(defaultVpcNameTagValue)
 									}),
 									buildMockEc2Tag(func(e *ec2.Tag) {}),

--- a/pkg/providers/aws/cluster_vpc.go
+++ b/pkg/providers/aws/cluster_vpc.go
@@ -285,19 +285,19 @@ func getDefaultSubnetTags(ctx context.Context, c client.Client) ([]*ec2.Tag, err
 	}
 	organizationTag := resources.GetOrganizationTag()
 
-	tags := []*tag{
+	tags := []*resources.Tag{
 		{
-			key:   defaultAWSPrivateSubnetTagKey,
-			value: "1",
+			Key:   defaultAWSPrivateSubnetTagKey,
+			Value: "1",
 		}, {
-			key:   fmt.Sprintf("%sclusterID", organizationTag),
-			value: clusterID,
+			Key:   fmt.Sprintf("%sclusterID", organizationTag),
+			Value: clusterID,
 		}, {
-			key:   tagDisplayName,
-			value: defaultSubnetNameTagValue,
-		}, buildManagedTag(),
+			Key:   resources.TagDisplayName,
+			Value: defaultSubnetNameTagValue,
+		}, resources.BuildManagedTag(),
 	}
-	infraTags, err := getUserInfraTags(ctx, c)
+	infraTags, err := resources.GetUserInfraTags(ctx, c)
 	if err != nil {
 		msg := "Failed to get user infrastructure tags"
 		return nil, errorUtil.Wrapf(err, msg)
@@ -305,7 +305,7 @@ func getDefaultSubnetTags(ctx context.Context, c client.Client) ([]*ec2.Tag, err
 	if infraTags != nil {
 		// merge tags into single array, where any duplicate
 		// values in infra are discarded in favour of the default tags
-		tags = mergeTags(tags, infraTags)
+		tags = resources.MergeTags(tags, infraTags)
 	}
 
 	return genericToEc2Tags(tags), nil

--- a/pkg/providers/aws/cluster_vpc_test.go
+++ b/pkg/providers/aws/cluster_vpc_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	configv1 "github.com/integr8ly/cloud-resource-operator/apis/config/v1"
+	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 	"reflect"
@@ -168,12 +169,12 @@ func Test_getDefaultSubnetTags(t *testing.T) {
 					Value: aws.String("test"),
 				},
 				{
-					Key:   aws.String(tagDisplayName),
+					Key:   aws.String(resources.TagDisplayName),
 					Value: aws.String(defaultSubnetNameTagValue),
 				},
 				{
-					Key:   aws.String(tagManagedKey),
-					Value: aws.String(tagManagedVal),
+					Key:   aws.String(resources.TagManagedKey),
+					Value: aws.String(resources.TagManagedVal),
 				},
 				{
 					Key:   aws.String("test-key"),

--- a/pkg/providers/aws/provider_blobstorage.go
+++ b/pkg/providers/aws/provider_blobstorage.go
@@ -334,7 +334,7 @@ func (p *BlobStorageProvider) removeCredsAndFinalizer(ctx context.Context, bs *v
 }
 
 func (p *BlobStorageProvider) getDefaultS3Tags(ctx context.Context, cr *v1alpha1.BlobStorage) ([]*s3.Tag, error) {
-	tags, _, err := getDefaultResourceTags(ctx, p.Client, cr.Spec.Type, cr.Name, cr.ObjectMeta.Labels["productName"])
+	tags, _, err := resources.GetDefaultResourceTags(ctx, p.Client, cr.Spec.Type, cr.Name, cr.ObjectMeta.Labels["productName"])
 	if err != nil {
 		msg := "Failed to get default s3 tags"
 		return nil, errorUtil.Wrapf(err, msg)

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -728,7 +728,7 @@ func (p *PostgresProvider) getRDSConfig(ctx context.Context, r *v1alpha1.Postgre
 }
 
 func (p *PostgresProvider) getDefaultRdsTags(ctx context.Context, cr *v1alpha1.Postgres) ([]*rds.Tag, error) {
-	tags, _, err := getDefaultResourceTags(ctx, p.Client, cr.Spec.Type, cr.Name, cr.ObjectMeta.Labels["productName"])
+	tags, _, err := resources.GetDefaultResourceTags(ctx, p.Client, cr.Spec.Type, cr.Name, cr.ObjectMeta.Labels["productName"])
 	if err != nil {
 		msg := "Failed to get default RDS tags"
 		return nil, errorUtil.Wrapf(err, msg)

--- a/pkg/providers/aws/provider_postgressnapshot.go
+++ b/pkg/providers/aws/provider_postgressnapshot.go
@@ -143,7 +143,7 @@ func (p *PostgresSnapshotProvider) createPostgresSnapshot(ctx context.Context, s
 			return nil, croType.StatusMessage(errMsg), errorUtil.New(errMsg)
 		}
 		logger.Info("creating rds snapshot")
-		tags, _, err := getDefaultResourceTags(ctx, p.client, postgres.Spec.Type, snapshotName, postgres.ObjectMeta.Labels["productName"])
+		tags, _, err := resources.GetDefaultResourceTags(ctx, p.client, postgres.Spec.Type, snapshotName, postgres.ObjectMeta.Labels["productName"])
 		if err != nil {
 			msg := "failed to get default postgres tags"
 			return nil, "", errorUtil.Wrapf(err, msg)

--- a/pkg/providers/aws/provider_postgressnapshot_test.go
+++ b/pkg/providers/aws/provider_postgressnapshot_test.go
@@ -184,7 +184,7 @@ func TestAWSPostgresSnapshotProvider_createPostgresSnapshot(t *testing.T) {
 						Value: aws.String("testtesttest000101010000000000UTC"),
 					},
 					{
-						Key:   aws.String(tagManagedKey),
+						Key:   aws.String(resources.TagManagedKey),
 						Value: aws.String("true"),
 					},
 					{

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -697,7 +697,7 @@ func (p *RedisProvider) getElasticacheConfig(ctx context.Context, r *v1alpha1.Re
 }
 
 func (p *RedisProvider) getDefaultElasticacheTags(ctx context.Context, cr *v1alpha1.Redis) ([]*elasticache.Tag, string, error) {
-	tags, clusterID, err := getDefaultResourceTags(ctx, p.Client, cr.Spec.Type, cr.Name, cr.ObjectMeta.Labels["productName"])
+	tags, clusterID, err := resources.GetDefaultResourceTags(ctx, p.Client, cr.Spec.Type, cr.Name, cr.ObjectMeta.Labels["productName"])
 	if err != nil {
 		msg := "Failed to get default redis tags"
 		return nil, "", errorUtil.Wrapf(err, msg)

--- a/pkg/providers/aws/provider_redissnapshot.go
+++ b/pkg/providers/aws/provider_redissnapshot.go
@@ -141,7 +141,7 @@ func (p *RedisSnapshotProvider) createRedisSnapshot(ctx context.Context, snapsho
 	// create snapshot of the redis instance
 	if foundSnapshot == nil {
 		logger.Info("creating redis snapshot")
-		tags, _, err := getDefaultResourceTags(ctx, p.client, redis.Spec.Type, snapshotName, redis.ObjectMeta.Labels["productName"])
+		tags, _, err := resources.GetDefaultResourceTags(ctx, p.client, redis.Spec.Type, snapshotName, redis.ObjectMeta.Labels["productName"])
 		if err != nil {
 			msg := "failed to get default redis tags"
 			return nil, "", errorUtil.Wrapf(err, msg)

--- a/pkg/providers/aws/provider_redissnapshot_test.go
+++ b/pkg/providers/aws/provider_redissnapshot_test.go
@@ -154,7 +154,7 @@ func TestAWSRedisSnapshotProvider_createRedisSnapshot(t *testing.T) {
 						Value: aws.String("testtesttest000101010000000000UTC"),
 					},
 					{
-						Key:   aws.String(tagManagedKey),
+						Key:   aws.String(resources.TagManagedKey),
 						Value: aws.String("true"),
 					},
 				}

--- a/pkg/providers/aws/tags.go
+++ b/pkg/providers/aws/tags.go
@@ -1,64 +1,43 @@
 package aws
 
 import (
-	"context"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
-	errorUtil "github.com/pkg/errors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	tagDisplayName = "Name"
-
-	tagManagedKey = "red-hat-managed"
-	tagManagedVal = "true"
-)
-
-// generic key-value tag
-type tag struct {
-	key   string
-	value string
+func ec2TagToGeneric(ec2Tag *ec2.Tag) *resources.Tag {
+	return &resources.Tag{Key: aws.StringValue(ec2Tag.Key), Value: aws.StringValue(ec2Tag.Value)}
 }
 
-func (a *tag) Equal(b *tag) bool {
-	return a.key == b.key && a.value == b.value
-}
-
-func ec2TagToGeneric(ec2Tag *ec2.Tag) *tag {
-	return &tag{key: aws.StringValue(ec2Tag.Key), value: aws.StringValue(ec2Tag.Value)}
-}
-
-func ec2TagsToGeneric(ec2Tags []*ec2.Tag) []*tag {
-	var genericTags []*tag
+func ec2TagsToGeneric(ec2Tags []*ec2.Tag) []*resources.Tag {
+	var genericTags []*resources.Tag
 	for _, ec2Tag := range ec2Tags {
-		genericTags = append(genericTags, &tag{key: aws.StringValue(ec2Tag.Key), value: aws.StringValue(ec2Tag.Value)})
+		genericTags = append(genericTags, &resources.Tag{Key: aws.StringValue(ec2Tag.Key), Value: aws.StringValue(ec2Tag.Value)})
 	}
 	return genericTags
 }
 
-func genericToEc2Tag(tag *tag) *ec2.Tag {
-	return &ec2.Tag{Key: aws.String(tag.key), Value: aws.String(tag.value)}
+func genericToEc2Tag(tag *resources.Tag) *ec2.Tag {
+	return &ec2.Tag{Key: aws.String(tag.Key), Value: aws.String(tag.Value)}
 }
 
-func genericToRdsTag(tag *tag) *rds.Tag {
-	return &rds.Tag{Key: aws.String(tag.key), Value: aws.String(tag.value)}
+func genericToRdsTag(tag *resources.Tag) *rds.Tag {
+	return &rds.Tag{Key: aws.String(tag.Key), Value: aws.String(tag.Value)}
 }
 
-func genericToS3Tag(tag *tag) *s3.Tag {
-	return &s3.Tag{Key: aws.String(tag.key), Value: aws.String(tag.value)}
+func genericToS3Tag(tag *resources.Tag) *s3.Tag {
+	return &s3.Tag{Key: aws.String(tag.Key), Value: aws.String(tag.Value)}
 }
 
-func genericToElasticacheTag(tag *tag) *elasticache.Tag {
-	return &elasticache.Tag{Key: aws.String(tag.key), Value: aws.String(tag.value)}
+func genericToElasticacheTag(tag *resources.Tag) *elasticache.Tag {
+	return &elasticache.Tag{Key: aws.String(tag.Key), Value: aws.String(tag.Value)}
 }
 
-func genericToRdsTags(tags []*tag) []*rds.Tag {
+func genericToRdsTags(tags []*resources.Tag) []*rds.Tag {
 	var rdsTags []*rds.Tag
 	for _, tag := range tags {
 		rdsTags = append(rdsTags, genericToRdsTag(tag))
@@ -66,7 +45,7 @@ func genericToRdsTags(tags []*tag) []*rds.Tag {
 	return rdsTags
 }
 
-func genericToS3Tags(tags []*tag) []*s3.Tag {
+func genericToS3Tags(tags []*resources.Tag) []*s3.Tag {
 	var s3Tags []*s3.Tag
 	for _, tag := range tags {
 		s3Tags = append(s3Tags, genericToS3Tag(tag))
@@ -74,7 +53,7 @@ func genericToS3Tags(tags []*tag) []*s3.Tag {
 	return s3Tags
 }
 
-func genericToElasticacheTags(tags []*tag) []*elasticache.Tag {
+func genericToElasticacheTags(tags []*resources.Tag) []*elasticache.Tag {
 	var cacheTags []*elasticache.Tag
 	for _, tag := range tags {
 		cacheTags = append(cacheTags, genericToElasticacheTag(tag))
@@ -82,129 +61,18 @@ func genericToElasticacheTags(tags []*tag) []*elasticache.Tag {
 	return cacheTags
 }
 
-func rdsTagstoGeneric(rdsTags []*rds.Tag) []*tag {
-	var genericTags []*tag
+func rdsTagstoGeneric(rdsTags []*rds.Tag) []*resources.Tag {
+	var genericTags []*resources.Tag
 	for _, rdsTag := range rdsTags {
-		genericTags = append(genericTags, &tag{key: aws.StringValue(rdsTag.Key), value: aws.StringValue(rdsTag.Value)})
+		genericTags = append(genericTags, &resources.Tag{Key: aws.StringValue(rdsTag.Key), Value: aws.StringValue(rdsTag.Value)})
 	}
 	return genericTags
 }
 
-func genericToEc2Tags(tags []*tag) []*ec2.Tag {
+func genericToEc2Tags(tags []*resources.Tag) []*ec2.Tag {
 	var ec2Tags []*ec2.Tag
 	for _, tag := range tags {
 		ec2Tags = append(ec2Tags, genericToEc2Tag(tag))
 	}
 	return ec2Tags
-}
-
-// this function merges generalTags and infraTags, where any duplicate key in
-// infraTags is discarded in favour of the value in infraTags
-func mergeTags(generalTags []*tag, infraTags []*tag) []*tag {
-	var dupMap = make(map[string]bool)
-	for _, tag := range generalTags {
-		dupMap[tag.key] = true
-	}
-	for _, tag := range infraTags {
-		if _, exists := dupMap[tag.key]; !exists {
-			generalTags = append(generalTags, tag)
-		}
-	}
-	return generalTags
-}
-
-func tagsContains(tags []*tag, key, value string) bool {
-	for _, tag := range tags {
-		if tag.key == key && tag.value == value {
-			return true
-		}
-	}
-	return false
-}
-
-// Checks whether all tags in first parameter are contained within second parameter
-func tagsContainsAll(as []*tag, bs []*tag) bool {
-	for _, a := range as {
-		found := false
-		for _, b := range bs {
-			if a.Equal(b) {
-				found = true
-			}
-		}
-		if !found {
-			return false
-		}
-	}
-	return true
-}
-
-func getDefaultResourceTags(ctx context.Context, c client.Client, specType string, name string, prodName string) ([]*tag, string, error) {
-	// set the tag values that will always be added
-	defaultOrganizationTag := resources.GetOrganizationTag()
-	clusterID, err := resources.GetClusterID(ctx, c)
-	if err != nil {
-		msg := "Failed to get cluster id"
-		return nil, "", errorUtil.Wrapf(err, msg)
-	}
-	tags := []*tag{
-		{
-			key:   defaultOrganizationTag + "clusterID",
-			value: clusterID,
-		},
-		{
-			key:   defaultOrganizationTag + "resource-type",
-			value: specType,
-		},
-		{
-			key:   defaultOrganizationTag + "resource-name",
-			value: name,
-		},
-		buildManagedTag(),
-	}
-
-	if prodName != "" {
-		productTag := &tag{
-			key:   defaultOrganizationTag + "product-name",
-			value: prodName,
-		}
-		tags = append(tags, productTag)
-	}
-
-	infraTags, err := getUserInfraTags(ctx, c)
-	if err != nil {
-		msg := "Failed to get user infrastructure tags"
-		return nil, "", errorUtil.Wrapf(err, msg)
-	}
-	if infraTags != nil {
-		// merge tags into single array, where any duplicate
-		// values in infra are overwritten by the default tags
-		tags = mergeTags(infraTags, tags)
-	}
-
-	return tags, clusterID, nil
-}
-
-func getUserInfraTags(ctx context.Context, c client.Client) ([]*tag, error) {
-	// get infra CR
-	infra, err := resources.GetClusterInfrastructure(ctx, c)
-	if err != nil {
-		msg := "failed to get cluster infrastructure"
-		return nil, errorUtil.Wrapf(err, msg)
-	}
-
-	var tags []*tag
-	// retrieve all user infrastructure tags
-	if infra.Status.PlatformStatus != nil && infra.Status.PlatformStatus.AWS != nil {
-		for _, t := range infra.Status.PlatformStatus.AWS.ResourceTags {
-			tags = append(tags, &tag{key: t.Key, value: t.Value})
-		}
-	}
-	return tags, nil
-}
-
-func buildManagedTag() *tag {
-	return &tag{
-		key:   tagManagedKey,
-		value: tagManagedVal,
-	}
 }

--- a/pkg/providers/aws/tags_test.go
+++ b/pkg/providers/aws/tags_test.go
@@ -1,13 +1,8 @@
 package aws
 
 import (
-	"context"
-	configv1 "github.com/integr8ly/cloud-resource-operator/apis/config/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
 	"reflect"
-	controllerruntime "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -23,7 +18,7 @@ func Test_ec2TagsToGeneric(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want []*tag
+		want []*resources.Tag
 	}{
 		{
 			name: "test convert format",
@@ -35,10 +30,10 @@ func Test_ec2TagsToGeneric(t *testing.T) {
 					},
 				},
 			},
-			want: []*tag{
+			want: []*resources.Tag{
 				{
-					key:   "testKey",
-					value: "testVal",
+					Key:   "testKey",
+					Value: "testVal",
 				},
 			},
 		},
@@ -54,12 +49,12 @@ func Test_ec2TagsToGeneric(t *testing.T) {
 					},
 				},
 			},
-			want: []*tag{
+			want: []*resources.Tag{
 				{
-					value: "testVal",
+					Value: "testVal",
 				},
 				{
-					key: "testKey",
+					Key: "testKey",
 				},
 			},
 		},
@@ -80,7 +75,7 @@ func Test_rdsTagsToGeneric(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want []*tag
+		want []*resources.Tag
 	}{
 		{
 			name: "test convert format",
@@ -92,10 +87,10 @@ func Test_rdsTagsToGeneric(t *testing.T) {
 					},
 				},
 			},
-			want: []*tag{
+			want: []*resources.Tag{
 				{
-					key:   "testKey",
-					value: "testVal",
+					Key:   "testKey",
+					Value: "testVal",
 				},
 			},
 		},
@@ -111,12 +106,12 @@ func Test_rdsTagsToGeneric(t *testing.T) {
 					},
 				},
 			},
-			want: []*tag{
+			want: []*resources.Tag{
 				{
-					value: "testVal",
+					Value: "testVal",
 				},
 				{
-					key: "testKey",
+					Key: "testKey",
 				},
 			},
 		},
@@ -132,7 +127,7 @@ func Test_rdsTagsToGeneric(t *testing.T) {
 
 func Test_genericToEc2Tags(t *testing.T) {
 	type args struct {
-		tags []*tag
+		tags []*resources.Tag
 	}
 	tests := []struct {
 		name string
@@ -142,10 +137,10 @@ func Test_genericToEc2Tags(t *testing.T) {
 		{
 			name: "test convert format",
 			args: args{
-				tags: []*tag{
+				tags: []*resources.Tag{
 					{
-						key:   "testKey",
-						value: "testVal",
+						Key:   "testKey",
+						Value: "testVal",
 					},
 				},
 			},
@@ -159,12 +154,12 @@ func Test_genericToEc2Tags(t *testing.T) {
 		{
 			name: "test missing keys or values",
 			args: args{
-				tags: []*tag{
+				tags: []*resources.Tag{
 					{
-						value: "testVal",
+						Value: "testVal",
 					},
 					{
-						key: "testKey",
+						Key: "testKey",
 					},
 				},
 			},
@@ -191,7 +186,7 @@ func Test_genericToEc2Tags(t *testing.T) {
 
 func Test_genericToRdsTags(t *testing.T) {
 	type args struct {
-		tags []*tag
+		tags []*resources.Tag
 	}
 	tests := []struct {
 		name string
@@ -201,10 +196,10 @@ func Test_genericToRdsTags(t *testing.T) {
 		{
 			name: "test convert format",
 			args: args{
-				tags: []*tag{
+				tags: []*resources.Tag{
 					{
-						key:   "testKey",
-						value: "testVal",
+						Key:   "testKey",
+						Value: "testVal",
 					},
 				},
 			},
@@ -218,12 +213,12 @@ func Test_genericToRdsTags(t *testing.T) {
 		{
 			name: "test missing keys or values",
 			args: args{
-				tags: []*tag{
+				tags: []*resources.Tag{
 					{
-						value: "testVal",
+						Value: "testVal",
 					},
 					{
-						key: "testKey",
+						Key: "testKey",
 					},
 				},
 			},
@@ -250,7 +245,7 @@ func Test_genericToRdsTags(t *testing.T) {
 
 func Test_genericToElasticacheTags(t *testing.T) {
 	type args struct {
-		tags []*tag
+		tags []*resources.Tag
 	}
 	tests := []struct {
 		name string
@@ -260,10 +255,10 @@ func Test_genericToElasticacheTags(t *testing.T) {
 		{
 			name: "test convert format",
 			args: args{
-				tags: []*tag{
+				tags: []*resources.Tag{
 					{
-						key:   "testKey",
-						value: "testVal",
+						Key:   "testKey",
+						Value: "testVal",
 					},
 				},
 			},
@@ -277,12 +272,12 @@ func Test_genericToElasticacheTags(t *testing.T) {
 		{
 			name: "test missing keys or values",
 			args: args{
-				tags: []*tag{
+				tags: []*resources.Tag{
 					{
-						value: "testVal",
+						Value: "testVal",
 					},
 					{
-						key: "testKey",
+						Key: "testKey",
 					},
 				},
 			},
@@ -302,443 +297,6 @@ func Test_genericToElasticacheTags(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := genericToElasticacheTags(tt.args.tags); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("genericToElasticacheTags() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_tagsContains(t *testing.T) {
-	type args struct {
-		tags  []*tag
-		key   string
-		value string
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{
-			name: "test success",
-			args: args{
-				tags: []*tag{
-					{
-						key:   "testKey",
-						value: "testVal",
-					},
-				},
-				key:   "testKey",
-				value: "testVal",
-			},
-			want: true,
-		},
-		{
-			name: "test failure",
-			args: args{
-				tags: []*tag{
-					{
-						key:   "testKey",
-						value: "testVal",
-					},
-				},
-				key:   "testKey",
-				value: "testVal2",
-			},
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tagsContains(tt.args.tags, tt.args.key, tt.args.value); got != tt.want {
-				t.Errorf("tagsContains() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_mergeTags(t *testing.T) {
-	type args struct {
-		tags1 []*tag
-		tags2 []*tag
-	}
-	tests := []struct {
-		name string
-		args args
-		want []*tag
-	}{
-		{
-			name: "test success",
-			args: args{
-				tags1: []*tag{
-					{
-						key:   "testKey",
-						value: "testVal",
-					},
-				},
-				tags2: []*tag{
-					{
-						key:   "testKey2",
-						value: "testVal2",
-					},
-				},
-			},
-			want: []*tag{
-				{
-					key:   "testKey",
-					value: "testVal",
-				},
-				{
-					key:   "testKey2",
-					value: "testVal2",
-				},
-			},
-		},
-		{
-			name: "test duplicate tag retrieves first value",
-			args: args{
-				tags1: []*tag{
-					{
-						key:   "testKey",
-						value: "testVal",
-					},
-				},
-				tags2: []*tag{
-					{
-						key:   "testKey",
-						value: "testVal2",
-					},
-					{
-						key:   "testKey3",
-						value: "testVal3",
-					},
-				},
-			},
-			want: []*tag{
-				{
-					key:   "testKey",
-					value: "testVal",
-				},
-				{
-					key:   "testKey3",
-					value: "testVal3",
-				},
-			},
-		},
-		{
-			name: "test empty first array",
-			args: args{
-				tags1: []*tag{},
-				tags2: []*tag{
-					{
-						key:   "testKey",
-						value: "testVal",
-					},
-				},
-			},
-			want: []*tag{
-				{
-					key:   "testKey",
-					value: "testVal",
-				},
-			},
-		},
-		{
-			name: "test empty second array",
-			args: args{
-				tags1: []*tag{
-					{
-						key:   "testKey",
-						value: "testVal",
-					},
-				},
-				tags2: []*tag{},
-			},
-			want: []*tag{
-				{
-					key:   "testKey",
-					value: "testVal",
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := mergeTags(tt.args.tags1, tt.args.tags2)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("mergeTags() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_tagsContainsAll(t *testing.T) {
-	type args struct {
-		tags1 []*tag
-		tags2 []*tag
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{
-			name: "test success",
-			args: args{
-				tags1: []*tag{
-					{
-						key:   "testKey",
-						value: "testVal",
-					},
-				},
-				tags2: []*tag{
-					{
-						key:   "testKey",
-						value: "testVal",
-					},
-				},
-			},
-			want: true,
-		},
-		{
-			name: "test success - different size",
-			args: args{
-				tags1: []*tag{
-					{
-						key:   "testKey",
-						value: "testVal",
-					},
-				},
-				tags2: []*tag{
-					{
-						key:   "testKey",
-						value: "testVal",
-					},
-					{
-						key:   "testKey2",
-						value: "testVal2",
-					},
-				},
-			},
-			want: true,
-		},
-		{
-			name: "test failure",
-			args: args{
-				tags1: []*tag{
-					{
-						key:   "testKey",
-						value: "testVal",
-					},
-				},
-				tags2: []*tag{
-					{
-						key:   "testKey",
-						value: "testVal2",
-					},
-				},
-			},
-			want: false,
-		},
-		{
-			name: "test failure - different size",
-			args: args{
-				tags1: []*tag{
-					{
-						key:   "testKey",
-						value: "testVal",
-					},
-					{
-						key:   "testKey2",
-						value: "testVal2",
-					},
-				},
-				tags2: []*tag{
-					{
-						key:   "testKey",
-						value: "testVal",
-					},
-				},
-			},
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tagsContainsAll(tt.args.tags1, tt.args.tags2); got != tt.want {
-				t.Errorf("tagsContainsAll() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_getDefaultResourceTags(t *testing.T) {
-	scheme := runtime.NewScheme()
-	err := configv1.AddToScheme(scheme)
-	if err != nil {
-		t.Fatal("failed to build scheme", err)
-	}
-	type args struct {
-		ctx      context.Context
-		client   client.Client
-		specType string
-		name     string
-		prodName string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    []*tag
-		wantErr bool
-	}{
-		{
-			name: "failed to get cluster id",
-			args: args{
-				ctx:      context.TODO(),
-				client:   fake.NewFakeClientWithScheme(scheme),
-				specType: "",
-				name:     "",
-				prodName: "",
-			},
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			name: "successfully retrieved default resource tags",
-			args: args{
-				ctx: context.TODO(),
-				client: fake.NewFakeClientWithScheme(scheme, &configv1.Infrastructure{
-					ObjectMeta: controllerruntime.ObjectMeta{
-						Name: "cluster",
-					},
-					Status: configv1.InfrastructureStatus{
-						InfrastructureName: defaultInfraName,
-						PlatformStatus: &configv1.PlatformStatus{
-							Type: configv1.AWSPlatformType,
-							AWS: &configv1.AWSPlatformStatus{
-								Region: "eu-west-1",
-								ResourceTags: []configv1.AWSResourceTag{
-									{
-										Key:   "test-key",
-										Value: "test-value",
-									},
-								},
-							},
-						},
-					},
-				}),
-				specType: "specType",
-				name:     "name",
-				prodName: "prodName",
-			},
-			want: []*tag{
-				{
-					key:   "test-key",
-					value: "test-value",
-				},
-				{
-					key:   "integreatly.org/clusterID",
-					value: "test",
-				},
-				{
-					key:   "integreatly.org/resource-type",
-					value: "specType",
-				},
-				{
-					key:   "integreatly.org/resource-name",
-					value: "name",
-				},
-				{
-					key:   "red-hat-managed",
-					value: "true",
-				},
-				{
-					key:   "integreatly.org/product-name",
-					value: "prodName",
-				},
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, _, err := getDefaultResourceTags(tt.args.ctx, tt.args.client, tt.args.specType, tt.args.name, tt.args.prodName)
-			if !tt.wantErr && err != nil {
-				t.Errorf("unexpected error in getDefaultResourceTags(): %v", err)
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("expected %v to equal %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_getUserInfraTags(t *testing.T) {
-	scheme := runtime.NewScheme()
-	err := configv1.AddToScheme(scheme)
-	if err != nil {
-		t.Fatal("failed to build scheme", err)
-	}
-	type args struct {
-		ctx    context.Context
-		client client.Client
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    []*tag
-		wantErr bool
-	}{
-		{
-			name: "failed to get cluster infrastructure",
-			args: args{
-				ctx:    context.TODO(),
-				client: fake.NewFakeClientWithScheme(scheme),
-			},
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			name: "successfully retrieved user infra tags",
-			args: args{
-				ctx: context.TODO(),
-				client: fake.NewFakeClientWithScheme(scheme, &configv1.Infrastructure{
-					ObjectMeta: controllerruntime.ObjectMeta{
-						Name: "cluster",
-					},
-					Status: configv1.InfrastructureStatus{
-						InfrastructureName: defaultInfraName,
-						PlatformStatus: &configv1.PlatformStatus{
-							Type: configv1.AWSPlatformType,
-							AWS: &configv1.AWSPlatformStatus{
-								Region: "eu-west-1",
-								ResourceTags: []configv1.AWSResourceTag{
-									{
-										Key:   "test-key",
-										Value: "test-value",
-									},
-								},
-							},
-						},
-					},
-				}),
-			},
-			want: []*tag{
-				{
-					key:   "test-key",
-					value: "test-value",
-				},
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := getUserInfraTags(tt.args.ctx, tt.args.client)
-			if !tt.wantErr && err != nil {
-				t.Errorf("unexpected error in getUserInfraTags(): %v", err)
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("expected %v to equal %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/providers/gcp/cluster_network_provider.go
+++ b/pkg/providers/gcp/cluster_network_provider.go
@@ -5,20 +5,20 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
-	"net/url"
-	"strings"
-
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers"
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers/gcp/gcpiface"
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
 	errorUtil "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/option"
-	servicenetworking "google.golang.org/api/servicenetworking/v1"
+	"google.golang.org/api/servicenetworking/v1"
 	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 	utils "k8s.io/utils/pointer"
+	"net"
+	"net/url"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+	"time"
 )
 
 const (
@@ -60,7 +60,7 @@ type CreateVpcInput struct {
 	CidrBlock string
 }
 
-// initialises the four required clients
+// NewNetworkManager initialises all required clients
 func NewNetworkManager(ctx context.Context, projectID string, opt option.ClientOption, client client.Client, logger *logrus.Entry) (*NetworkProvider, error) {
 	networksApi, err := gcpiface.NewNetworksAPI(ctx, opt)
 	if err != nil {
@@ -120,16 +120,45 @@ func (n *NetworkProvider) CreateNetworkIpRange(ctx context.Context, cidrRange *n
 		if err != nil {
 			return nil, errorUtil.Wrap(err, "failed to create ip address range")
 		}
-		// check if address exists
-		address, err = n.getAddressRange(ctx, ipRangeName)
-		if err != nil {
+		if address, err = n.waitForAddress(ctx, ipRangeName); err != nil {
 			return nil, errorUtil.Wrap(err, "failed to retrieve ip address range")
 		}
 	}
 	return address, nil
 }
 
-// Creates the network service connection and will return the service if it has been created successfully
+func (n *NetworkProvider) waitForAddress(ctx context.Context, ipRangeName string) (*computepb.Address, error) {
+	addressChan := make(chan *computepb.Address, 1)
+	errorChan := make(chan error, 1)
+	defer close(addressChan)
+	defer close(errorChan)
+	go func() {
+		for {
+			address, err := n.getAddressRange(ctx, ipRangeName)
+			if err != nil {
+				errorChan <- err
+				break
+			}
+			if address != nil {
+				addressChan <- address
+				break
+			}
+			time.Sleep(time.Second * 3)
+		}
+
+	}()
+	select {
+	case address := <-addressChan:
+		n.Logger.Infof("created ip address range %s: %s/%d", address.GetName(), address.GetAddress(), address.GetPrefixLength())
+		return address, nil
+	case err := <-errorChan:
+		return nil, err
+	case <-time.After(time.Minute):
+		return nil, fmt.Errorf("waitForAddress() timed out")
+	}
+}
+
+// CreateNetworkService Creates the network service connection and will return the service if it has been created successfully
 // This automatically creates a peering connection to the clusterVpc named after the service connection
 func (n *NetworkProvider) CreateNetworkService(ctx context.Context) (*servicenetworking.Connection, error) {
 	clusterVpc, err := getClusterVpc(ctx, n.Client, n.NetworkApi, n.ProjectID, n.Logger)
@@ -161,9 +190,7 @@ func (n *NetworkProvider) CreateNetworkService(ctx context.Context) (*servicenet
 			if err != nil {
 				return nil, errorUtil.Wrap(err, "failed to create service connection")
 			}
-			// check if service exists
-			service, err = n.getServiceConnection(clusterVpc)
-			if err != nil {
+			if service, err = n.waitForConnection(clusterVpc); err != nil {
 				return nil, errorUtil.Wrap(err, "failed to retrieve service connection")
 			}
 		}
@@ -171,7 +198,38 @@ func (n *NetworkProvider) CreateNetworkService(ctx context.Context) (*servicenet
 	return service, nil
 }
 
-// Removes the peering connection from the cluster vpc
+func (n *NetworkProvider) waitForConnection(clusterVpc *computepb.Network) (*servicenetworking.Connection, error) {
+	connectionChan := make(chan *servicenetworking.Connection, 1)
+	errorChan := make(chan error, 1)
+	defer close(connectionChan)
+	defer close(errorChan)
+	go func() {
+		for {
+			connection, err := n.getServiceConnection(clusterVpc)
+			if err != nil {
+				errorChan <- err
+				break
+			}
+			if connection != nil {
+				connectionChan <- connection
+				break
+			}
+			time.Sleep(time.Second * 3)
+		}
+
+	}()
+	select {
+	case connection := <-connectionChan:
+		n.Logger.Infof("created network service connection %s", connection.Service)
+		return connection, nil
+	case err := <-errorChan:
+		return nil, err
+	case <-time.After(time.Minute):
+		return nil, fmt.Errorf("waitForConnection() timed out")
+	}
+}
+
+// DeleteNetworkPeering Removes the peering connection from the cluster vpc
 // The service connection removal can get stuck if this is not performed first
 func (n *NetworkProvider) DeleteNetworkPeering(ctx context.Context) error {
 	clusterVpc, err := getClusterVpc(ctx, n.Client, n.NetworkApi, n.ProjectID, n.Logger)
@@ -189,7 +247,7 @@ func (n *NetworkProvider) DeleteNetworkPeering(ctx context.Context) error {
 	return nil
 }
 
-// This deletes the network service connection, but can get stuck if peering
+// DeleteNetworkService This deletes the network service connection, but can get stuck if peering
 // has not been removed
 func (n *NetworkProvider) DeleteNetworkService(ctx context.Context) error {
 	clusterVpc, err := getClusterVpc(ctx, n.Client, n.NetworkApi, n.ProjectID, n.Logger)

--- a/pkg/providers/gcp/cluster_network_provider.go
+++ b/pkg/providers/gcp/cluster_network_provider.go
@@ -44,7 +44,10 @@ type NetworkManager interface {
 	ReconcileNetworkProviderConfig(ctx context.Context, configManager ConfigManager, tier string) (*net.IPNet, error)
 }
 
-var _ NetworkManager = (*NetworkProvider)(nil)
+var (
+	_              NetworkManager = (*NetworkProvider)(nil)
+	defaultTimeout                = time.Minute
+)
 
 type NetworkProvider struct {
 	Client      client.Client
@@ -153,7 +156,7 @@ func (n *NetworkProvider) waitForAddress(ctx context.Context, ipRangeName string
 		return address, nil
 	case err := <-errorChan:
 		return nil, err
-	case <-time.After(time.Minute):
+	case <-time.After(defaultTimeout):
 		return nil, fmt.Errorf("waitForAddress() timed out")
 	}
 }
@@ -224,7 +227,7 @@ func (n *NetworkProvider) waitForConnection(clusterVpc *computepb.Network) (*ser
 		return connection, nil
 	case err := <-errorChan:
 		return nil, err
-	case <-time.After(time.Minute):
+	case <-time.After(defaultTimeout):
 		return nil, fmt.Errorf("waitForConnection() timed out")
 	}
 }

--- a/pkg/providers/gcp/cluster_network_provider_test.go
+++ b/pkg/providers/gcp/cluster_network_provider_test.go
@@ -275,29 +275,6 @@ func TestNetworkProvider_CreateNetworkIpRange(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "create ip range in progress",
-			fields: fields{
-				Client: moqClient.NewSigsClientMoqWithScheme(scheme, buildTestGcpInfrastructure(nil)),
-				NetworkApi: gcpiface.GetMockNetworksClient(func(networksClient *gcpiface.MockNetworksClient) {
-					networksClient.ListFn = buildValidGcpListNetworks
-				}),
-				SubnetsApi: gcpiface.GetMockSubnetsClient(func(subnetClient *gcpiface.MockSubnetsClient) {
-					subnetClient.GetFn = func(req *computepb.GetSubnetworkRequest) (*computepb.Subnetwork, error) {
-						return buildValidSubnet(req.Subnetwork, gcpTestMasterSubnetCidr), nil
-					}
-					subnetClient.GetFnTwo = func(req *computepb.GetSubnetworkRequest) (*computepb.Subnetwork, error) {
-						return buildValidSubnet(req.Subnetwork, gcpTestWorkerSubnetCidr), nil
-					}
-				}),
-				AddressApi: gcpiface.GetMockAddressClient(nil),
-			},
-			args: args{
-				ipRangeCidr: buildIpRangeCidr(gcpTestValidCidr),
-			},
-			want:    nil,
-			wantErr: false,
-		},
-		{
 			name: "create ip range exists",
 			fields: fields{
 				Client: moqClient.NewSigsClientMoqWithScheme(scheme, buildTestGcpInfrastructure(nil)),
@@ -612,23 +589,6 @@ func TestNetworkProvider_CreateNetworkService(t *testing.T) {
 				ProjectID: gcpTestProjectId,
 			},
 			want:    buildValidConnection(gcpTestNetworkName, gcpTestProjectId, fmt.Sprintf(defaultServicesFormat, defaultServiceConnectionURI)),
-			wantErr: false,
-		},
-		{
-			name: "create service network in progress",
-			fields: fields{
-				Client: moqClient.NewSigsClientMoqWithScheme(scheme, buildTestGcpInfrastructure(nil)),
-				NetworkApi: gcpiface.GetMockNetworksClient(func(networksClient *gcpiface.MockNetworksClient) {
-					networksClient.ListFn = buildValidGcpListNetworks
-				}),
-				AddressApi: gcpiface.GetMockAddressClient(func(addressClient *gcpiface.MockAddressClient) {
-					addressClient.GetFn = func(req *computepb.GetGlobalAddressRequest) (*computepb.Address, error) {
-						return buildValidGcpAddressRange(gcpTestIpRangeName), nil
-					}
-				}),
-				ServicesApi: gcpiface.GetMockServicesClient(nil),
-			},
-			want:    nil,
 			wantErr: false,
 		},
 		{

--- a/pkg/providers/gcp/gcpiface/redis_api.go
+++ b/pkg/providers/gcp/gcpiface/redis_api.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"github.com/googleapis/gax-go/v2"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	redispb "google.golang.org/genproto/googleapis/cloud/redis/v1"
@@ -15,24 +16,29 @@ type RedisAPI interface {
 	DeleteInstance(context.Context, *redispb.DeleteInstanceRequest, ...gax.CallOption) (*redis.DeleteInstanceOperation, error)
 	CreateInstance(context.Context, *redispb.CreateInstanceRequest, ...gax.CallOption) (*redis.CreateInstanceOperation, error)
 	GetInstance(context.Context, *redispb.GetInstanceRequest, ...gax.CallOption) (*redispb.Instance, error)
+	UpdateInstance(context.Context, *redispb.UpdateInstanceRequest, ...gax.CallOption) (*redis.UpdateInstanceOperation, error)
+	UpgradeInstance(context.Context, *redispb.UpgradeInstanceRequest, ...gax.CallOption) (*redis.UpgradeInstanceOperation, error)
 }
 
 type redisClient struct {
 	RedisAPI
 	redisService *redis.CloudRedisClient
+	logger       *logrus.Entry
 }
 
-func NewRedisAPI(ctx context.Context, opt option.ClientOption) (RedisAPI, error) {
+func NewRedisAPI(ctx context.Context, opt option.ClientOption, logger *logrus.Entry) (RedisAPI, error) {
 	cloudRedisClient, err := redis.NewCloudRedisClient(ctx, opt)
 	if err != nil {
 		return nil, err
 	}
 	return &redisClient{
 		redisService: cloudRedisClient,
+		logger:       logger,
 	}, nil
 }
 
 func (c *redisClient) ListInstances(ctx context.Context, req *redispb.ListInstancesRequest, opts ...gax.CallOption) ([]*redispb.Instance, error) {
+	c.logger.Info("fetching all gcp redis instances")
 	redisIterator := c.redisService.ListInstances(ctx, req, opts...)
 	var instances []*redispb.Instance
 	for {
@@ -45,27 +51,47 @@ func (c *redisClient) ListInstances(ctx context.Context, req *redispb.ListInstan
 		}
 		instances = append(instances, instance)
 	}
+	c.logger.Infof("found %d gcp redis instances", len(instances))
 	return instances, nil
 }
 
 func (c *redisClient) DeleteInstance(ctx context.Context, req *redispb.DeleteInstanceRequest, opts ...gax.CallOption) (*redis.DeleteInstanceOperation, error) {
+	c.logger.Infof("deleting gcp redis instance %s", req.Name)
 	return c.redisService.DeleteInstance(ctx, req, opts...)
 }
 
 func (c *redisClient) CreateInstance(ctx context.Context, req *redispb.CreateInstanceRequest, opts ...gax.CallOption) (*redis.CreateInstanceOperation, error) {
+	c.logger.Infof("creating gcp redis instance %s", req.Instance.Name)
 	return c.redisService.CreateInstance(ctx, req, opts...)
 }
 
 func (c *redisClient) GetInstance(ctx context.Context, req *redispb.GetInstanceRequest, opts ...gax.CallOption) (*redispb.Instance, error) {
-	return c.redisService.GetInstance(ctx, req, opts...)
+	c.logger.Infof("fetching gcp redis instance %s", req.Name)
+	instance, err := c.redisService.GetInstance(ctx, req, opts...)
+	if instance != nil {
+		c.logger.Infof("found gcp redis instance %s", req.Name)
+	}
+	return instance, err
+}
+
+func (c *redisClient) UpdateInstance(ctx context.Context, req *redispb.UpdateInstanceRequest, opts ...gax.CallOption) (*redis.UpdateInstanceOperation, error) {
+	c.logger.Infof("updating gcp redis instance %s", req.Instance.Name)
+	return c.redisService.UpdateInstance(ctx, req, opts...)
+}
+
+func (c *redisClient) UpgradeInstance(ctx context.Context, req *redispb.UpgradeInstanceRequest, opts ...gax.CallOption) (*redis.UpgradeInstanceOperation, error) {
+	c.logger.Infof("upgrading gcp redis instance %s", req.Name)
+	return c.redisService.UpgradeInstance(ctx, req, opts...)
 }
 
 type MockRedisClient struct {
 	RedisAPI
-	ListInstancesFn  func(context.Context, *redispb.ListInstancesRequest, ...gax.CallOption) ([]*redispb.Instance, error)
-	DeleteInstanceFn func(context.Context, *redispb.DeleteInstanceRequest, ...gax.CallOption) (*redis.DeleteInstanceOperation, error)
-	CreateInstanceFn func(context.Context, *redispb.CreateInstanceRequest, ...gax.CallOption) (*redis.CreateInstanceOperation, error)
-	GetInstanceFn    func(context.Context, *redispb.GetInstanceRequest, ...gax.CallOption) (*redispb.Instance, error)
+	ListInstancesFn   func(context.Context, *redispb.ListInstancesRequest, ...gax.CallOption) ([]*redispb.Instance, error)
+	DeleteInstanceFn  func(context.Context, *redispb.DeleteInstanceRequest, ...gax.CallOption) (*redis.DeleteInstanceOperation, error)
+	CreateInstanceFn  func(context.Context, *redispb.CreateInstanceRequest, ...gax.CallOption) (*redis.CreateInstanceOperation, error)
+	GetInstanceFn     func(context.Context, *redispb.GetInstanceRequest, ...gax.CallOption) (*redispb.Instance, error)
+	UpdateInstanceFn  func(context.Context, *redispb.UpdateInstanceRequest, ...gax.CallOption) (*redis.UpdateInstanceOperation, error)
+	UpgradeInstanceFn func(context.Context, *redispb.UpgradeInstanceRequest, ...gax.CallOption) (*redis.UpgradeInstanceOperation, error)
 }
 
 func GetMockRedisClient(modifyFn func(redisClient *MockRedisClient)) *MockRedisClient {
@@ -79,8 +105,14 @@ func GetMockRedisClient(modifyFn func(redisClient *MockRedisClient)) *MockRedisC
 		CreateInstanceFn: func(ctx context.Context, request *redispb.CreateInstanceRequest, opts ...gax.CallOption) (*redis.CreateInstanceOperation, error) {
 			return &redis.CreateInstanceOperation{}, nil
 		},
-		GetInstanceFn: func(ctx context.Context, request *redispb.GetInstanceRequest, callOption ...gax.CallOption) (*redispb.Instance, error) {
+		GetInstanceFn: func(ctx context.Context, request *redispb.GetInstanceRequest, opts ...gax.CallOption) (*redispb.Instance, error) {
 			return &redispb.Instance{}, nil
+		},
+		UpdateInstanceFn: func(ctx context.Context, request *redispb.UpdateInstanceRequest, opts ...gax.CallOption) (*redis.UpdateInstanceOperation, error) {
+			return &redis.UpdateInstanceOperation{}, nil
+		},
+		UpgradeInstanceFn: func(ctx context.Context, request *redispb.UpgradeInstanceRequest, opts ...gax.CallOption) (*redis.UpgradeInstanceOperation, error) {
+			return &redis.UpgradeInstanceOperation{}, nil
 		},
 	}
 	if modifyFn != nil {
@@ -115,4 +147,18 @@ func (m *MockRedisClient) GetInstance(ctx context.Context, req *redispb.GetInsta
 		return m.GetInstanceFn(ctx, req, opts...)
 	}
 	return &redispb.Instance{}, nil
+}
+
+func (m *MockRedisClient) UpdateInstance(ctx context.Context, req *redispb.UpdateInstanceRequest, opts ...gax.CallOption) (*redis.UpdateInstanceOperation, error) {
+	if m.UpdateInstanceFn != nil {
+		return m.UpdateInstanceFn(ctx, req, opts...)
+	}
+	return &redis.UpdateInstanceOperation{}, nil
+}
+
+func (m *MockRedisClient) UpgradeInstance(ctx context.Context, req *redispb.UpgradeInstanceRequest, opts ...gax.CallOption) (*redis.UpgradeInstanceOperation, error) {
+	if m.UpgradeInstanceFn != nil {
+		return m.UpgradeInstanceFn(ctx, req, opts...)
+	}
+	return &redis.UpgradeInstanceOperation{}, nil
 }

--- a/pkg/providers/gcp/provider_redis.go
+++ b/pkg/providers/gcp/provider_redis.go
@@ -322,6 +322,10 @@ func (p *RedisProvider) buildCreateInstanceRequest(ctx context.Context, r *v1alp
 		}
 		createInstanceRequest.InstanceId = instanceID
 	}
+	tags, err := buildDefaultRedisTags(ctx, p.Client, r, createInstanceRequest)
+	if err != nil {
+		return nil, errorUtil.Wrap(err, "failed to build gcp redis instance tags")
+	}
 	defaultInstance := &redispb.Instance{
 		Name:              fmt.Sprintf(redisInstanceNameFormat, strategyConfig.ProjectID, strategyConfig.Region, createInstanceRequest.InstanceId),
 		Tier:              redispb.Instance_STANDARD_HA,
@@ -331,6 +335,7 @@ func (p *RedisProvider) buildCreateInstanceRequest(ctx context.Context, r *v1alp
 		ConnectMode:       redispb.Instance_PRIVATE_SERVICE_ACCESS,
 		ReservedIpRange:   address.GetName(),
 		RedisVersion:      redisVersion,
+		Labels:            tags,
 	}
 	if createInstanceRequest.Instance == nil {
 		createInstanceRequest.Instance = defaultInstance

--- a/pkg/providers/gcp/provider_redis.go
+++ b/pkg/providers/gcp/provider_redis.go
@@ -322,7 +322,7 @@ func (p *RedisProvider) buildCreateInstanceRequest(ctx context.Context, r *v1alp
 		}
 		createInstanceRequest.InstanceId = instanceID
 	}
-	tags, err := buildDefaultRedisTags(ctx, p.Client, r, createInstanceRequest)
+	tags, err := buildDefaultRedisTags(ctx, p.Client, r)
 	if err != nil {
 		return nil, errorUtil.Wrap(err, "failed to build gcp redis instance tags")
 	}
@@ -340,6 +340,12 @@ func (p *RedisProvider) buildCreateInstanceRequest(ctx context.Context, r *v1alp
 	if createInstanceRequest.Instance == nil {
 		createInstanceRequest.Instance = defaultInstance
 		return createInstanceRequest, nil
+	}
+	if createInstanceRequest.Instance.Labels == nil {
+		createInstanceRequest.Instance.Labels = map[string]string{}
+	}
+	for key, value := range tags {
+		createInstanceRequest.Instance.Labels[key] = value
 	}
 	if createInstanceRequest.Instance.Name == "" {
 		createInstanceRequest.Instance.Name = defaultInstance.Name

--- a/pkg/providers/gcp/provider_redis_test.go
+++ b/pkg/providers/gcp/provider_redis_test.go
@@ -1047,9 +1047,9 @@ func TestRedisProvider_buildCreateInstanceRequest(t *testing.T) {
 		ReservedIpRange:   gcpTestIpRangeName,
 		RedisVersion:      redisVersion,
 		Labels: map[string]string{
-			"integreatly.org/clusterID":     gcpTestClusterName,
-			"integreatly.org/resource-name": testName,
-			"integreatly.org/resource-type": "",
+			"integreatly-org_clusterid":     gcpTestClusterName,
+			"integreatly-org_resource-name": "testname",
+			"integreatly-org_resource-type": "",
 			"red-hat-managed":               "true",
 		},
 	}

--- a/pkg/providers/gcp/tags.go
+++ b/pkg/providers/gcp/tags.go
@@ -5,11 +5,10 @@ import (
 	"github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
 	errorUtil "github.com/pkg/errors"
-	redispb "google.golang.org/genproto/googleapis/cloud/redis/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func buildDefaultRedisTags(ctx context.Context, client k8sclient.Client, r *v1alpha1.Redis, createInstanceRequest *redispb.CreateInstanceRequest) (map[string]string, error) {
+func buildDefaultRedisTags(ctx context.Context, client k8sclient.Client, r *v1alpha1.Redis) (map[string]string, error) {
 	defaultTags, _, err := resources.GetDefaultResourceTags(ctx, client, r.Spec.Type, r.Name, r.ObjectMeta.Labels["productName"])
 	if err != nil {
 		return nil, errorUtil.Wrapf(err, "failed to get default redis tags")

--- a/pkg/providers/gcp/tags.go
+++ b/pkg/providers/gcp/tags.go
@@ -1,0 +1,22 @@
+package gcp
+
+import (
+	"context"
+	"github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
+	errorUtil "github.com/pkg/errors"
+	redispb "google.golang.org/genproto/googleapis/cloud/redis/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func buildDefaultRedisTags(ctx context.Context, client k8sclient.Client, r *v1alpha1.Redis, createInstanceRequest *redispb.CreateInstanceRequest) (map[string]string, error) {
+	defaultTags, _, err := resources.GetDefaultResourceTags(ctx, client, r.Spec.Type, r.Name, r.ObjectMeta.Labels["productName"])
+	if err != nil {
+		return nil, errorUtil.Wrapf(err, "failed to get default redis tags")
+	}
+	tags := make(map[string]string, len(defaultTags))
+	for _, tag := range defaultTags {
+		tags[tag.Key] = tag.Value
+	}
+	return tags, nil
+}

--- a/pkg/providers/gcp/tags_test.go
+++ b/pkg/providers/gcp/tags_test.go
@@ -41,9 +41,9 @@ func Test_buildDefaultRedisTags(t *testing.T) {
 				},
 			},
 			want: map[string]string{
-				"integreatly.org/clusterID":     gcpTestClusterName,
-				"integreatly.org/resource-name": testName,
-				"integreatly.org/resource-type": "testType",
+				"integreatly-org_clusterid":     gcpTestClusterName,
+				"integreatly-org_resource-name": "testname",
+				"integreatly-org_resource-type": "testtype",
 				resources.TagManagedKey:         "true",
 			},
 			wantErr: false,

--- a/pkg/providers/gcp/tags_test.go
+++ b/pkg/providers/gcp/tags_test.go
@@ -1,0 +1,80 @@
+package gcp
+
+import (
+	"context"
+	"github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1/types"
+	moqClient "github.com/integr8ly/cloud-resource-operator/pkg/client/fake"
+	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+)
+
+func Test_buildDefaultRedisTags(t *testing.T) {
+	scheme, err := buildTestScheme()
+	if err != nil {
+		t.Fatal("failed to build scheme", err)
+	}
+	type args struct {
+		client client.Client
+		r      *v1alpha1.Redis
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "success building default redis tags",
+			args: args{
+				client: moqClient.NewSigsClientMoqWithScheme(scheme, buildTestGcpInfrastructure(nil)),
+				r: &v1alpha1.Redis{
+					ObjectMeta: v1.ObjectMeta{
+						Name: testName,
+					},
+					Spec: types.ResourceTypeSpec{
+						Type: "testType",
+					},
+				},
+			},
+			want: map[string]string{
+				"integreatly.org/clusterID":     gcpTestClusterName,
+				"integreatly.org/resource-name": testName,
+				"integreatly.org/resource-type": "testType",
+				resources.TagManagedKey:         "true",
+			},
+			wantErr: false,
+		},
+		{
+			name: "failure building default redis tags",
+			args: args{
+				client: moqClient.NewSigsClientMoqWithScheme(scheme),
+				r: &v1alpha1.Redis{
+					ObjectMeta: v1.ObjectMeta{
+						Name: testName,
+					},
+					Spec: types.ResourceTypeSpec{
+						Type: "testType",
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildDefaultRedisTags(context.TODO(), tt.args.client, tt.args.r)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildDefaultRedisTags() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildDefaultRedisTags() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/resources/tags.go
+++ b/pkg/resources/tags.go
@@ -1,0 +1,135 @@
+package resources
+
+import (
+	"context"
+	errorUtil "github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	TagDisplayName = "Name"
+
+	TagManagedKey = "red-hat-managed"
+	TagManagedVal = "true"
+)
+
+// generic key-value tag
+type Tag struct {
+	Key   string
+	Value string
+}
+
+func (a *Tag) Equal(b *Tag) bool {
+	return a.Key == b.Key && a.Value == b.Value
+}
+
+// MergeTags merges generalTags and infraTags, where any duplicate key in
+// infraTags is discarded in favour of the value in infraTags
+func MergeTags(generalTags []*Tag, infraTags []*Tag) []*Tag {
+	var dupMap = make(map[string]bool)
+	for _, tag := range generalTags {
+		dupMap[tag.Key] = true
+	}
+	for _, tag := range infraTags {
+		if _, exists := dupMap[tag.Key]; !exists {
+			generalTags = append(generalTags, tag)
+		}
+	}
+	return generalTags
+}
+
+func TagsContains(tags []*Tag, key, value string) bool {
+	for _, tag := range tags {
+		if tag.Key == key && tag.Value == value {
+			return true
+		}
+	}
+	return false
+}
+
+// TagsContainsAll checks whether all tags in first parameter are contained within second parameter
+func TagsContainsAll(as []*Tag, bs []*Tag) bool {
+	for _, a := range as {
+		found := false
+		for _, b := range bs {
+			if a.Equal(b) {
+				found = true
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func GetDefaultResourceTags(ctx context.Context, c client.Client, specType string, name string, prodName string) ([]*Tag, string, error) {
+	// set the tag values that will always be added
+	defaultOrganizationTag := GetOrganizationTag()
+	clusterID, err := GetClusterID(ctx, c)
+	if err != nil {
+		msg := "Failed to get cluster id"
+		return nil, "", errorUtil.Wrapf(err, msg)
+	}
+	tags := []*Tag{
+		{
+			Key:   defaultOrganizationTag + "clusterID",
+			Value: clusterID,
+		},
+		{
+			Key:   defaultOrganizationTag + "resource-type",
+			Value: specType,
+		},
+		{
+			Key:   defaultOrganizationTag + "resource-name",
+			Value: name,
+		},
+		BuildManagedTag(),
+	}
+
+	if prodName != "" {
+		productTag := &Tag{
+			Key:   defaultOrganizationTag + "product-name",
+			Value: prodName,
+		}
+		tags = append(tags, productTag)
+	}
+
+	infraTags, err := GetUserInfraTags(ctx, c)
+	if err != nil {
+		msg := "Failed to get user infrastructure tags"
+		return nil, "", errorUtil.Wrapf(err, msg)
+	}
+	if infraTags != nil {
+		// merge tags into single array, where any duplicate
+		// values in infra are overwritten by the default tags
+		tags = MergeTags(infraTags, tags)
+	}
+
+	return tags, clusterID, nil
+}
+
+func GetUserInfraTags(ctx context.Context, c client.Client) ([]*Tag, error) {
+	// get infra CR
+	infra, err := GetClusterInfrastructure(ctx, c)
+	if err != nil {
+		msg := "failed to get cluster infrastructure"
+		return nil, errorUtil.Wrapf(err, msg)
+	}
+
+	var tags []*Tag
+	// retrieve all user infrastructure tags
+	if infra.Status.PlatformStatus != nil && infra.Status.PlatformStatus.AWS != nil {
+		for _, t := range infra.Status.PlatformStatus.AWS.ResourceTags {
+			tags = append(tags, &Tag{Key: t.Key, Value: t.Value})
+		}
+	}
+	return tags, nil
+}
+
+func BuildManagedTag() *Tag {
+	return &Tag{
+		Key:   TagManagedKey,
+		Value: TagManagedVal,
+	}
+}

--- a/pkg/resources/tags_test.go
+++ b/pkg/resources/tags_test.go
@@ -1,0 +1,449 @@
+package resources
+
+import (
+	"context"
+	configv1 "github.com/integr8ly/cloud-resource-operator/apis/config/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"reflect"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+func Test_tagsContains(t *testing.T) {
+	type args struct {
+		tags  []*Tag
+		key   string
+		value string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "test success",
+			args: args{
+				tags: []*Tag{
+					{
+						Key:   "testKey",
+						Value: "testVal",
+					},
+				},
+				key:   "testKey",
+				value: "testVal",
+			},
+			want: true,
+		},
+		{
+			name: "test failure",
+			args: args{
+				tags: []*Tag{
+					{
+						Key:   "testKey",
+						Value: "testVal",
+					},
+				},
+				key:   "testKey",
+				value: "testVal2",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TagsContains(tt.args.tags, tt.args.key, tt.args.value); got != tt.want {
+				t.Errorf("tagsContains() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_mergeTags(t *testing.T) {
+	type args struct {
+		tags1 []*Tag
+		tags2 []*Tag
+	}
+	tests := []struct {
+		name string
+		args args
+		want []*Tag
+	}{
+		{
+			name: "test success",
+			args: args{
+				tags1: []*Tag{
+					{
+						Key:   "testKey",
+						Value: "testVal",
+					},
+				},
+				tags2: []*Tag{
+					{
+						Key:   "testKey2",
+						Value: "testVal2",
+					},
+				},
+			},
+			want: []*Tag{
+				{
+					Key:   "testKey",
+					Value: "testVal",
+				},
+				{
+					Key:   "testKey2",
+					Value: "testVal2",
+				},
+			},
+		},
+		{
+			name: "test duplicate tag retrieves first value",
+			args: args{
+				tags1: []*Tag{
+					{
+						Key:   "testKey",
+						Value: "testVal",
+					},
+				},
+				tags2: []*Tag{
+					{
+						Key:   "testKey",
+						Value: "testVal2",
+					},
+					{
+						Key:   "testKey3",
+						Value: "testVal3",
+					},
+				},
+			},
+			want: []*Tag{
+				{
+					Key:   "testKey",
+					Value: "testVal",
+				},
+				{
+					Key:   "testKey3",
+					Value: "testVal3",
+				},
+			},
+		},
+		{
+			name: "test empty first array",
+			args: args{
+				tags1: []*Tag{},
+				tags2: []*Tag{
+					{
+						Key:   "testKey",
+						Value: "testVal",
+					},
+				},
+			},
+			want: []*Tag{
+				{
+					Key:   "testKey",
+					Value: "testVal",
+				},
+			},
+		},
+		{
+			name: "test empty second array",
+			args: args{
+				tags1: []*Tag{
+					{
+						Key:   "testKey",
+						Value: "testVal",
+					},
+				},
+				tags2: []*Tag{},
+			},
+			want: []*Tag{
+				{
+					Key:   "testKey",
+					Value: "testVal",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MergeTags(tt.args.tags1, tt.args.tags2)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("mergeTags() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_tagsContainsAll(t *testing.T) {
+	type args struct {
+		tags1 []*Tag
+		tags2 []*Tag
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "test success",
+			args: args{
+				tags1: []*Tag{
+					{
+						Key:   "testKey",
+						Value: "testVal",
+					},
+				},
+				tags2: []*Tag{
+					{
+						Key:   "testKey",
+						Value: "testVal",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "test success - different size",
+			args: args{
+				tags1: []*Tag{
+					{
+						Key:   "testKey",
+						Value: "testVal",
+					},
+				},
+				tags2: []*Tag{
+					{
+						Key:   "testKey",
+						Value: "testVal",
+					},
+					{
+						Key:   "testKey2",
+						Value: "testVal2",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "test failure",
+			args: args{
+				tags1: []*Tag{
+					{
+						Key:   "testKey",
+						Value: "testVal",
+					},
+				},
+				tags2: []*Tag{
+					{
+						Key:   "testKey",
+						Value: "testVal2",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "test failure - different size",
+			args: args{
+				tags1: []*Tag{
+					{
+						Key:   "testKey",
+						Value: "testVal",
+					},
+					{
+						Key:   "testKey2",
+						Value: "testVal2",
+					},
+				},
+				tags2: []*Tag{
+					{
+						Key:   "testKey",
+						Value: "testVal",
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TagsContainsAll(tt.args.tags1, tt.args.tags2); got != tt.want {
+				t.Errorf("tagsContainsAll() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getDefaultResourceTags(t *testing.T) {
+	scheme := runtime.NewScheme()
+	err := configv1.AddToScheme(scheme)
+	if err != nil {
+		t.Fatal("failed to build scheme", err)
+	}
+	type args struct {
+		ctx      context.Context
+		client   client.Client
+		specType string
+		name     string
+		prodName string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []*Tag
+		wantErr bool
+	}{
+		{
+			name: "failed to get cluster id",
+			args: args{
+				ctx:      context.TODO(),
+				client:   fake.NewFakeClientWithScheme(scheme),
+				specType: "",
+				name:     "",
+				prodName: "",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "successfully retrieved default resource tags",
+			args: args{
+				ctx: context.TODO(),
+				client: fake.NewFakeClientWithScheme(scheme, &configv1.Infrastructure{
+					ObjectMeta: controllerruntime.ObjectMeta{
+						Name: "cluster",
+					},
+					Status: configv1.InfrastructureStatus{
+						InfrastructureName: "test",
+						PlatformStatus: &configv1.PlatformStatus{
+							Type: configv1.AWSPlatformType,
+							AWS: &configv1.AWSPlatformStatus{
+								Region: "eu-west-1",
+								ResourceTags: []configv1.AWSResourceTag{
+									{
+										Key:   "test-key",
+										Value: "test-value",
+									},
+								},
+							},
+						},
+					},
+				}),
+				specType: "specType",
+				name:     "name",
+				prodName: "prodName",
+			},
+			want: []*Tag{
+				{
+					Key:   "test-key",
+					Value: "test-value",
+				},
+				{
+					Key:   "integreatly.org/clusterID",
+					Value: "test",
+				},
+				{
+					Key:   "integreatly.org/resource-type",
+					Value: "specType",
+				},
+				{
+					Key:   "integreatly.org/resource-name",
+					Value: "name",
+				},
+				{
+					Key:   "red-hat-managed",
+					Value: "true",
+				},
+				{
+					Key:   "integreatly.org/product-name",
+					Value: "prodName",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _, err := GetDefaultResourceTags(tt.args.ctx, tt.args.client, tt.args.specType, tt.args.name, tt.args.prodName)
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error in getDefaultResourceTags(): %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("expected %v to equal %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getUserInfraTags(t *testing.T) {
+	scheme := runtime.NewScheme()
+	err := configv1.AddToScheme(scheme)
+	if err != nil {
+		t.Fatal("failed to build scheme", err)
+	}
+	type args struct {
+		ctx    context.Context
+		client client.Client
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []*Tag
+		wantErr bool
+	}{
+		{
+			name: "failed to get cluster infrastructure",
+			args: args{
+				ctx:    context.TODO(),
+				client: fake.NewFakeClientWithScheme(scheme),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "successfully retrieved user infra tags",
+			args: args{
+				ctx: context.TODO(),
+				client: fake.NewFakeClientWithScheme(scheme, &configv1.Infrastructure{
+					ObjectMeta: controllerruntime.ObjectMeta{
+						Name: "cluster",
+					},
+					Status: configv1.InfrastructureStatus{
+						InfrastructureName: "test",
+						PlatformStatus: &configv1.PlatformStatus{
+							Type: configv1.AWSPlatformType,
+							AWS: &configv1.AWSPlatformStatus{
+								Region: "eu-west-1",
+								ResourceTags: []configv1.AWSResourceTag{
+									{
+										Key:   "test-key",
+										Value: "test-value",
+									},
+								},
+							},
+						},
+					},
+				}),
+			},
+			want: []*Tag{
+				{
+					Key:   "test-key",
+					Value: "test-value",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetUserInfraTags(tt.args.ctx, tt.args.client)
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error in getUserInfraTags(): %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("expected %v to equal %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/MGDAPI-4992

## Verification

- Provision a GCP cluster
  - From the master branch of the [Delorean](https://github.com/integr8ly/delorean) repo create a file in the root of the repo called gcp_service_account.json. Request GCP credentials and add these to the file
  - Run:
    ```
    make -f make/ocm.mk ocm/cluster.json BYOC=true CLOUD_PROVIDER=gcp OCM_CLUSTER_REGION=europe-west2
    ```
  - Edit the cluster.json file to update the name (and remove the expiration timestamp if necessary). You can also reduce the number of nodes to 2
  - Run:
    ```
    make ocm/cluster/create
    ```
- Create a Redis instance
  - Checkout my pull request
    ```
    gh pr checkout 590
    ```
  - Log in to your cluster and run:
    ```
    PROVIDER=gcp make cluster/prepare
    ```
  - Run CRO:
    ```
    make run
    ```
  - Create a Redis instance (v5.0):
    ```
    oc patch configmap cloud-resources-gcp-strategies -n cloud-resource-operator --type=json -p='[{"op":"replace","path":"/data/redis","value":"{\"development\":{\"region\":\"\",\"projectID\":\"\",\"createStrategy\":{\"instance\":{\"redis_version\":\"REDIS_5_0\"}},\"deleteStrategy\":{}}}"}]'
    PROVIDER=gcp make cluster/seed/redis
    ```
  - Wait until it provisions and check that the instance has been created on GCP:
    ```
    gcloud redis instances list --region=europe-west2
    gcloud redis instances describe <INSTANCE_NAME> --region=europe-west2
    ```
  - Patch the strategy config map which will trigger an update on the previously created Redis instance:
    ```
    oc patch configmap cloud-resources-gcp-strategies -n cloud-resource-operator --type=json -p='[{"op":"replace","path":"/data/redis","value":"{\"development\":{\"region\":\"\",\"projectID\":\"\",\"createStrategy\":{\"instance\":{\"redis_version\":\"REDIS_5_0\",\"memory_size_gb\":2,\"labels\":{\"test-label-key\":\"test-label-value-new\"},\"redis_configs\":{\"activedefrag\":\"yes\"}}},\"deleteStrategy\":{}}}"}]'
    oc patch redis example-redis -n cloud-resource-operator --type=json -p='[{"op":"replace","path":"/spec/maintenanceWindow","value":true}]'
    ```
  - Wait until it updates and check that the instance has all updates listed in the config map applied:
    ```
    gcloud redis instances list --region=europe-west2
    gcloud redis instances describe <INSTANCE_NAME> --region=europe-west2
    ```
  - Patch the strategy config map which will trigger an upgrade on the previously created Redis instance:
    ```
    oc patch configmap cloud-resources-gcp-strategies -n cloud-resource-operator --type=json -p='[{"op":"replace","path":/data/redis,"value":"{\"development\":{\"region\":\"\",\"projectID\":\"\",\"createStrategy\":{\"instance\":{\"redis_version\":\"REDIS_6_X\"}},\"deleteStrategy\":{}}}"}]'
    oc patch redis example-redis -n cloud-resource-operator --type=json -p='[{"op":"replace","path":"/spec/maintenanceWindow","value":true}]'
    ```
  - Wait until it upgrades and check that the instance has the upgraded version listed in the config map applied:
    ```
    gcloud redis instances list --region=europe-west2
    gcloud redis instances describe <INSTANCE_NAME> --region=europe-west2
    ```
  - Finally, delete the Redis instance and wait for it to complete:
    ```
    oc delete redis example-redis -n cloud-resource-operator
    ```