### PR TITLE
MGDAPI-4929 - feat: allow defining cache node size in Redis CR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ VERSION=0.42.0
 COMPILE_TARGET=./tmp/_output/bin/$(IMAGE_NAME)
 UPGRADE ?= true
 CHANNEL ?= rhmi
+REDIS_NODE_SIZE ?= ""
+REDIS_NAME ?= example-redis
 
 SHELL=/bin/bash
 
@@ -102,11 +104,11 @@ cluster/seed/managed/blobstorage:
 
 .PHONY: cluster/seed/workshop/redis
 cluster/seed/workshop/redis:
-	@cat config/samples/integreatly_v1alpha1_redis.yaml | sed "s/type: REPLACE_ME/type: workshop/g" | oc apply -f - -n $(NAMESPACE)
+	@cat config/samples/integreatly_v1alpha1_redis.yaml | sed "s/name: REPLACE_ME/name: $(REDIS_NAME)/g" | sed "s/type: REPLACE_ME/type: workshop/g" | sed "s/size: REPLACE_ME/size: $(REDIS_NODE_SIZE)/g" | oc apply -f - -n $(NAMESPACE)
 
 .PHONY: cluster/seed/managed/redis
 cluster/seed/managed/redis:
-	@cat config/samples/integreatly_v1alpha1_redis.yaml | sed "s/type: REPLACE_ME/type: managed/g" | oc apply -f - -n $(NAMESPACE)
+	@cat config/samples/integreatly_v1alpha1_redis.yaml | sed "s/name: REPLACE_ME/name: $(REDIS_NAME)/g" | sed "s/type: REPLACE_ME/type: managed/g" | sed "s/size: REPLACE_ME/size: $(REDIS_NODE_SIZE)/g" | oc apply -f - -n $(NAMESPACE)
 
 .PHONY: cluster/seed/managed/redissnapshot
 cluster/seed/managed/redissnapshot:

--- a/apis/integreatly/v1alpha1/types/types.go
+++ b/apis/integreatly/v1alpha1/types/types.go
@@ -30,6 +30,8 @@ type ResourceTypeSpec struct {
 	ApplyImmediately  bool       `json:"applyImmediately,omitempty"`
 	MaintenanceWindow bool       `json:"maintenanceWindow,omitempty"`
 	SecretRef         *SecretRef `json:"secretRef"`
+	// Size allows defining the node size. It is only available to Redis CR. Blobstorage and Postgres CR's currently does nothing
+	Size string `json:"size,omitempty"`
 }
 
 type StatusPhase string

--- a/config/crd/bases/integreatly.org_blobstorages.yaml
+++ b/config/crd/bases/integreatly.org_blobstorages.yaml
@@ -49,6 +49,10 @@ spec:
                 required:
                 - name
                 type: object
+              size:
+                description: Size allows defining the node size. It is only available
+                  to Redis CR. Blobstorage and Postgres CR's currently does nothing
+                type: string
               skipCreate:
                 type: boolean
               tier:

--- a/config/crd/bases/integreatly.org_postgres.yaml
+++ b/config/crd/bases/integreatly.org_postgres.yaml
@@ -49,6 +49,10 @@ spec:
                 required:
                 - name
                 type: object
+              size:
+                description: Size allows defining the node size. It is only available
+                  to Redis CR. Blobstorage and Postgres CR's currently does nothing
+                type: string
               skipCreate:
                 type: boolean
               tier:

--- a/config/crd/bases/integreatly.org_redis.yaml
+++ b/config/crd/bases/integreatly.org_redis.yaml
@@ -49,6 +49,10 @@ spec:
                 required:
                 - name
                 type: object
+              size:
+                description: Size allows defining the node size. It is only available
+                  to Redis CR. Blobstorage and Postgres CR's currently does nothing
+                type: string
               skipCreate:
                 type: boolean
               tier:

--- a/config/samples/integreatly_v1alpha1_redis.yaml
+++ b/config/samples/integreatly_v1alpha1_redis.yaml
@@ -2,14 +2,14 @@ apiVersion: integreatly.org/v1alpha1
 kind: Redis
 metadata:
   # name must be between 1-40 characters
-  name: example-redis
+  name: REPLACE_ME
   labels:
   # label for the product we are installing , subject to change
     productName: productName
 spec:
   # i want my redis storage information output in a secret named example-redis-sec
   secretRef:
-    name: example-redis-sec
+    name: REPLACE_ME-sec
   # i want a redis storage of a development-level tier
   tier: development
   # the type i want for a redis storage
@@ -18,3 +18,5 @@ spec:
   applyImmediately: false
   # whether service updates should take place
   maintenanceWindow: false
+  # Optionally set the redis node size
+  size: REPLACE_ME

--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -681,6 +681,11 @@ func (p *RedisProvider) getElasticacheConfig(ctx context.Context, r *v1alpha1.Re
 		return nil, nil, nil, nil, errorUtil.Wrap(err, "failed to unmarshal aws elasticache cluster configuration")
 	}
 
+	// Override if node size is defined in the CR spec
+	if r.Spec.Size != "" {
+		elasticacheCreateConfig.CacheNodeType = aws.String(r.Spec.Size)
+	}
+
 	elasticacheDeleteConfig := &elasticache.DeleteReplicationGroupInput{}
 	if err := json.Unmarshal(stratCfg.DeleteStrategy, elasticacheDeleteConfig); err != nil {
 		return nil, nil, nil, nil, errorUtil.Wrap(err, "failed to unmarshal aws elasticache cluster configuration")


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/MGDAPI-4929

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make run`
- Verify default node size is used when not specified in CR
```
make cluster/seed/managed/redis
```
- Verify node size is used when not specified in CR but specified in strategy config map
  - Update `cloud-resources-aws-strategies` config map for `redis` to 
  ```
  oc patch configmaps cloud-resources-aws-strategies -p '{"data":{"redis":"{\"development\": { \"region\": \"\", \"createStrategy\": {\"cacheNodeType\": \"cache.t3.small\"}, \"deleteStrategy\": {}, \"serviceUpdates\": [\"elasticache-20210615-002\"]  }}\n"}}' --type merge
  ```
  - Create second redis
  ```
  make cluster/seed/managed/redis REDIS_NAME=example-redis2
  ```
- Verify node size is used when specified in the CR
  ```
  make cluster/seed/managed/redis REDIS_NAME=example-redis3 REDIS_NODE_SIZE=cache.m5.large
  ```

![image](https://user-images.githubusercontent.com/24636860/211336061-ea28ec7e-3293-4ccc-bc18-3b5de672a213.png)

## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below