### PR TITLE
MGDAPI-5009 implement gcp postgres metrics

### DIFF
--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -1039,33 +1039,6 @@ func (p *PostgresProvider) configureRDSVpc(ctx context.Context, rdsSvc rdsiface.
 	return nil
 }
 
-func buildPostgresInfoMetricLabels(cr *v1alpha1.Postgres, instance *rds.DBInstance, clusterID, instanceName string) map[string]string {
-	labels := buildPostgresGenericMetricLabels(cr, clusterID, instanceName)
-	if instance != nil {
-		labels["status"] = *instance.DBInstanceStatus
-		return labels
-	}
-	labels["status"] = "nil"
-	return labels
-}
-
-func buildPostgresGenericMetricLabels(cr *v1alpha1.Postgres, clusterID, instanceName string) map[string]string {
-	labels := map[string]string{}
-	labels["clusterID"] = clusterID
-	labels["resourceID"] = cr.Name
-	labels["namespace"] = cr.Namespace
-	labels["instanceID"] = instanceName
-	labels["productName"] = cr.Labels["productName"]
-	labels["strategy"] = postgresProviderName
-	return labels
-}
-
-func buildPostgresStatusMetricsLabels(cr *v1alpha1.Postgres, clusterID, instanceName string, phase croType.StatusPhase) map[string]string {
-	labels := buildPostgresGenericMetricLabels(cr, clusterID, instanceName)
-	labels["statusPhase"] = string(phase)
-	return labels
-}
-
 func (p *PostgresProvider) exposePostgresMetrics(ctx context.Context, cr *v1alpha1.Postgres, instance *rds.DBInstance, ec2Svc ec2iface.EC2API) {
 	// build instance name
 	instanceName, err := p.buildInstanceName(ctx, cr)
@@ -1082,11 +1055,12 @@ func (p *PostgresProvider) exposePostgresMetrics(ctx context.Context, cr *v1alph
 	}
 
 	// build metric labels
-	infoLabels := buildPostgresInfoMetricLabels(cr, instance, clusterID, instanceName)
-	// build available mertic labels
-	genericLabels := buildPostgresGenericMetricLabels(cr, clusterID, instanceName)
-
-	// set status gauge
+	var status string
+	if instance != nil {
+		status = resources.SafeStringDereference(instance.DBInstanceStatus)
+	}
+	infoLabels := resources.BuildInfoMetricLabels(cr.ObjectMeta, status, clusterID, instanceName, postgresProviderName)
+	genericLabels := resources.BuildGenericMetricLabels(cr.ObjectMeta, clusterID, instanceName, postgresProviderName)
 	resources.SetMetricCurrentTime(resources.DefaultPostgresInfoMetricName, infoLabels)
 
 	// set generic status metrics
@@ -1095,7 +1069,7 @@ func (p *PostgresProvider) exposePostgresMetrics(ctx context.Context, cr *v1alph
 	// the value of the metric should be 0.0 when the resource is not in that phase
 	// this follows the approach that pod status
 	for _, phase := range []croType.StatusPhase{croType.PhaseFailed, croType.PhaseDeleteInProgress, croType.PhasePaused, croType.PhaseComplete, croType.PhaseInProgress} {
-		labelsFailed := buildPostgresStatusMetricsLabels(cr, clusterID, instanceName, phase)
+		labelsFailed := resources.BuildStatusMetricsLabels(cr.ObjectMeta, clusterID, instanceName, postgresProviderName, phase)
 		resources.SetMetric(resources.DefaultPostgresStatusMetricName, labelsFailed, resources.Btof64(cr.Status.Phase == phase))
 	}
 
@@ -1157,8 +1131,7 @@ func (p *PostgresProvider) setPostgresDeletionTimestampMetric(ctx context.Contex
 			logrus.Errorf("failed to get cluster id while exposing information metric for %v", instanceName)
 			return
 		}
-
-		labels := buildPostgresStatusMetricsLabels(cr, clusterID, instanceName, cr.Status.Phase)
+		labels := resources.BuildStatusMetricsLabels(cr.ObjectMeta, clusterID, instanceName, postgresProviderName, cr.Status.Phase)
 		resources.SetMetric(resources.DefaultPostgresDeletionMetricName, labels, float64(cr.DeletionTimestamp.Unix()))
 	}
 }
@@ -1234,8 +1207,7 @@ func (p *PostgresProvider) createRDSConnectionMetric(ctx context.Context, cr *v1
 
 	}
 
-	// build generic labels to be added to metric
-	genericLabels := buildPostgresGenericMetricLabels(cr, clusterID, instanceName)
+	genericLabels := resources.BuildGenericMetricLabels(cr.ObjectMeta, clusterID, instanceName, postgresProviderName)
 
 	// check if the instance is available
 	if instance == nil {

--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -1121,14 +1121,14 @@ func (p *PostgresProvider) setPostgresDeletionTimestampMetric(ctx context.Contex
 		// build instance name
 		instanceName, err := p.buildInstanceName(ctx, cr)
 		if err != nil {
-			logrus.Errorf("error occurred while building instance name during postgres metrics: %v", err)
+			p.Logger.Errorf("error occurred while building instance name during postgres metrics: %v", err)
 		}
 
 		// get Cluster Id
-		logrus.Info("setting postgres information metric")
+		p.Logger.Info("setting postgres information metric")
 		clusterID, err := resources.GetClusterID(ctx, p.Client)
 		if err != nil {
-			logrus.Errorf("failed to get cluster id while exposing information metric for %v", instanceName)
+			p.Logger.Errorf("failed to get cluster id while exposing information metric for %v", instanceName)
 			return
 		}
 		labels := resources.BuildStatusMetricsLabels(cr.ObjectMeta, clusterID, instanceName, postgresProviderName, cr.Status.Phase)

--- a/pkg/providers/aws/provider_postgres_test.go
+++ b/pkg/providers/aws/provider_postgres_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"reflect"
 	"strconv"
@@ -2867,6 +2868,66 @@ func TestAddAnnotation_ClientUpdate(t *testing.T) {
 				}
 				return
 			}
+		})
+	}
+}
+
+func TestPostgresProvider_setPostgresDeletionTimestampMetric(t *testing.T) {
+	type fields struct {
+		Client client.Client
+	}
+	type args struct {
+		cr *v1alpha1.Postgres
+	}
+	scheme, err := buildTestSchemePostgresql()
+	if err != nil {
+		t.Fatal("failed to build scheme", err)
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			name: "success setting postgres deletion timestamp metric",
+			fields: fields{
+				Client: moqClient.NewSigsClientMoqWithScheme(scheme, buildTestInfra()),
+			},
+			args: args{
+				cr: &v1alpha1.Postgres{
+					ObjectMeta: metav1.ObjectMeta{
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					},
+				},
+			},
+		},
+		{
+			name: "failure setting postgres deletion timestamp metric",
+			fields: fields{
+				Client: func() client.Client {
+					mockClient := moqClient.NewSigsClientMoqWithScheme(scheme)
+					mockClient.GetFunc = func(ctx context.Context, key types.NamespacedName, obj client.Object) error {
+						return fmt.Errorf("generic error")
+					}
+					return mockClient
+				}(),
+			},
+			args: args{
+				cr: &v1alpha1.Postgres{
+					ObjectMeta: metav1.ObjectMeta{
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &PostgresProvider{
+				Client: tt.fields.Client,
+				Logger: logrus.NewEntry(logrus.StandardLogger()),
+			}
+			p.setPostgresDeletionTimestampMetric(context.TODO(), tt.args.cr)
 		})
 	}
 }

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -971,10 +971,10 @@ func (p *RedisProvider) exposeRedisMetrics(ctx context.Context, cr *v1alpha1.Red
 	if instance != nil {
 		status = resources.SafeStringDereference(instance.Status)
 	}
-	infoLabels := resources.BuildRedisInfoMetricLabels(cr, status, clusterID, cacheName, redisProviderName)
+	infoLabels := resources.BuildInfoMetricLabels(cr.ObjectMeta, status, clusterID, cacheName, redisProviderName)
 
 	// build generic metrics
-	genericLabels := resources.BuildRedisGenericMetricLabels(cr, clusterID, cacheName, redisProviderName)
+	genericLabels := resources.BuildGenericMetricLabels(cr.ObjectMeta, clusterID, cacheName, redisProviderName)
 
 	// set status gauge
 	resources.SetMetricCurrentTime(resources.DefaultRedisInfoMetricName, infoLabels)
@@ -985,7 +985,7 @@ func (p *RedisProvider) exposeRedisMetrics(ctx context.Context, cr *v1alpha1.Red
 	// the value of the metric should be 0.0 when the resource is not in that phase
 	// this follows the approach that pod status
 	for _, phase := range []croType.StatusPhase{croType.PhaseFailed, croType.PhaseDeleteInProgress, croType.PhasePaused, croType.PhaseComplete, croType.PhaseInProgress} {
-		labelsFailed := resources.BuildRedisStatusMetricsLabels(cr, clusterID, cacheName, redisProviderName, phase)
+		labelsFailed := resources.BuildStatusMetricsLabels(cr.ObjectMeta, clusterID, cacheName, redisProviderName, phase)
 		resources.SetMetric(resources.DefaultRedisStatusMetricName, labelsFailed, resources.Btof64(cr.Status.Phase == phase))
 	}
 
@@ -1019,7 +1019,7 @@ func (p *RedisProvider) setRedisDeletionTimestampMetric(ctx context.Context, cr 
 			return
 		}
 
-		labels := resources.BuildRedisStatusMetricsLabels(cr, clusterID, cacheName, redisProviderName, cr.Status.Phase)
+		labels := resources.BuildStatusMetricsLabels(cr.ObjectMeta, clusterID, cacheName, redisProviderName, cr.Status.Phase)
 		resources.SetMetric(resources.DefaultRedisDeletionMetricName, labels, float64(cr.DeletionTimestamp.Unix()))
 	}
 }
@@ -1095,7 +1095,7 @@ func (p *RedisProvider) createElasticacheConnectionMetric(ctx context.Context, c
 	}
 
 	// build generic labels to be added to metric
-	genericLabels := resources.BuildRedisGenericMetricLabels(cr, clusterID, cacheName, redisProviderName)
+	genericLabels := resources.BuildGenericMetricLabels(cr.ObjectMeta, clusterID, cacheName, redisProviderName)
 
 	// check if the node group is available
 	if cache == nil || cache.NodeGroups == nil {

--- a/pkg/providers/gcp/provider_postgres.go
+++ b/pkg/providers/gcp/provider_postgres.go
@@ -536,8 +536,10 @@ func (p *PostgresProvider) exposePostgresInstanceMetrics(ctx context.Context, pg
 	var instanceConnectable float64
 	if resources.Contains(healthyPostgresInstanceStates(), instanceState) {
 		instanceHealthy = 1
-		if success := p.TCPPinger.TCPConnection(instance.IpAddresses[0].IpAddress, defaultGCPPostgresPort); success {
-			instanceConnectable = 1
+		if len(instance.IpAddresses) > 0 {
+			if success := p.TCPPinger.TCPConnection(instance.IpAddresses[0].IpAddress, defaultGCPPostgresPort); success {
+				instanceConnectable = 1
+			}
 		}
 	}
 	resources.SetMetric(resources.DefaultPostgresAvailMetricName, genericLabels, instanceHealthy)

--- a/pkg/providers/gcp/provider_postgres_test.go
+++ b/pkg/providers/gcp/provider_postgres_test.go
@@ -1553,7 +1553,7 @@ func TestPostgresProvider_reconcileCloudSQLInstance(t *testing.T) {
 				ConfigManager:     tt.fields.ConfigManager,
 				TCPPinger:         resources.BuildMockConnectionTester(),
 			}
-			_, got1, err := pp.reconcileCloudSQLInstance(tt.args.ctx, tt.args.p, tt.args.sqladminService, tt.args.cloudSQLCreateConfig, tt.args.strategyConfig, tt.args.maintenanceWindow)
+			_, got1, err := pp.reconcileCloudSQLInstance(tt.args.ctx, tt.args.p, tt.args.sqladminService, tt.args.cloudSQLCreateConfig, tt.args.strategyConfig, tt.args.maintenanceWindow, buildTestComputeAddress(nil))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("reconcileCloudSQLInstance() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/providers/gcp/provider_postgres_test.go
+++ b/pkg/providers/gcp/provider_postgres_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 	"reflect"
 	"testing"
@@ -121,8 +122,9 @@ func TestPostgresProvider_DeleteCloudSQLInstance(t *testing.T) {
 				sqladminService: gcpiface.GetMockSQLClient(func(sqlClient *gcpiface.MockSqlClient) {
 					sqlClient.GetInstanceFn = func(ctx context.Context, s string, s2 string) (*sqladmin.DatabaseInstance, error) {
 						return &sqladmin.DatabaseInstance{
-							Name:  gcpTestPostgresInstanceName,
-							State: "PENDING_DELETE",
+							Name:        gcpTestPostgresInstanceName,
+							State:       "PENDING_DELETE",
+							IpAddresses: []*sqladmin.IpMapping{{}},
 						}, nil
 					}
 				}),
@@ -156,9 +158,10 @@ func TestPostgresProvider_DeleteCloudSQLInstance(t *testing.T) {
 				sqladminService: gcpiface.GetMockSQLClient(func(sqlClient *gcpiface.MockSqlClient) {
 					sqlClient.GetInstanceFn = func(ctx context.Context, s string, s2 string) (*sqladmin.DatabaseInstance, error) {
 						return &sqladmin.DatabaseInstance{
-							Name:     gcpTestPostgresInstanceName,
-							State:    "RUNNABLE",
-							Settings: &sqladmin.Settings{DeletionProtectionEnabled: false},
+							Name:        gcpTestPostgresInstanceName,
+							State:       "RUNNABLE",
+							Settings:    &sqladmin.Settings{DeletionProtectionEnabled: false},
+							IpAddresses: []*sqladmin.IpMapping{{}},
 						}, nil
 					}
 					sqlClient.DeleteInstanceFn = func(ctx context.Context, s string, s2 string) (*sqladmin.Operation, error) {
@@ -324,9 +327,10 @@ func TestPostgresProvider_DeleteCloudSQLInstance(t *testing.T) {
 				sqladminService: gcpiface.GetMockSQLClient(func(sqlClient *gcpiface.MockSqlClient) {
 					sqlClient.GetInstanceFn = func(ctx context.Context, s string, s2 string) (*sqladmin.DatabaseInstance, error) {
 						return &sqladmin.DatabaseInstance{
-							Name:     gcpTestPostgresInstanceName,
-							State:    "RUNNABLE",
-							Settings: &sqladmin.Settings{DeletionProtectionEnabled: false},
+							Name:        gcpTestPostgresInstanceName,
+							State:       "RUNNABLE",
+							Settings:    &sqladmin.Settings{DeletionProtectionEnabled: false},
+							IpAddresses: []*sqladmin.IpMapping{{}},
 						}, nil
 					}
 				}),
@@ -359,9 +363,10 @@ func TestPostgresProvider_DeleteCloudSQLInstance(t *testing.T) {
 				sqladminService: gcpiface.GetMockSQLClient(func(sqlClient *gcpiface.MockSqlClient) {
 					sqlClient.GetInstanceFn = func(ctx context.Context, s string, s2 string) (*sqladmin.DatabaseInstance, error) {
 						return &sqladmin.DatabaseInstance{
-							Name:     gcpTestPostgresInstanceName,
-							State:    "RUNNABLE",
-							Settings: &sqladmin.Settings{DeletionProtectionEnabled: false},
+							Name:        gcpTestPostgresInstanceName,
+							State:       "RUNNABLE",
+							Settings:    &sqladmin.Settings{DeletionProtectionEnabled: false},
+							IpAddresses: []*sqladmin.IpMapping{{}},
 						}, nil
 					}
 					sqlClient.DeleteInstanceFn = func(ctx context.Context, s string, s2 string) (*sqladmin.Operation, error) {
@@ -438,9 +443,10 @@ func TestPostgresProvider_DeleteCloudSQLInstance(t *testing.T) {
 				sqladminService: gcpiface.GetMockSQLClient(func(sqlClient *gcpiface.MockSqlClient) {
 					sqlClient.GetInstanceFn = func(ctx context.Context, s string, s2 string) (*sqladmin.DatabaseInstance, error) {
 						return &sqladmin.DatabaseInstance{
-							Name:     gcpTestPostgresInstanceName,
-							State:    "RUNNABLE",
-							Settings: &sqladmin.Settings{DeletionProtectionEnabled: true},
+							Name:        gcpTestPostgresInstanceName,
+							State:       "RUNNABLE",
+							Settings:    &sqladmin.Settings{DeletionProtectionEnabled: true},
+							IpAddresses: []*sqladmin.IpMapping{{}},
 						}, nil
 					}
 					sqlClient.ModifyInstanceFn = func(ctx context.Context, s string, s2 string, instance *sqladmin.DatabaseInstance) (*sqladmin.Operation, error) {
@@ -747,6 +753,7 @@ func TestPostgresProvider_DeleteCloudSQLInstance(t *testing.T) {
 				Logger:            tt.fields.Logger,
 				CredentialManager: tt.fields.CredentialManager,
 				ConfigManager:     tt.fields.ConfigManager,
+				TCPPinger:         resources.BuildMockConnectionTester(),
 			}
 			got, err := pp.deleteCloudSQLInstance(tt.args.ctx, tt.args.networkManager, tt.args.sqladminService, tt.args.p, tt.args.isLastResource)
 			if (err != nil) != tt.wantErr {
@@ -1212,6 +1219,7 @@ func TestPostgresProvider_DeletePostgres(t *testing.T) {
 				Logger:            tt.fields.Logger,
 				CredentialManager: tt.fields.CredentialManager,
 				ConfigManager:     tt.fields.ConfigManager,
+				TCPPinger:         resources.BuildMockConnectionTester(),
 			}
 			got, err := pp.DeletePostgres(tt.args.ctx, tt.args.p)
 			if (err != nil) != tt.wantErr {
@@ -1440,8 +1448,9 @@ func TestPostgresProvider_reconcileCloudSQLInstance(t *testing.T) {
 				sqladminService: gcpiface.GetMockSQLClient(func(sqlClient *gcpiface.MockSqlClient) {
 					sqlClient.GetInstanceFn = func(ctx context.Context, s string, s2 string) (*sqladmin.DatabaseInstance, error) {
 						return &sqladmin.DatabaseInstance{
-							Name:  gcpTestPostgresInstanceName,
-							State: "PENDING_CREATE",
+							Name:        gcpTestPostgresInstanceName,
+							State:       "PENDING_CREATE",
+							IpAddresses: []*sqladmin.IpMapping{{}},
 						}, nil
 					}
 				}),
@@ -1541,6 +1550,7 @@ func TestPostgresProvider_reconcileCloudSQLInstance(t *testing.T) {
 				Logger:            tt.fields.Logger,
 				CredentialManager: tt.fields.CredentialManager,
 				ConfigManager:     tt.fields.ConfigManager,
+				TCPPinger:         resources.BuildMockConnectionTester(),
 			}
 			_, got1, err := pp.reconcileCloudSQLInstance(tt.args.ctx, tt.args.p, tt.args.sqladminService, tt.args.cloudSQLCreateConfig, tt.args.strategyConfig, tt.args.maintenanceWindow)
 			if (err != nil) != tt.wantErr {
@@ -1657,6 +1667,7 @@ func TestPostgresProvider_ReconcilePostgres(t *testing.T) {
 				Logger:            tt.fields.Logger,
 				CredentialManager: tt.fields.CredentialManager,
 				ConfigManager:     tt.fields.ConfigManager,
+				TCPPinger:         resources.BuildMockConnectionTester(),
 			}
 			got, statusMessage, err := pp.ReconcilePostgres(tt.args.ctx, tt.args.p)
 			if (err != nil) != tt.wantErr {

--- a/pkg/providers/gcp/provider_redis.go
+++ b/pkg/providers/gcp/provider_redis.go
@@ -293,15 +293,15 @@ func (p *RedisProvider) exposeRedisInstanceMetrics(ctx context.Context, r *v1alp
 		p.Logger.Errorf("failed to get cluster id while exposing metrics for redis instance %s", instanceName)
 		return
 	}
-	genericLabels := resources.BuildRedisGenericMetricLabels(r, clusterID, instanceName, redisProviderName)
+	genericLabels := resources.BuildGenericMetricLabels(r.ObjectMeta, clusterID, instanceName, redisProviderName)
 	instanceState := instance.State.String()
-	infoLabels := resources.BuildRedisInfoMetricLabels(r, instanceState, clusterID, instanceName, redisProviderName)
+	infoLabels := resources.BuildInfoMetricLabels(r.ObjectMeta, instanceState, clusterID, instanceName, redisProviderName)
 	resources.SetMetricCurrentTime(resources.DefaultRedisInfoMetricName, infoLabels)
 	// a single metric should be exposed for each possible status phase
 	// the value of the metric should be 1.0 when the resource is in that phase
 	// the value of the metric should be 0.0 when the resource is not in that phase
 	for _, phase := range []croType.StatusPhase{croType.PhaseFailed, croType.PhaseDeleteInProgress, croType.PhasePaused, croType.PhaseComplete, croType.PhaseInProgress} {
-		labelsFailed := resources.BuildRedisStatusMetricsLabels(r, clusterID, instanceName, redisProviderName, phase)
+		labelsFailed := resources.BuildStatusMetricsLabels(r.ObjectMeta, clusterID, instanceName, redisProviderName, phase)
 		resources.SetMetric(resources.DefaultRedisStatusMetricName, labelsFailed, resources.Btof64(r.Status.Phase == phase))
 	}
 	// set availability metric, based on the status flag on the memorystore redis instance in gcp
@@ -344,7 +344,7 @@ func (p *RedisProvider) setRedisDeletionTimestampMetric(ctx context.Context, r *
 			p.Logger.Errorf("failed to get cluster id while exposing metrics for redis instance %s", instanceName)
 			return
 		}
-		labels := resources.BuildRedisStatusMetricsLabels(r, clusterID, instanceName, redisProviderName, r.Status.Phase)
+		labels := resources.BuildStatusMetricsLabels(r.ObjectMeta, clusterID, instanceName, redisProviderName, r.Status.Phase)
 		resources.SetMetric(resources.DefaultRedisDeletionMetricName, labels, float64(r.DeletionTimestamp.Unix()))
 	}
 }

--- a/pkg/resources/labels.go
+++ b/pkg/resources/labels.go
@@ -1,12 +1,12 @@
 package resources
 
 import (
-	"github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
 	croType "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1/types"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// BuildRedisGenericMetricLabels returns generic labels to be added to every metric
-func BuildRedisGenericMetricLabels(r *v1alpha1.Redis, clusterID, cacheName, providerName string) map[string]string {
+// BuildGenericMetricLabels returns generic labels to be added to every metric
+func BuildGenericMetricLabels(r v1.ObjectMeta, clusterID, cacheName, providerName string) map[string]string {
 	return map[string]string{
 		"clusterID":   clusterID,
 		"resourceID":  r.Name,
@@ -17,9 +17,9 @@ func BuildRedisGenericMetricLabels(r *v1alpha1.Redis, clusterID, cacheName, prov
 	}
 }
 
-// BuildRedisInfoMetricLabels adds extra information to labels around resource
-func BuildRedisInfoMetricLabels(r *v1alpha1.Redis, status string, clusterID, cacheName, providerName string) map[string]string {
-	labels := BuildRedisGenericMetricLabels(r, clusterID, cacheName, providerName)
+// BuildInfoMetricLabels adds extra information to labels around resource
+func BuildInfoMetricLabels(r v1.ObjectMeta, status string, clusterID, cacheName, providerName string) map[string]string {
+	labels := BuildGenericMetricLabels(r, clusterID, cacheName, providerName)
 	if status != "" {
 		labels["status"] = status
 		return labels
@@ -28,8 +28,8 @@ func BuildRedisInfoMetricLabels(r *v1alpha1.Redis, status string, clusterID, cac
 	return labels
 }
 
-func BuildRedisStatusMetricsLabels(r *v1alpha1.Redis, clusterID, cacheName, providerName string, phase croType.StatusPhase) map[string]string {
-	labels := BuildRedisGenericMetricLabels(r, clusterID, cacheName, providerName)
+func BuildStatusMetricsLabels(r v1.ObjectMeta, clusterID, cacheName, providerName string, phase croType.StatusPhase) map[string]string {
+	labels := BuildGenericMetricLabels(r, clusterID, cacheName, providerName)
 	labels["statusPhase"] = string(phase)
 	return labels
 }

--- a/pkg/resources/labels_test.go
+++ b/pkg/resources/labels_test.go
@@ -48,7 +48,7 @@ func TestBuildRedisGenericMetricLabels(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := BuildRedisGenericMetricLabels(tt.args.r, tt.args.clusterID, tt.args.cacheName, tt.args.providerName); !reflect.DeepEqual(got, tt.want) {
+			if got := BuildGenericMetricLabels(tt.args.r.ObjectMeta, tt.args.clusterID, tt.args.cacheName, tt.args.providerName); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("BuildRedisGenericMetricLabels() = %v, want %v", got, tt.want)
 			}
 		})
@@ -125,7 +125,7 @@ func TestBuildRedisInfoMetricLabels(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := BuildRedisInfoMetricLabels(tt.args.r, tt.args.status, tt.args.clusterID, tt.args.cacheName, tt.args.providerName); !reflect.DeepEqual(got, tt.want) {
+			if got := BuildInfoMetricLabels(tt.args.r.ObjectMeta, tt.args.status, tt.args.clusterID, tt.args.cacheName, tt.args.providerName); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("BuildRedisInfoMetricLabels() = %v, want %v", got, tt.want)
 			}
 		})
@@ -175,7 +175,7 @@ func TestBuildRedisStatusMetricsLabels(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := BuildRedisStatusMetricsLabels(tt.args.r, tt.args.clusterID, tt.args.cacheName, tt.args.providerName, tt.args.phase); !reflect.DeepEqual(got, tt.want) {
+			if got := BuildStatusMetricsLabels(tt.args.r.ObjectMeta, tt.args.clusterID, tt.args.cacheName, tt.args.providerName, tt.args.phase); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("BuildRedisStatusMetricsLabels() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/MGDAPI-5009

## Verification

- Provision a GCP cluster
  - From the master branch of the [Delorean](https://github.com/integr8ly/delorean) repo create a file in the root of the repo called gcp_service_account.json. Request GCP credentials and add these to the file
  - Run:
    ```
    make -f make/ocm.mk ocm/cluster.json BYOC=true CLOUD_PROVIDER=gcp OCM_CLUSTER_REGION=europe-west2
    ```
  - Edit the cluster.json file to update the name (and remove the expiration timestamp if necessary). You can also reduce the number of nodes to 2
  - Run:
    ```
    make ocm/cluster/create
    ```
- Create a Postgres instance
  - Checkout my pull request
    ```
    gh pr checkout 605
    ```
  - Log in to your cluster and run:
    ```
    PROVIDER=gcp make cluster/prepare
    ```
  - Install the operator from my index image:
    ```
    cat << EOF | oc create -f - -n openshift-marketplace
      apiVersion: operators.coreos.com/v1alpha1
      kind: CatalogSource
      metadata:
        name: cro
        namespace: openshift-marketplace
      spec:
        image: 'quay.io/tdimov0/cloud-resource-operator:index-v0.43.0'
        sourceType: grpc
    EOF
    ```
  - Create a Postgres instance and wait until it provisions successfully:
    ```
    PROVIDER=gcp make cluster/seed/postgres
    ```
  - Delete the Postgres instance and wait for it to complete:
    ```
    oc delete postgres example-postgres -n cloud-resource-operator
    ```
  - Open a remote shell to the operator pod:
    ```
    PODNAME=$(oc get pods -n cloud-resource-operator -o json | jq -r '.items[0].metadata.name')
    oc rsh $PODNAME
    ```
  - Check if the `cro_***` metrics are available and showing accurate values:
    ```
    curl localhost:8383/metrics | grep cro_
    ```
  - You should get similar result to this:
    ```
    cro_postgres_available{clusterID="tdimov-ccs-lrsxt",instanceID="tdimovccslrsxtcloudresourceoperator-xezy",namespace="cloud-resource-operator",productName="productName",resourceID="example-postgres",strategy="gcp-cloudsql"} 1
    cro_postgres_connection{clusterID="tdimov-ccs-lrsxt",instanceID="tdimovccslrsxtcloudresourceoperator-xezy",namespace="cloud-resource-operator",productName="productName",resourceID="example-postgres",strategy="gcp-cloudsql"} 1
    cro_postgres_deletion_timestamp{clusterID="tdimov-ccs-lrsxt",instanceID="tdimovccslrsxtcloudresourceoperator-xezy",namespace="cloud-resource-operator",productName="productName",resourceID="example-postgres",statusPhase="deletion in progress",strategy="gcp-cloudsql"} 1.672841427e+09
    cro_postgres_deletion_timestamp{clusterID="tdimov-ccs-lrsxt",instanceID="tdimovccslrsxtcloudresourceoperator-xezy",namespace="cloud-resource-operator",productName="productName",resourceID="example-postgres",statusPhase="failed",strategy="gcp-cloudsql"} 1.672841427e+09
    cro_postgres_info{clusterID="tdimov-ccs-lrsxt",instanceID="tdimovccslrsxtcloudresourceoperator-xezy",namespace="cloud-resource-operator",productName="productName",resourceID="example-postgres",status="RUNNABLE",strategy="gcp-cloudsql"} 1.67284143748741e+09
    cro_postgres_status_phase{clusterID="tdimov-ccs-lrsxt",instanceID="tdimovccslrsxtcloudresourceoperator-xezy",namespace="cloud-resource-operator",productName="productName",resourceID="example-postgres",statusPhase="complete",strategy="gcp-cloudsql"} 0
    cro_postgres_status_phase{clusterID="tdimov-ccs-lrsxt",instanceID="tdimovccslrsxtcloudresourceoperator-xezy",namespace="cloud-resource-operator",productName="productName",resourceID="example-postgres",statusPhase="deletion in progress",strategy="gcp-cloudsql"} 0
    cro_postgres_status_phase{clusterID="tdimov-ccs-lrsxt",instanceID="tdimovccslrsxtcloudresourceoperator-xezy",namespace="cloud-resource-operator",productName="productName",resourceID="example-postgres",statusPhase="failed",strategy="gcp-cloudsql"} 1
    cro_postgres_status_phase{clusterID="tdimov-ccs-lrsxt",instanceID="tdimovccslrsxtcloudresourceoperator-xezy",namespace="cloud-resource-operator",productName="productName",resourceID="example-postgres",statusPhase="in progress",strategy="gcp-cloudsql"} 0
    cro_postgres_status_phase{clusterID="tdimov-ccs-lrsxt",instanceID="tdimovccslrsxtcloudresourceoperator-xezy",namespace="cloud-resource-operator",productName="productName",resourceID="example-postgres",statusPhase="paused",strategy="gcp-cloudsql"} 0

    ```