### PR TITLE
MGDAPI-4900 [Postgres] Update

### DIFF
--- a/pkg/providers/gcp/gcpiface/database_types.go
+++ b/pkg/providers/gcp/gcpiface/database_types.go
@@ -291,7 +291,7 @@ type Settings struct {
 	// StorageAutoResizeLimit: The maximum size to which storage capacity
 	// can be automatically increased. The default value is 0, which
 	// specifies that there is no limit.
-	StorageAutoResizeLimit int64 `json:"storageAutoResizeLimit,omitempty,string"`
+	StorageAutoResizeLimit int64 `json:"storageAutoResizeLimit,omitempty"`
 
 	// Tier: The tier (or machine type) for this instance, for example
 	// `db-custom-1-3840`. WARNING: Changing this restarts the instance.

--- a/pkg/providers/gcp/gcpiface/database_types.go
+++ b/pkg/providers/gcp/gcpiface/database_types.go
@@ -1,0 +1,389 @@
+package gcpiface
+
+import sqladmin "google.golang.org/api/sqladmin/v1beta4"
+
+type DatabaseInstance struct {
+	// ConnectionName: Connection name of the Cloud SQL instance used in
+	// connection strings.
+	ConnectionName string `json:"connectionName,omitempty"`
+
+	// DatabaseVersion: The database engine type and version. The
+	// `databaseVersion` field cannot be changed after instance creation.
+	//
+	// Possible values:
+	//   "SQL_DATABASE_VERSION_UNSPECIFIED" - This is an unknown database
+	// version.
+	//   "MYSQL_5_1" - The database version is MySQL 5.1.
+	//   "MYSQL_5_5" - The database version is MySQL 5.5.
+	//   "MYSQL_5_6" - The database version is MySQL 5.6.
+	//   "MYSQL_5_7" - The database version is MySQL 5.7.
+	//   "SQLSERVER_2017_STANDARD" - The database version is SQL Server 2017
+	// Standard.
+	//   "SQLSERVER_2017_ENTERPRISE" - The database version is SQL Server
+	// 2017 Enterprise.
+	//   "SQLSERVER_2017_EXPRESS" - The database version is SQL Server 2017
+	// Express.
+	//   "SQLSERVER_2017_WEB" - The database version is SQL Server 2017 Web.
+	//   "POSTGRES_9_6" - The database version is PostgreSQL 9.6.
+	//   "POSTGRES_10" - The database version is PostgreSQL 10.
+	//   "POSTGRES_11" - The database version is PostgreSQL 11.
+	//   "POSTGRES_12" - The database version is PostgreSQL 12.
+	//   "POSTGRES_13" - The database version is PostgreSQL 13.
+	//   "POSTGRES_14" - The database version is PostgreSQL 14.
+	//   "MYSQL_8_0" - The database version is MySQL 8.
+	//   "MYSQL_8_0_18" - The database major version is MySQL 8.0 and the
+	// minor version is 18.
+	//   "MYSQL_8_0_26" - The database major version is MySQL 8.0 and the
+	// minor version is 26.
+	//   "MYSQL_8_0_27" - The database major version is MySQL 8.0 and the
+	// minor version is 27.
+	//   "MYSQL_8_0_28" - The database major version is MySQL 8.0 and the
+	// minor version is 28.
+	//   "MYSQL_8_0_29" - The database major version is MySQL 8.0 and the
+	// minor version is 29.
+	//   "MYSQL_8_0_30" - The database major version is MySQL 8.0 and the
+	// minor version is 30.
+	//   "SQLSERVER_2019_STANDARD" - The database version is SQL Server 2019
+	// Standard.
+	//   "SQLSERVER_2019_ENTERPRISE" - The database version is SQL Server
+	// 2019 Enterprise.
+	//   "SQLSERVER_2019_EXPRESS" - The database version is SQL Server 2019
+	// Express.
+	//   "SQLSERVER_2019_WEB" - The database version is SQL Server 2019 Web.
+	DatabaseVersion string `json:"databaseVersion,omitempty"`
+
+	// DiskEncryptionConfiguration: Disk encryption configuration specific
+	// to an instance.
+	DiskEncryptionConfiguration *sqladmin.DiskEncryptionConfiguration `json:"diskEncryptionConfiguration,omitempty"`
+
+	// FailoverReplica: The name and status of the failover replica.
+	FailoverReplica *DatabaseInstanceFailoverReplica `json:"failoverReplica,omitempty"`
+
+	// GceZone: The Compute Engine zone that the instance is currently
+	// serving from. This value could be different from the zone that was
+	// specified when the instance was created if the instance has failed
+	// over to its secondary zone. WARNING: Changing this might restart the
+	// instance.
+	GceZone string `json:"gceZone,omitempty"`
+
+	// InstanceType: The instance type.
+	//
+	// Possible values:
+	//   "SQL_INSTANCE_TYPE_UNSPECIFIED" - This is an unknown Cloud SQL
+	// instance type.
+	//   "CLOUD_SQL_INSTANCE" - A regular Cloud SQL instance that is not
+	// replicating from a primary instance.
+	//   "ON_PREMISES_INSTANCE" - An instance running on the customer's
+	// premises that is not managed by Cloud SQL.
+	//   "READ_REPLICA_INSTANCE" - A Cloud SQL instance acting as a
+	// read-replica.
+	InstanceType string `json:"instanceType,omitempty"`
+
+	// IpAddresses: The assigned IP addresses for the instance.
+	IpAddresses []*sqladmin.IpMapping `json:"ipAddresses,omitempty"`
+
+	// Kind: This is always `sql#instance`.
+	Kind string `json:"kind,omitempty"`
+
+	// MaintenanceVersion: The current software version on the instance.
+	MaintenanceVersion string `json:"maintenanceVersion,omitempty"`
+
+	// MasterInstanceName: The name of the instance which will act as
+	// primary in the replication setup.
+	MasterInstanceName string `json:"masterInstanceName,omitempty"`
+
+	// MaxDiskSize: The maximum disk size of the instance in bytes.
+	MaxDiskSize int64 `json:"maxDiskSize,omitempty,string"`
+
+	// Name: Name of the Cloud SQL instance. This does not include the
+	// project ID.
+	Name string `json:"name,omitempty"`
+
+	// Project: The project ID of the project containing the Cloud SQL
+	// instance. The Google apps domain is prefixed if applicable.
+	Project string `json:"project,omitempty"`
+
+	// Region: The geographical region. Can be: * `us-central` (`FIRST_GEN`
+	// instances only) * `us-central1` (`SECOND_GEN` instances only) *
+	// `asia-east1` or `europe-west1`. Defaults to `us-central` or
+	// `us-central1` depending on the instance type. The region cannot be
+	// changed after instance creation.
+	Region string `json:"region,omitempty"`
+
+	// ReplicaNames: The replicas of the instance.
+	ReplicaNames []string `json:"replicaNames,omitempty"`
+
+	// RootPassword: Initial root password. Use only on creation. You must
+	// set root passwords before you can connect to PostgreSQL instances.
+	RootPassword string `json:"rootPassword,omitempty"`
+
+	// SecondaryGceZone: The Compute Engine zone that the failover instance
+	// is currently serving from for a regional instance. This value could
+	// be different from the zone that was specified when the instance was
+	// created if the instance has failed over to its secondary/failover
+	// zone.
+	SecondaryGceZone string `json:"secondaryGceZone,omitempty"`
+
+	// SelfLink: The URI of this resource.
+	SelfLink string `json:"selfLink,omitempty"`
+
+	// ServerCaCert: SSL configuration.
+	ServerCaCert *sqladmin.SslCert `json:"serverCaCert,omitempty"`
+
+	// Settings: The user settings.
+	Settings *Settings `json:"settings,omitempty"`
+}
+
+type Settings struct {
+	// ActivationPolicy: The activation policy specifies when the instance
+	// is activated; it is applicable only when the instance state is
+	// RUNNABLE. Valid values: * `ALWAYS`: The instance is on, and remains
+	// so even in the absence of connection requests. * `NEVER`: The
+	// instance is off; it is not activated, even if a connection request
+	// arrives.
+	//
+	// Possible values:
+	//   "SQL_ACTIVATION_POLICY_UNSPECIFIED" - Unknown activation plan.
+	//   "ALWAYS" - The instance is always up and running.
+	//   "NEVER" - The instance never starts.
+	//   "ON_DEMAND" - The instance starts upon receiving requests.
+	ActivationPolicy string `json:"activationPolicy,omitempty"`
+
+	// AvailabilityType: Availability type. Potential values: * `ZONAL`: The
+	// instance serves data from only one zone. Outages in that zone affect
+	// data accessibility. * `REGIONAL`: The instance can serve data from
+	// more than one zone in a region (it is highly available)./ For more
+	// information, see Overview of the High Availability Configuration
+	// (https://cloud.google.com/sql/docs/mysql/high-availability).
+	//
+	// Possible values:
+	//   "SQL_AVAILABILITY_TYPE_UNSPECIFIED" - This is an unknown
+	// Availability type.
+	//   "ZONAL" - Zonal available instance.
+	//   "REGIONAL" - Regional available instance.
+	AvailabilityType string `json:"availabilityType,omitempty"`
+
+	// BackupConfiguration: The daily backup configuration for the instance.
+	BackupConfiguration *BackupConfiguration `json:"backupConfiguration,omitempty"`
+
+	// Collation: The name of server Instance collation.
+	Collation string `json:"collation,omitempty"`
+
+	// ConnectorEnforcement: Specifies if connections must use Cloud SQL
+	// connectors. Option values include the following: `NOT_REQUIRED`
+	// (Cloud SQL instances can be connected without Cloud SQL Connectors)
+	// and `REQUIRED` (Only allow connections that use Cloud SQL Connectors)
+	// Note that using REQUIRED disables all existing authorized networks.
+	// If this field is not specified when creating a new instance,
+	// NOT_REQUIRED is used. If this field is not specified when patching or
+	// updating an existing instance, it is left unchanged in the instance.
+	//
+	// Possible values:
+	//   "CONNECTOR_ENFORCEMENT_UNSPECIFIED" - The requirement for Cloud SQL
+	// connectors is unknown.
+	//   "NOT_REQUIRED" - Do not require Cloud SQL connectors.
+	//   "REQUIRED" - Require all connections to use Cloud SQL connectors,
+	// including the Cloud SQL Auth Proxy and Cloud SQL Java, Python, and Go
+	// connectors. Note: This disables all existing authorized networks.
+	ConnectorEnforcement string `json:"connectorEnforcement,omitempty"`
+
+	// CrashSafeReplicationEnabled: Configuration specific to read replica
+	// instances. Indicates whether database flags for crash-safe
+	// replication are enabled. This property was only applicable to First
+	// Generation instances.
+	CrashSafeReplicationEnabled *bool `json:"crashSafeReplicationEnabled,omitempty,string"`
+
+	// DataDiskSizeGb: The size of data disk, in GB. The data disk size
+	// minimum is 10GB.
+	DataDiskSizeGb int64 `json:"dataDiskSizeGb,omitempty,string"`
+
+	// DataDiskType: The type of data disk: `PD_SSD` (default) or `PD_HDD`.
+	// Not used for First Generation instances.
+	//
+	// Possible values:
+	//   "SQL_DATA_DISK_TYPE_UNSPECIFIED" - This is an unknown data disk
+	// type.
+	//   "PD_SSD" - An SSD data disk.
+	//   "PD_HDD" - An HDD data disk.
+	//   "OBSOLETE_LOCAL_SSD" - This field is deprecated and will be removed
+	// from a future version of the API.
+	DataDiskType string `json:"dataDiskType,omitempty"`
+
+	// DatabaseFlags: The database flags passed to the instance at startup.
+	DatabaseFlags []*sqladmin.DatabaseFlags `json:"databaseFlags,omitempty"`
+
+	// DatabaseReplicationEnabled: Configuration specific to read replica
+	// instances. Indicates whether replication is enabled or not. WARNING:
+	// Changing this restarts the instance.
+	DatabaseReplicationEnabled *bool `json:"databaseReplicationEnabled,omitempty,string"`
+
+	// DeletionProtectionEnabled: Configuration to protect against
+	// accidental instance deletion.
+	DeletionProtectionEnabled *bool `json:"deletionProtectionEnabled,omitempty,string"`
+
+	// DenyMaintenancePeriods: Deny maintenance periods
+	DenyMaintenancePeriods []*sqladmin.DenyMaintenancePeriod `json:"denyMaintenancePeriods,omitempty"`
+
+	// InsightsConfig: Insights configuration, for now relevant only for
+	// Postgres.
+	InsightsConfig *sqladmin.InsightsConfig `json:"insightsConfig,omitempty"`
+
+	// IpConfiguration: The settings for IP Management. This allows to
+	// enable or disable the instance IP and manage which external networks
+	// can connect to the instance. The IPv4 address cannot be disabled for
+	// Second Generation instances.
+	IpConfiguration *IpConfiguration `json:"ipConfiguration,omitempty"`
+
+	// Kind: This is always `sql#settings`.
+	Kind string `json:"kind,omitempty"`
+
+	// LocationPreference: The location preference settings. This allows the
+	// instance to be located as near as possible to either an App Engine
+	// app or Compute Engine zone for better performance. App Engine
+	// co-location was only applicable to First Generation instances.
+	LocationPreference *sqladmin.LocationPreference `json:"locationPreference,omitempty"`
+
+	// MaintenanceWindow: The maintenance window for this instance. This
+	// specifies when the instance can be restarted for maintenance
+	// purposes.
+	MaintenanceWindow *sqladmin.MaintenanceWindow `json:"maintenanceWindow,omitempty"`
+
+	// PasswordValidationPolicy: The local user password validation policy
+	// of the instance.
+	PasswordValidationPolicy *sqladmin.PasswordValidationPolicy `json:"passwordValidationPolicy,omitempty"`
+
+	// PricingPlan: The pricing plan for this instance. This can be either
+	// `PER_USE` or `PACKAGE`. Only `PER_USE` is supported for Second
+	// Generation instances.
+	//
+	// Possible values:
+	//   "SQL_PRICING_PLAN_UNSPECIFIED" - This is an unknown pricing plan
+	// for this instance.
+	//   "PACKAGE" - The instance is billed at a monthly flat rate.
+	//   "PER_USE" - The instance is billed per usage.
+	PricingPlan string `json:"pricingPlan,omitempty"`
+
+	// ReplicationType: The type of replication this instance uses. This can
+	// be either `ASYNCHRONOUS` or `SYNCHRONOUS`. (Deprecated) This property
+	// was only applicable to First Generation instances.
+	//
+	// Possible values:
+	//   "SQL_REPLICATION_TYPE_UNSPECIFIED" - This is an unknown replication
+	// type for a Cloud SQL instance.
+	//   "SYNCHRONOUS" - The synchronous replication mode for First
+	// Generation instances. It is the default value.
+	//   "ASYNCHRONOUS" - The asynchronous replication mode for First
+	// Generation instances. It provides a slight performance gain, but if
+	// an outage occurs while this option is set to asynchronous, you can
+	// lose up to a few seconds of updates to your data.
+	ReplicationType string `json:"replicationType,omitempty"`
+
+	// SettingsVersion: The version of instance settings. This is a required
+	// field for update method to make sure concurrent updates are handled
+	// properly. During update, use the most recent settingsVersion value
+	// for this instance and do not try to update this value.
+	SettingsVersion int64 `json:"settingsVersion,omitempty,string"`
+
+	// StorageAutoResize: Configuration to increase storage size
+	// automatically. The default value is true.
+	StorageAutoResize *bool `json:"storageAutoResize,omitempty,string"`
+
+	// StorageAutoResizeLimit: The maximum size to which storage capacity
+	// can be automatically increased. The default value is 0, which
+	// specifies that there is no limit.
+	StorageAutoResizeLimit int64 `json:"storageAutoResizeLimit,omitempty,string"`
+
+	// Tier: The tier (or machine type) for this instance, for example
+	// `db-custom-1-3840`. WARNING: Changing this restarts the instance.
+	Tier string `json:"tier,omitempty"`
+
+	// UserLabels: User-provided labels, represented as a dictionary where
+	// each label is a single key value pair.
+	UserLabels map[string]string `json:"userLabels,omitempty"`
+}
+
+type DatabaseInstanceFailoverReplica struct {
+	// Available: The availability status of the failover replica. A false
+	// status indicates that the failover replica is out of sync. The
+	// primary instance can only failover to the failover replica when the
+	// status is true.
+	Available *bool `json:"available,omitempty,string"`
+
+	// Name: The name of the failover replica. If specified at instance
+	// creation, a failover replica is created for the instance. The name
+	// doesn't include the project ID.
+	Name string `json:"name,omitempty"`
+}
+
+type BackupConfiguration struct {
+	// BackupRetentionSettings: Backup retention settings.
+	BackupRetentionSettings *BackupRetentionSettings `json:"backupRetentionSettings,omitempty"`
+
+	// BinaryLogEnabled: (MySQL only) Whether binary log is enabled. If
+	// backup configuration is disabled, binarylog must be disabled as well.
+	BinaryLogEnabled *bool `json:"binaryLogEnabled,omitempty,string"`
+
+	// Enabled: Whether this configuration is enabled.
+	Enabled *bool `json:"enabled,omitempty,string"`
+
+	// Kind: This is always `sql#backupConfiguration`.
+	Kind string `json:"kind,omitempty"`
+
+	// Location: Location of the backup
+	Location string `json:"location,omitempty"`
+
+	// PointInTimeRecoveryEnabled: (Postgres only) Whether point in time
+	// recovery is enabled.
+	PointInTimeRecoveryEnabled *bool `json:"pointInTimeRecoveryEnabled,omitempty,string"`
+
+	// ReplicationLogArchivingEnabled: Reserved for future use.
+	ReplicationLogArchivingEnabled *bool `json:"replicationLogArchivingEnabled,omitempty,string"`
+
+	// StartTime: Start time for the daily backup configuration in UTC
+	// timezone in the 24-hour format - `HH:MM`.
+	StartTime string `json:"startTime,omitempty"`
+
+	// TransactionLogRetentionDays: The number of days of transaction logs
+	// we retain for point in time restore, from 1-7.
+	TransactionLogRetentionDays int64 `json:"transactionLogRetentionDays,omitempty"`
+}
+
+type IpConfiguration struct {
+	// AllocatedIpRange: The name of the allocated ip range for the private
+	// ip Cloud SQL instance. For example:
+	// "google-managed-services-default". If set, the instance ip will be
+	// created in the allocated range. The range name must comply with RFC
+	// 1035 (https://tools.ietf.org/html/rfc1035). Specifically, the name
+	// must be 1-63 characters long and match the regular expression
+	// `[a-z]([-a-z0-9]*[a-z0-9])?.`
+	AllocatedIpRange string `json:"allocatedIpRange,omitempty"`
+
+	// AuthorizedNetworks: The list of external networks that are allowed to
+	// connect to the instance using the IP. In 'CIDR' notation, also known
+	// as 'slash' notation (for example: `157.197.200.0/24`).
+	AuthorizedNetworks []*sqladmin.AclEntry `json:"authorizedNetworks,omitempty"`
+
+	// Ipv4Enabled: Whether the instance is assigned a public IP address or
+	// not.
+	Ipv4Enabled *bool `json:"ipv4Enabled,omitempty,string"`
+
+	// PrivateNetwork: The resource link for the VPC network from which the
+	// Cloud SQL instance is accessible for private IP. For example,
+	// `/projects/myProject/global/networks/default`. This setting can be
+	// updated, but it cannot be removed after it is set.
+	PrivateNetwork string `json:"privateNetwork,omitempty"`
+
+	// RequireSsl: Whether SSL connections over IP are enforced or not.
+	RequireSsl *bool `json:"requireSsl,omitempty,string"`
+}
+
+type BackupRetentionSettings struct {
+
+	// The unit that 'retained_backups' represents.
+	RetentionUnit string `json:"retentionUnit,omitempty"`
+	// Depending on the value of retention_unit, this is used to determine
+	// if a backup needs to be deleted.  If retention_unit is 'COUNT', we will
+	// retain this many backups.
+	RetainedBackups int64 `json:"retainedBackups,omitempty,string"`
+	// contains filtered or unexported fields
+}

--- a/pkg/providers/gcp/provider_postgres.go
+++ b/pkg/providers/gcp/provider_postgres.go
@@ -176,7 +176,7 @@ func (p *PostgresProvider) reconcileCloudSQLInstance(ctx context.Context, pg *v1
 		if modifiedInstance != nil {
 			logger.Infof("modifying cloudSQL instance: %s", foundInstance.Name)
 			_, err := sqladminService.ModifyInstance(ctx, strategyConfig.ProjectID, foundInstance.Name, modifiedInstance)
-			if err != nil && !resources.IsNotAlreadyExistsError(err) {
+			if err != nil && !resources.IsNotStatusConflictError(err) {
 				msg := fmt.Sprintf("failed to modify cloudsql instance: %s", foundInstance.Name)
 				return nil, croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
 			}
@@ -595,26 +595,15 @@ func buildCloudSQLUpdateStrategy(cloudSQLConfig *gcpiface.DatabaseInstance, foun
 		modifiedInstance.Settings.BackupConfiguration = &sqladmin.BackupConfiguration{
 			ForceSendFields: []string{},
 		}
-
-		if cloudSQLConfig.Settings.BackupConfiguration != nil && foundInstanceConfig.Settings.BackupConfiguration != nil {
-			if cloudSQLConfig.Settings.BackupConfiguration.Enabled != nil && *cloudSQLConfig.Settings.BackupConfiguration.Enabled != foundInstanceConfig.Settings.BackupConfiguration.Enabled {
-				modifiedInstance.Settings.BackupConfiguration.Enabled = *cloudSQLConfig.Settings.BackupConfiguration.Enabled
-				modifiedInstance.Settings.BackupConfiguration.ForceSendFields = append(modifiedInstance.Settings.BackupConfiguration.ForceSendFields, "Enabled")
-				updateFound = true
-			}
-			if cloudSQLConfig.Settings.BackupConfiguration.PointInTimeRecoveryEnabled != nil && *cloudSQLConfig.Settings.BackupConfiguration.PointInTimeRecoveryEnabled != foundInstanceConfig.Settings.BackupConfiguration.PointInTimeRecoveryEnabled {
-				modifiedInstance.Settings.BackupConfiguration.PointInTimeRecoveryEnabled = *cloudSQLConfig.Settings.BackupConfiguration.PointInTimeRecoveryEnabled
-				modifiedInstance.Settings.BackupConfiguration.ForceSendFields = append(modifiedInstance.Settings.BackupConfiguration.ForceSendFields, "PointInTimeRecoveryEnabled")
-				updateFound = true
-			}
-			if cloudSQLConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetentionUnit != foundInstanceConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetentionUnit {
-				modifiedInstance.Settings.BackupConfiguration.BackupRetentionSettings.RetentionUnit = cloudSQLConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetentionUnit
-				updateFound = true
-			}
-			if cloudSQLConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetainedBackups != foundInstanceConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetainedBackups {
-				modifiedInstance.Settings.BackupConfiguration.BackupRetentionSettings.RetainedBackups = cloudSQLConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetainedBackups
-				updateFound = true
-			}
+		if cloudSQLConfig.Settings.BackupConfiguration.Enabled != nil && *cloudSQLConfig.Settings.BackupConfiguration.Enabled != foundInstanceConfig.Settings.BackupConfiguration.Enabled {
+			modifiedInstance.Settings.BackupConfiguration.Enabled = *cloudSQLConfig.Settings.BackupConfiguration.Enabled
+			modifiedInstance.Settings.BackupConfiguration.ForceSendFields = append(modifiedInstance.Settings.BackupConfiguration.ForceSendFields, "Enabled")
+			updateFound = true
+		}
+		if cloudSQLConfig.Settings.BackupConfiguration.PointInTimeRecoveryEnabled != nil && *cloudSQLConfig.Settings.BackupConfiguration.PointInTimeRecoveryEnabled != foundInstanceConfig.Settings.BackupConfiguration.PointInTimeRecoveryEnabled {
+			modifiedInstance.Settings.BackupConfiguration.PointInTimeRecoveryEnabled = *cloudSQLConfig.Settings.BackupConfiguration.PointInTimeRecoveryEnabled
+			modifiedInstance.Settings.BackupConfiguration.ForceSendFields = append(modifiedInstance.Settings.BackupConfiguration.ForceSendFields, "PointInTimeRecoveryEnabled")
+			updateFound = true
 		}
 	}
 
@@ -653,8 +642,8 @@ func buildCloudSQLUpdateStrategy(cloudSQLConfig *gcpiface.DatabaseInstance, foun
 		if versionUpgradeNeeded {
 			logrus.Info(fmt.Sprintf("Version upgrade found, the current DatabaseVersion is %s and is upgrading to %s", foundInstanceConfig.DatabaseVersion, cloudSQLConfig.DatabaseVersion))
 			modifiedInstance.DatabaseVersion = cloudSQLConfig.DatabaseVersion
+			updateFound = true
 		}
-		updateFound = true
 	}
 
 	if !updateFound {
@@ -696,6 +685,7 @@ func convertDatabaseStruct(cloudSQLCreateConfig *gcpiface.DatabaseInstance) (*sq
 		gcpInstanceConfig.DiskEncryptionConfiguration = cloudSQLCreateConfig.DiskEncryptionConfiguration
 	}
 	if cloudSQLCreateConfig.FailoverReplica != nil {
+		gcpInstanceConfig.FailoverReplica = &sqladmin.DatabaseInstanceFailoverReplica{}
 		if cloudSQLCreateConfig.FailoverReplica.Available != nil {
 			gcpInstanceConfig.FailoverReplica.Available = *cloudSQLCreateConfig.FailoverReplica.Available
 		}

--- a/pkg/providers/gcp/provider_postgres.go
+++ b/pkg/providers/gcp/provider_postgres.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -136,7 +137,7 @@ func (p *PostgresProvider) ReconcilePostgres(ctx context.Context, pg *v1alpha1.P
 	return p.reconcileCloudSQLInstance(ctx, pg, sqlClient, cloudSQLCreateConfig, strategyConfig, maintenanceWindowEnabled)
 }
 
-func (p *PostgresProvider) reconcileCloudSQLInstance(ctx context.Context, pg *v1alpha1.Postgres, sqladminService gcpiface.SQLAdminService, cloudSQLCreateConfig *sqladmin.DatabaseInstance, strategyConfig *StrategyConfig, maintenanceWindowEnabled bool) (*providers.PostgresInstance, croType.StatusMessage, error) {
+func (p *PostgresProvider) reconcileCloudSQLInstance(ctx context.Context, pg *v1alpha1.Postgres, sqladminService gcpiface.SQLAdminService, cloudSQLCreateConfig *gcpiface.DatabaseInstance, strategyConfig *StrategyConfig, maintenanceWindowEnabled bool) (*providers.PostgresInstance, croType.StatusMessage, error) {
 	logger := p.Logger.WithField("action", "reconcileCloudSQLInstance")
 	logger.Infof("reconciling cloudSQL instance")
 
@@ -153,7 +154,8 @@ func (p *PostgresProvider) reconcileCloudSQLInstance(ctx context.Context, pg *v1
 		return nil, croType.StatusMessage(errMsg), errorUtil.Wrapf(err, errMsg)
 	}
 
-	if err := p.buildCloudSQLCreateStrategy(ctx, pg, cloudSQLCreateConfig, sec); err != nil {
+	gcpInstanceConfig, _, err := p.buildCloudSQLCreateStrategy(ctx, pg, cloudSQLCreateConfig, sec)
+	if err != nil {
 		msg := "failed to build and verify gcp cloudSQL instance configuration"
 		return nil, croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
 	}
@@ -164,12 +166,35 @@ func (p *PostgresProvider) reconcileCloudSQLInstance(ctx context.Context, pg *v1
 		return nil, croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
 	}
 
-	// TODO setPostgresServiceMaintenanceMetric,exposePostgresMetrics, createCloudSQLConnectionMetric see MGDAPI-4489
-	// TODO update strategy MGDAPI-4900
+	if maintenanceWindowEnabled {
+		logger.Infof("building cloudSQL update strategy for: %s", foundInstance.Name)
+		modifiedInstance, err := buildCloudSQLUpdateStrategy(cloudSQLCreateConfig, foundInstance, pg)
+		if err != nil {
+			msg := "error building update config for cloudsql instance"
+			return nil, croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
+		}
+		if modifiedInstance != nil {
+			logger.Infof("modifying cloudSQL instance: %s", foundInstance.Name)
+			_, err := sqladminService.ModifyInstance(ctx, strategyConfig.ProjectID, foundInstance.Name, modifiedInstance)
+			if err != nil && !resources.IsNotAlreadyExistsError(err) {
+				msg := fmt.Sprintf("failed to modify cloudsql instance: %s", foundInstance.Name)
+				return nil, croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
+			}
+		}
+
+		//_, err = controllerutil.CreateOrUpdate(ctx, p.Client, pg, func() error {
+		//	pg.Spec.MaintenanceWindow = false
+		//	return nil
+		//})
+		//if err != nil {
+		//	msg := "failed to set postgres maintenance window to false"
+		//	return nil, croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
+		//}
+	}
 
 	if foundInstance == nil {
 		logger.Infof("no instance found, creating one")
-		_, err := sqladminService.CreateInstance(ctx, strategyConfig.ProjectID, cloudSQLCreateConfig)
+		_, err := sqladminService.CreateInstance(ctx, strategyConfig.ProjectID, gcpInstanceConfig)
 		if err != nil && !resources.IsNotFoundError(err) {
 			msg := "failed to create cloudSQL instance"
 			return nil, croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
@@ -372,7 +397,7 @@ func buildPostgresStatusMetricsLabels(cr *v1alpha1.Postgres, clusterID, instance
 	return labels
 }
 
-func (p *PostgresProvider) getPostgresConfig(ctx context.Context, pg *v1alpha1.Postgres) (*sqladmin.DatabaseInstance, *sqladmin.DatabaseInstance, *StrategyConfig, error) {
+func (p *PostgresProvider) getPostgresConfig(ctx context.Context, pg *v1alpha1.Postgres) (*gcpiface.DatabaseInstance, *sqladmin.DatabaseInstance, *StrategyConfig, error) {
 	strategyConfig, err := p.ConfigManager.ReadStorageStrategy(ctx, providers.PostgresResourceType, pg.Spec.Tier)
 	if err != nil {
 		errMsg := "failed to read gcp strategy config"
@@ -405,7 +430,7 @@ func (p *PostgresProvider) getPostgresConfig(ctx context.Context, pg *v1alpha1.P
 		return nil, nil, nil, errorUtil.Wrapf(err, "failed to build cloudsql instance name")
 	}
 
-	cloudSQLCreateConfig := &sqladmin.DatabaseInstance{}
+	cloudSQLCreateConfig := &gcpiface.DatabaseInstance{}
 	if err := json.Unmarshal(strategyConfig.CreateStrategy, cloudSQLCreateConfig); err != nil {
 		return nil, nil, nil, errorUtil.Wrap(err, "failed to unmarshal gcp postgres create request")
 	}
@@ -427,7 +452,7 @@ func (p *PostgresProvider) getPostgresConfig(ctx context.Context, pg *v1alpha1.P
 	return cloudSQLCreateConfig, cloudSQLDeleteConfig, strategyConfig, nil
 }
 
-func (p *PostgresProvider) buildCloudSQLCreateStrategy(ctx context.Context, pg *v1alpha1.Postgres, cloudSQLCreateConfig *sqladmin.DatabaseInstance, sec *v1.Secret) error {
+func (p *PostgresProvider) buildCloudSQLCreateStrategy(ctx context.Context, pg *v1alpha1.Postgres, cloudSQLCreateConfig *gcpiface.DatabaseInstance, sec *v1.Secret) (*sqladmin.DatabaseInstance, *gcpiface.DatabaseInstance, error) {
 
 	if cloudSQLCreateConfig.DatabaseVersion == "" {
 		cloudSQLCreateConfig.DatabaseVersion = defaultGCPCLoudSQLDatabaseVersion
@@ -439,34 +464,34 @@ func (p *PostgresProvider) buildCloudSQLCreateStrategy(ctx context.Context, pg *
 
 	instanceName, err := resources.BuildInfraNameFromObject(ctx, p.Client, pg.ObjectMeta, defaultGcpIdentifierLength)
 	if err != nil {
-		return errorUtil.Wrapf(err, "failed to build instance name")
+		return nil, nil, errorUtil.Wrapf(err, "failed to build instance name")
 	}
 	if cloudSQLCreateConfig.Name == "" {
 		cloudSQLCreateConfig.Name = instanceName
 	}
-
+	
 	if cloudSQLCreateConfig.RootPassword == "" {
 		cloudSQLCreateConfig.RootPassword = string(sec.Data[defaultPostgresPasswordKey])
 	}
 
 	if cloudSQLCreateConfig.Settings == nil {
-		cloudSQLCreateConfig.Settings = &sqladmin.Settings{
+		cloudSQLCreateConfig.Settings = &gcpiface.Settings{
 			Tier:                   defaultTier,
 			AvailabilityType:       defaultAvailabilityType,
 			StorageAutoResizeLimit: defaultStorageAutoResizeLimit,
 			StorageAutoResize:      utils.Bool(defaultStorageAutoResize),
-			BackupConfiguration: &sqladmin.BackupConfiguration{
-				Enabled:                    defaultBackupConfigEnabled,
-				PointInTimeRecoveryEnabled: defaultPointInTimeRecoveryEnabled,
-				BackupRetentionSettings: &sqladmin.BackupRetentionSettings{
+			BackupConfiguration: &gcpiface.BackupConfiguration{
+				Enabled:                    utils.Bool(defaultBackupConfigEnabled),
+				PointInTimeRecoveryEnabled: utils.Bool(defaultPointInTimeRecoveryEnabled),
+				BackupRetentionSettings: &gcpiface.BackupRetentionSettings{
 					RetentionUnit:   defaultBackupRetentionSettingsRetentionUnit,
 					RetainedBackups: defaultBackupRetentionSettingsRetainedBackups,
 				},
 			},
 			DataDiskSizeGb:            defaultDataDiskSizeGb,
-			DeletionProtectionEnabled: defaultDeleteProtectionEnabled,
-			IpConfiguration: &sqladmin.IpConfiguration{
-				Ipv4Enabled: defaultIPConfigIPV4Enabled,
+			DeletionProtectionEnabled: utils.Bool(defaultDeleteProtectionEnabled),
+			IpConfiguration: &gcpiface.IpConfiguration{
+				Ipv4Enabled: utils.Bool(defaultIPConfigIPV4Enabled),
 			},
 		}
 	}
@@ -480,10 +505,10 @@ func (p *PostgresProvider) buildCloudSQLCreateStrategy(ctx context.Context, pg *
 		cloudSQLCreateConfig.Settings.StorageAutoResizeLimit = defaultStorageAutoResizeLimit
 	}
 	if cloudSQLCreateConfig.Settings.BackupConfiguration == nil {
-		cloudSQLCreateConfig.Settings.BackupConfiguration = &sqladmin.BackupConfiguration{
-			Enabled:                    defaultBackupConfigEnabled,
-			PointInTimeRecoveryEnabled: defaultPointInTimeRecoveryEnabled,
-			BackupRetentionSettings: &sqladmin.BackupRetentionSettings{
+		cloudSQLCreateConfig.Settings.BackupConfiguration = &gcpiface.BackupConfiguration{
+			Enabled:                    utils.Bool(defaultBackupConfigEnabled),
+			PointInTimeRecoveryEnabled: utils.Bool(defaultPointInTimeRecoveryEnabled),
+			BackupRetentionSettings: &gcpiface.BackupRetentionSettings{
 				RetentionUnit:   defaultBackupRetentionSettingsRetentionUnit,
 				RetainedBackups: defaultBackupRetentionSettingsRetainedBackups,
 			},
@@ -498,7 +523,136 @@ func (p *PostgresProvider) buildCloudSQLCreateStrategy(ctx context.Context, pg *
 	if cloudSQLCreateConfig.Settings.DataDiskSizeGb == 0 {
 		cloudSQLCreateConfig.Settings.DataDiskSizeGb = defaultDataDiskSizeGb
 	}
-	return nil
+
+	gcpInstanceConfig, err := convertDatabaseStruct(cloudSQLCreateConfig)
+	if err != nil {
+		errMsg := "failed to convert database struct"
+		return nil, nil, errorUtil.Wrap(err, errMsg)
+	}
+
+	return gcpInstanceConfig, cloudSQLCreateConfig, nil
+}
+
+func buildCloudSQLUpdateStrategy(cloudSQLConfig *gcpiface.DatabaseInstance, foundInstanceConfig *sqladmin.DatabaseInstance, pg *v1alpha1.Postgres) (*sqladmin.DatabaseInstance, error) {
+	logrus.Infof("verifying that %s configuration is as expected", foundInstanceConfig.Name)
+	updateFound := false
+	modifiedInstance := &sqladmin.DatabaseInstance{}
+
+	if cloudSQLConfig.Region != foundInstanceConfig.Region {
+		modifiedInstance.Region = cloudSQLConfig.Region
+		updateFound = true
+	}
+
+	if cloudSQLConfig.Settings != nil && foundInstanceConfig.Settings != nil {
+		modifiedInstance.Settings = &sqladmin.Settings{
+			ForceSendFields: []string{},
+		}
+
+		if cloudSQLConfig.Settings.DeletionProtectionEnabled != nil && *cloudSQLConfig.Settings.DeletionProtectionEnabled != foundInstanceConfig.Settings.DeletionProtectionEnabled {
+			modifiedInstance.Settings.DeletionProtectionEnabled = *cloudSQLConfig.Settings.DeletionProtectionEnabled
+			modifiedInstance.Settings.ForceSendFields = append(modifiedInstance.Settings.ForceSendFields, "DeletionProtectionEnabled")
+			updateFound = true
+		}
+
+		if cloudSQLConfig.Settings.StorageAutoResize != nil && *cloudSQLConfig.Settings.StorageAutoResize != *foundInstanceConfig.Settings.StorageAutoResize {
+			modifiedInstance.Settings.StorageAutoResize = cloudSQLConfig.Settings.StorageAutoResize
+			modifiedInstance.Settings.ForceSendFields = append(modifiedInstance.Settings.ForceSendFields, "StorageAutoResize")
+			updateFound = true
+		}
+
+		if cloudSQLConfig.Settings.Tier != foundInstanceConfig.Settings.Tier {
+			modifiedInstance.Settings.Tier = cloudSQLConfig.Settings.Tier
+			updateFound = true
+		}
+		if cloudSQLConfig.Settings.AvailabilityType != foundInstanceConfig.Settings.AvailabilityType {
+			modifiedInstance.Settings.AvailabilityType = cloudSQLConfig.Settings.AvailabilityType
+			updateFound = true
+		}
+		if cloudSQLConfig.Settings.StorageAutoResizeLimit != foundInstanceConfig.Settings.StorageAutoResizeLimit {
+			modifiedInstance.Settings.StorageAutoResizeLimit = cloudSQLConfig.Settings.StorageAutoResizeLimit
+			updateFound = true
+		}
+		if cloudSQLConfig.Settings.DataDiskSizeGb != foundInstanceConfig.Settings.DataDiskSizeGb {
+			modifiedInstance.Settings.DataDiskSizeGb = cloudSQLConfig.Settings.DataDiskSizeGb
+			updateFound = true
+		}
+	}
+
+	if cloudSQLConfig.Settings.BackupConfiguration != nil && foundInstanceConfig.Settings.BackupConfiguration != nil {
+		modifiedInstance.Settings.BackupConfiguration = &sqladmin.BackupConfiguration{
+			ForceSendFields: []string{},
+		}
+
+		if cloudSQLConfig.Settings.BackupConfiguration != nil && foundInstanceConfig.Settings.BackupConfiguration != nil {
+			if cloudSQLConfig.Settings.BackupConfiguration.Enabled != nil && *cloudSQLConfig.Settings.BackupConfiguration.Enabled != foundInstanceConfig.Settings.BackupConfiguration.Enabled {
+				modifiedInstance.Settings.BackupConfiguration.Enabled = *cloudSQLConfig.Settings.BackupConfiguration.Enabled
+				modifiedInstance.Settings.BackupConfiguration.ForceSendFields = append(modifiedInstance.Settings.BackupConfiguration.ForceSendFields, "Enabled")
+				updateFound = true
+			}
+			if cloudSQLConfig.Settings.BackupConfiguration.PointInTimeRecoveryEnabled != nil && *cloudSQLConfig.Settings.BackupConfiguration.PointInTimeRecoveryEnabled != foundInstanceConfig.Settings.BackupConfiguration.PointInTimeRecoveryEnabled {
+				modifiedInstance.Settings.BackupConfiguration.PointInTimeRecoveryEnabled = *cloudSQLConfig.Settings.BackupConfiguration.PointInTimeRecoveryEnabled
+				modifiedInstance.Settings.BackupConfiguration.ForceSendFields = append(modifiedInstance.Settings.BackupConfiguration.ForceSendFields, "PointInTimeRecoveryEnabled")
+				updateFound = true
+			}
+			if cloudSQLConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetentionUnit != foundInstanceConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetentionUnit {
+				modifiedInstance.Settings.BackupConfiguration.BackupRetentionSettings.RetentionUnit = cloudSQLConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetentionUnit
+				updateFound = true
+			}
+			if cloudSQLConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetainedBackups != foundInstanceConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetainedBackups {
+				modifiedInstance.Settings.BackupConfiguration.BackupRetentionSettings.RetainedBackups = cloudSQLConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetainedBackups
+				updateFound = true
+			}
+		}
+	}
+
+	if cloudSQLConfig.Settings.BackupConfiguration.BackupRetentionSettings != nil && foundInstanceConfig.Settings.BackupConfiguration.BackupRetentionSettings != nil {
+		modifiedInstance.Settings.BackupConfiguration.BackupRetentionSettings = &sqladmin.BackupRetentionSettings{}
+
+		if cloudSQLConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetentionUnit != foundInstanceConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetentionUnit {
+			modifiedInstance.Settings.BackupConfiguration.BackupRetentionSettings.RetentionUnit = cloudSQLConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetentionUnit
+			updateFound = true
+		}
+		if cloudSQLConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetainedBackups != foundInstanceConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetainedBackups {
+			modifiedInstance.Settings.BackupConfiguration.BackupRetentionSettings.RetainedBackups = cloudSQLConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetainedBackups
+			updateFound = true
+		}
+	}
+
+	if cloudSQLConfig.Settings.IpConfiguration != nil && foundInstanceConfig.Settings.IpConfiguration != nil {
+		modifiedInstance.Settings.IpConfiguration = &sqladmin.IpConfiguration{
+			ForceSendFields: []string{},
+		}
+		if cloudSQLConfig.Settings.IpConfiguration != nil && foundInstanceConfig.Settings.IpConfiguration != nil {
+			if cloudSQLConfig.Settings.IpConfiguration.Ipv4Enabled != nil && *cloudSQLConfig.Settings.IpConfiguration.Ipv4Enabled != foundInstanceConfig.Settings.IpConfiguration.Ipv4Enabled {
+				modifiedInstance.Settings.IpConfiguration.Ipv4Enabled = *cloudSQLConfig.Settings.IpConfiguration.Ipv4Enabled
+				modifiedInstance.Settings.IpConfiguration.ForceSendFields = append(modifiedInstance.Settings.IpConfiguration.ForceSendFields, "Ipv4Enabled")
+				updateFound = true
+			}
+		}
+	}
+
+	if cloudSQLConfig.DatabaseVersion != "" {
+		//cloudSQLConfigSemverDatabaseVersion := strings.Replace(cloudSQLConfig.DatabaseVersion, "_", ".", -1)
+		//version1 := strings.TrimPrefix(cloudSQLConfigSemverDatabaseVersion, "POSTGRES.")
+		//foundInstanceConfigSemverDatabaseVersion := strings.Replace(foundInstanceConfig.DatabaseVersion, "_", ".", -1)
+		//version2 := strings.TrimPrefix(foundInstanceConfigSemverDatabaseVersion, "POSTGRES.")
+		newVersion, existingVersion := formatGcpPostgresVersion(cloudSQLConfig.DatabaseVersion, foundInstanceConfig.DatabaseVersion)
+		versionUpgradeNeeded, err := resources.VerifyVersionUpgradeNeeded(existingVersion, newVersion)
+		if err != nil {
+			return nil, errorUtil.Wrap(err, "failed to parse database version")
+		}
+		if versionUpgradeNeeded {
+			logrus.Info(fmt.Sprintf("Version upgrade found, the current DatabaseVersion is %s and is upgrading to %s", foundInstanceConfig.DatabaseVersion, cloudSQLConfig.DatabaseVersion))
+			modifiedInstance.DatabaseVersion = cloudSQLConfig.DatabaseVersion
+		}
+		updateFound = true
+	}
+
+	if !updateFound {
+		return nil, nil
+	}
+
+	return modifiedInstance, nil
 }
 
 func buildDefaultCloudSQLSecret(p *v1alpha1.Postgres) (*v1.Secret, error) {
@@ -518,4 +672,210 @@ func buildDefaultCloudSQLSecret(p *v1alpha1.Postgres) (*v1.Secret, error) {
 		},
 		Type: v1.SecretTypeOpaque,
 	}, nil
+}
+
+func convertDatabaseStruct(cloudSQLCreateConfig *gcpiface.DatabaseInstance) (*sqladmin.DatabaseInstance, error) {
+	gcpInstanceConfig := &sqladmin.DatabaseInstance{}
+
+	if cloudSQLCreateConfig.ConnectionName != "" {
+		gcpInstanceConfig.ConnectionName = cloudSQLCreateConfig.ConnectionName
+	}
+	if cloudSQLCreateConfig.DatabaseVersion != "" {
+		gcpInstanceConfig.DatabaseVersion = cloudSQLCreateConfig.DatabaseVersion
+	}
+	if cloudSQLCreateConfig.DiskEncryptionConfiguration != nil {
+		gcpInstanceConfig.DiskEncryptionConfiguration = cloudSQLCreateConfig.DiskEncryptionConfiguration
+	}
+	if cloudSQLCreateConfig.FailoverReplica != nil {
+		if cloudSQLCreateConfig.FailoverReplica.Available != nil {
+			gcpInstanceConfig.FailoverReplica.Available = *cloudSQLCreateConfig.FailoverReplica.Available
+		}
+		if cloudSQLCreateConfig.FailoverReplica.Name != "" {
+			gcpInstanceConfig.FailoverReplica.Name = cloudSQLCreateConfig.FailoverReplica.Name
+		}
+	}
+	if cloudSQLCreateConfig.GceZone != "" {
+		gcpInstanceConfig.GceZone = cloudSQLCreateConfig.GceZone
+	}
+	if cloudSQLCreateConfig.InstanceType != "" {
+		gcpInstanceConfig.InstanceType = cloudSQLCreateConfig.InstanceType
+	}
+	if cloudSQLCreateConfig.IpAddresses != nil {
+		gcpInstanceConfig.IpAddresses = cloudSQLCreateConfig.IpAddresses
+	}
+	if cloudSQLCreateConfig.Kind != "" {
+		gcpInstanceConfig.Kind = cloudSQLCreateConfig.Kind
+	}
+	if cloudSQLCreateConfig.MaintenanceVersion != "" {
+		gcpInstanceConfig.MaintenanceVersion = cloudSQLCreateConfig.MaintenanceVersion
+	}
+	if cloudSQLCreateConfig.MasterInstanceName != "" {
+		gcpInstanceConfig.MasterInstanceName = cloudSQLCreateConfig.MasterInstanceName
+	}
+	if cloudSQLCreateConfig.MaxDiskSize != 0 {
+		gcpInstanceConfig.MaxDiskSize = cloudSQLCreateConfig.MaxDiskSize
+	}
+	if cloudSQLCreateConfig.Name != "" {
+		gcpInstanceConfig.Name = cloudSQLCreateConfig.Name
+	}
+	if cloudSQLCreateConfig.Project != "" {
+		gcpInstanceConfig.Project = cloudSQLCreateConfig.Project
+	}
+	if cloudSQLCreateConfig.Region != "" {
+		gcpInstanceConfig.Region = cloudSQLCreateConfig.Region
+	}
+	if cloudSQLCreateConfig.ReplicaNames != nil {
+		gcpInstanceConfig.ReplicaNames = cloudSQLCreateConfig.ReplicaNames
+	}
+	if cloudSQLCreateConfig.RootPassword != "" {
+		gcpInstanceConfig.RootPassword = cloudSQLCreateConfig.RootPassword
+	}
+	if cloudSQLCreateConfig.SecondaryGceZone != "" {
+		gcpInstanceConfig.GceZone = cloudSQLCreateConfig.SecondaryGceZone
+	}
+	if cloudSQLCreateConfig.SelfLink != "" {
+		gcpInstanceConfig.SelfLink = cloudSQLCreateConfig.SelfLink
+	}
+	if cloudSQLCreateConfig.ServerCaCert != nil {
+		gcpInstanceConfig.ServerCaCert = cloudSQLCreateConfig.ServerCaCert
+	}
+	if cloudSQLCreateConfig.Settings != nil {
+		gcpInstanceConfig.Settings = &sqladmin.Settings{}
+		if cloudSQLCreateConfig.Settings.ActivationPolicy != "" {
+			gcpInstanceConfig.Settings.ActivationPolicy = cloudSQLCreateConfig.Settings.ActivationPolicy
+		}
+		//if cloudSQLCreateConfig.Settings.AvailabilityType != "" {
+		//	gcpInstanceConfig.Settings.AvailabilityType = cloudSQLCreateConfig.Settings.AvailabilityType
+		//}
+		if cloudSQLCreateConfig.Settings.BackupConfiguration != nil {
+			gcpInstanceConfig.Settings.BackupConfiguration = &sqladmin.BackupConfiguration{}
+			if cloudSQLCreateConfig.Settings.BackupConfiguration.BackupRetentionSettings != nil {
+				gcpInstanceConfig.Settings.BackupConfiguration.BackupRetentionSettings = &sqladmin.BackupRetentionSettings{}
+				if cloudSQLCreateConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetentionUnit != "" {
+					gcpInstanceConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetentionUnit = cloudSQLCreateConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetentionUnit
+				}
+				if cloudSQLCreateConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetainedBackups != 0 {
+					gcpInstanceConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetainedBackups = cloudSQLCreateConfig.Settings.BackupConfiguration.BackupRetentionSettings.RetainedBackups
+				}
+			}
+
+			if cloudSQLCreateConfig.Settings.BackupConfiguration.BinaryLogEnabled != nil {
+				gcpInstanceConfig.Settings.BackupConfiguration.BinaryLogEnabled = *cloudSQLCreateConfig.Settings.BackupConfiguration.BinaryLogEnabled
+			}
+			if cloudSQLCreateConfig.Settings.BackupConfiguration.Enabled != nil {
+				gcpInstanceConfig.Settings.BackupConfiguration.Enabled = *cloudSQLCreateConfig.Settings.BackupConfiguration.Enabled
+			}
+			if cloudSQLCreateConfig.Settings.BackupConfiguration.Kind != "" {
+				gcpInstanceConfig.Settings.BackupConfiguration.Kind = cloudSQLCreateConfig.Settings.BackupConfiguration.Kind
+			}
+			if cloudSQLCreateConfig.Settings.BackupConfiguration.Location != "" {
+				gcpInstanceConfig.Settings.BackupConfiguration.Location = cloudSQLCreateConfig.Settings.BackupConfiguration.Location
+			}
+			if cloudSQLCreateConfig.Settings.BackupConfiguration.PointInTimeRecoveryEnabled != nil {
+				gcpInstanceConfig.Settings.BackupConfiguration.PointInTimeRecoveryEnabled = *cloudSQLCreateConfig.Settings.BackupConfiguration.PointInTimeRecoveryEnabled
+			}
+			if cloudSQLCreateConfig.Settings.BackupConfiguration.ReplicationLogArchivingEnabled != nil {
+				gcpInstanceConfig.Settings.BackupConfiguration.ReplicationLogArchivingEnabled = *cloudSQLCreateConfig.Settings.BackupConfiguration.ReplicationLogArchivingEnabled
+			}
+			if cloudSQLCreateConfig.Settings.BackupConfiguration.StartTime != "" {
+				gcpInstanceConfig.Settings.BackupConfiguration.StartTime = cloudSQLCreateConfig.Settings.BackupConfiguration.StartTime
+			}
+			if cloudSQLCreateConfig.Settings.BackupConfiguration.TransactionLogRetentionDays != 0 {
+				gcpInstanceConfig.Settings.BackupConfiguration.TransactionLogRetentionDays = cloudSQLCreateConfig.Settings.BackupConfiguration.TransactionLogRetentionDays
+			}
+		}
+		if cloudSQLCreateConfig.Settings.Collation != "" {
+			gcpInstanceConfig.Settings.Collation = cloudSQLCreateConfig.Settings.Collation
+		}
+		if cloudSQLCreateConfig.Settings.ConnectorEnforcement != "" {
+			gcpInstanceConfig.Settings.ConnectorEnforcement = cloudSQLCreateConfig.Settings.ConnectorEnforcement
+		}
+		if cloudSQLCreateConfig.Settings.CrashSafeReplicationEnabled != nil {
+			gcpInstanceConfig.Settings.CrashSafeReplicationEnabled = *cloudSQLCreateConfig.Settings.CrashSafeReplicationEnabled
+		}
+		if cloudSQLCreateConfig.Settings.DataDiskSizeGb != 0 {
+			gcpInstanceConfig.Settings.DataDiskSizeGb = cloudSQLCreateConfig.Settings.DataDiskSizeGb
+		}
+		if cloudSQLCreateConfig.Settings.DataDiskType != "" {
+			gcpInstanceConfig.Settings.DataDiskType = cloudSQLCreateConfig.Settings.DataDiskType
+		}
+		if cloudSQLCreateConfig.Settings.DatabaseFlags != nil {
+			gcpInstanceConfig.Settings.DatabaseFlags = cloudSQLCreateConfig.Settings.DatabaseFlags
+		}
+		if cloudSQLCreateConfig.Settings.DatabaseReplicationEnabled != nil {
+			gcpInstanceConfig.Settings.DatabaseReplicationEnabled = *cloudSQLCreateConfig.Settings.DatabaseReplicationEnabled
+		}
+		if cloudSQLCreateConfig.Settings.DeletionProtectionEnabled != nil {
+			gcpInstanceConfig.Settings.DeletionProtectionEnabled = *cloudSQLCreateConfig.Settings.DeletionProtectionEnabled
+		}
+		if cloudSQLCreateConfig.Settings.DenyMaintenancePeriods != nil {
+			gcpInstanceConfig.Settings.DenyMaintenancePeriods = cloudSQLCreateConfig.Settings.DenyMaintenancePeriods
+		}
+		if cloudSQLCreateConfig.Settings.InsightsConfig != nil {
+			gcpInstanceConfig.Settings.InsightsConfig = cloudSQLCreateConfig.Settings.InsightsConfig
+		}
+		if cloudSQLCreateConfig.Settings.IpConfiguration != nil {
+			gcpInstanceConfig.Settings.IpConfiguration = &sqladmin.IpConfiguration{}
+			if cloudSQLCreateConfig.Settings.IpConfiguration.AllocatedIpRange != "" {
+				gcpInstanceConfig.Settings.IpConfiguration.AllocatedIpRange = cloudSQLCreateConfig.Settings.IpConfiguration.AllocatedIpRange
+			}
+			if cloudSQLCreateConfig.Settings.IpConfiguration.AuthorizedNetworks != nil {
+				gcpInstanceConfig.Settings.IpConfiguration.AuthorizedNetworks = cloudSQLCreateConfig.Settings.IpConfiguration.AuthorizedNetworks
+			}
+			if cloudSQLCreateConfig.Settings.IpConfiguration.AuthorizedNetworks != nil {
+				gcpInstanceConfig.Settings.IpConfiguration.AuthorizedNetworks = cloudSQLCreateConfig.Settings.IpConfiguration.AuthorizedNetworks
+			}
+			if cloudSQLCreateConfig.Settings.IpConfiguration.Ipv4Enabled != nil {
+				gcpInstanceConfig.Settings.IpConfiguration.Ipv4Enabled = *cloudSQLCreateConfig.Settings.IpConfiguration.Ipv4Enabled
+			}
+			if cloudSQLCreateConfig.Settings.IpConfiguration.PrivateNetwork != "" {
+				gcpInstanceConfig.Settings.IpConfiguration.PrivateNetwork = cloudSQLCreateConfig.Settings.IpConfiguration.PrivateNetwork
+			}
+			if cloudSQLCreateConfig.Settings.IpConfiguration.RequireSsl != nil {
+				gcpInstanceConfig.Settings.IpConfiguration.RequireSsl = *cloudSQLCreateConfig.Settings.IpConfiguration.RequireSsl
+			}
+		}
+		if cloudSQLCreateConfig.Settings.Kind != "" {
+			gcpInstanceConfig.Settings.Kind = cloudSQLCreateConfig.Settings.Kind
+		}
+		if cloudSQLCreateConfig.Settings.LocationPreference != nil {
+			gcpInstanceConfig.Settings.LocationPreference = cloudSQLCreateConfig.Settings.LocationPreference
+		}
+		if cloudSQLCreateConfig.Settings.MaintenanceWindow != nil {
+			gcpInstanceConfig.Settings.MaintenanceWindow = cloudSQLCreateConfig.Settings.MaintenanceWindow
+		}
+		if cloudSQLCreateConfig.Settings.PasswordValidationPolicy != nil {
+			gcpInstanceConfig.Settings.PasswordValidationPolicy = cloudSQLCreateConfig.Settings.PasswordValidationPolicy
+		}
+		if cloudSQLCreateConfig.Settings.PricingPlan != "" {
+			gcpInstanceConfig.Settings.PricingPlan = cloudSQLCreateConfig.Settings.PricingPlan
+		}
+		if cloudSQLCreateConfig.Settings.ReplicationType != "" {
+			gcpInstanceConfig.Settings.ReplicationType = cloudSQLCreateConfig.Settings.ReplicationType
+		}
+		if cloudSQLCreateConfig.Settings.SettingsVersion != 0 {
+			gcpInstanceConfig.Settings.SettingsVersion = cloudSQLCreateConfig.Settings.SettingsVersion
+		}
+		if cloudSQLCreateConfig.Settings.StorageAutoResize != nil {
+			gcpInstanceConfig.Settings.StorageAutoResize = cloudSQLCreateConfig.Settings.StorageAutoResize
+		}
+		if cloudSQLCreateConfig.Settings.StorageAutoResizeLimit != 0 {
+			gcpInstanceConfig.Settings.StorageAutoResizeLimit = cloudSQLCreateConfig.Settings.StorageAutoResizeLimit
+		}
+		if cloudSQLCreateConfig.Settings.Tier != "" {
+			gcpInstanceConfig.Settings.Tier = cloudSQLCreateConfig.Settings.Tier
+		}
+		if cloudSQLCreateConfig.Settings.UserLabels != nil {
+			gcpInstanceConfig.Settings.UserLabels = cloudSQLCreateConfig.Settings.UserLabels
+		}
+	}
+	return gcpInstanceConfig, nil
+}
+
+func formatGcpPostgresVersion(gcpNewVersion string, gcpExistingVersion string) (semverNewVersion string, semverExistingVersion string) {
+	cloudSQLConfigSemverDatabaseVersion := strings.Replace(gcpNewVersion, "_", ".", -1)
+	semverNewVersion = strings.TrimPrefix(cloudSQLConfigSemverDatabaseVersion, "POSTGRES.")
+	foundInstanceConfigSemverDatabaseVersion := strings.Replace(gcpExistingVersion, "_", ".", -1)
+	semverExistingVersion = strings.TrimPrefix(foundInstanceConfigSemverDatabaseVersion, "POSTGRES.")
+	return semverNewVersion, semverExistingVersion
 }

--- a/pkg/providers/gcp/provider_postgres.go
+++ b/pkg/providers/gcp/provider_postgres.go
@@ -167,7 +167,7 @@ func (p *PostgresProvider) reconcileCloudSQLInstance(ctx context.Context, pg *v1
 	}
 
 	if maintenanceWindowEnabled {
-		logger.Infof("building cloudSQL update strategy for: %s", foundInstance.Name)
+		logger.Infof("building cloudSQL update config for: %s", foundInstance.Name)
 		modifiedInstance, err := buildCloudSQLUpdateStrategy(cloudSQLCreateConfig, foundInstance, pg)
 		if err != nil {
 			msg := "error building update config for cloudsql instance"
@@ -182,14 +182,14 @@ func (p *PostgresProvider) reconcileCloudSQLInstance(ctx context.Context, pg *v1
 			}
 		}
 
-		//_, err = controllerutil.CreateOrUpdate(ctx, p.Client, pg, func() error {
-		//	pg.Spec.MaintenanceWindow = false
-		//	return nil
-		//})
-		//if err != nil {
-		//	msg := "failed to set postgres maintenance window to false"
-		//	return nil, croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
-		//}
+		_, err = controllerutil.CreateOrUpdate(ctx, p.Client, pg, func() error {
+			pg.Spec.MaintenanceWindow = false
+			return nil
+		})
+		if err != nil {
+			msg := "failed to set postgres maintenance window to false"
+			return nil, croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
+		}
 	}
 
 	if foundInstance == nil {
@@ -469,9 +469,14 @@ func (p *PostgresProvider) buildCloudSQLCreateStrategy(ctx context.Context, pg *
 	if cloudSQLCreateConfig.Name == "" {
 		cloudSQLCreateConfig.Name = instanceName
 	}
-	
+
 	if cloudSQLCreateConfig.RootPassword == "" {
 		cloudSQLCreateConfig.RootPassword = string(sec.Data[defaultPostgresPasswordKey])
+	}
+
+	tags, err := buildDefaultPostgresTags(ctx, p.Client, pg)
+	if err != nil {
+		return nil, nil, errorUtil.Wrap(err, "failed to build gcp postgres instance tags")
 	}
 
 	if cloudSQLCreateConfig.Settings == nil {
@@ -493,8 +498,16 @@ func (p *PostgresProvider) buildCloudSQLCreateStrategy(ctx context.Context, pg *
 			IpConfiguration: &gcpiface.IpConfiguration{
 				Ipv4Enabled: utils.Bool(defaultIPConfigIPV4Enabled),
 			},
+			UserLabels: tags,
 		}
 	}
+	if cloudSQLCreateConfig.Settings.UserLabels == nil {
+		cloudSQLCreateConfig.Settings.UserLabels = map[string]string{}
+	}
+	for key, value := range tags {
+		cloudSQLCreateConfig.Settings.UserLabels[key] = value
+	}
+
 	if cloudSQLCreateConfig.Settings.Tier == "" {
 		cloudSQLCreateConfig.Settings.Tier = defaultTier
 	}
@@ -632,10 +645,6 @@ func buildCloudSQLUpdateStrategy(cloudSQLConfig *gcpiface.DatabaseInstance, foun
 	}
 
 	if cloudSQLConfig.DatabaseVersion != "" {
-		//cloudSQLConfigSemverDatabaseVersion := strings.Replace(cloudSQLConfig.DatabaseVersion, "_", ".", -1)
-		//version1 := strings.TrimPrefix(cloudSQLConfigSemverDatabaseVersion, "POSTGRES.")
-		//foundInstanceConfigSemverDatabaseVersion := strings.Replace(foundInstanceConfig.DatabaseVersion, "_", ".", -1)
-		//version2 := strings.TrimPrefix(foundInstanceConfigSemverDatabaseVersion, "POSTGRES.")
 		newVersion, existingVersion := formatGcpPostgresVersion(cloudSQLConfig.DatabaseVersion, foundInstanceConfig.DatabaseVersion)
 		versionUpgradeNeeded, err := resources.VerifyVersionUpgradeNeeded(existingVersion, newVersion)
 		if err != nil {
@@ -744,9 +753,9 @@ func convertDatabaseStruct(cloudSQLCreateConfig *gcpiface.DatabaseInstance) (*sq
 		if cloudSQLCreateConfig.Settings.ActivationPolicy != "" {
 			gcpInstanceConfig.Settings.ActivationPolicy = cloudSQLCreateConfig.Settings.ActivationPolicy
 		}
-		//if cloudSQLCreateConfig.Settings.AvailabilityType != "" {
-		//	gcpInstanceConfig.Settings.AvailabilityType = cloudSQLCreateConfig.Settings.AvailabilityType
-		//}
+		if cloudSQLCreateConfig.Settings.AvailabilityType != "" {
+			gcpInstanceConfig.Settings.AvailabilityType = cloudSQLCreateConfig.Settings.AvailabilityType
+		}
 		if cloudSQLCreateConfig.Settings.BackupConfiguration != nil {
 			gcpInstanceConfig.Settings.BackupConfiguration = &sqladmin.BackupConfiguration{}
 			if cloudSQLCreateConfig.Settings.BackupConfiguration.BackupRetentionSettings != nil {

--- a/pkg/providers/gcp/provider_postgres.go
+++ b/pkg/providers/gcp/provider_postgres.go
@@ -168,7 +168,7 @@ func (p *PostgresProvider) reconcileCloudSQLInstance(ctx context.Context, pg *v1
 
 	if maintenanceWindowEnabled {
 		logger.Infof("building cloudSQL update config for: %s", foundInstance.Name)
-		modifiedInstance, err := buildCloudSQLUpdateStrategy(cloudSQLCreateConfig, foundInstance, pg)
+		modifiedInstance, err := buildCloudSQLUpdateStrategy(cloudSQLCreateConfig, foundInstance)
 		if err != nil {
 			msg := "error building update config for cloudsql instance"
 			return nil, croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
@@ -181,7 +181,6 @@ func (p *PostgresProvider) reconcileCloudSQLInstance(ctx context.Context, pg *v1
 				return nil, croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
 			}
 		}
-
 		_, err = controllerutil.CreateOrUpdate(ctx, p.Client, pg, func() error {
 			pg.Spec.MaintenanceWindow = false
 			return nil
@@ -290,7 +289,7 @@ func (p *PostgresProvider) deleteCloudSQLInstance(ctx context.Context, networkMa
 		}
 		if !foundInstance.Settings.DeletionProtectionEnabled {
 			_, err = sqladminService.DeleteInstance(ctx, strategyConfig.ProjectID, foundInstance.Name)
-			if err != nil && !resources.IsNotFoundError(err) {
+			if err != nil && !resources.IsNotStatusConflictError(err) {
 				msg := fmt.Sprintf("failed to delete postgres instance: %s", cloudSQLDeleteConfig.Name)
 				return croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
 			}
@@ -309,7 +308,7 @@ func (p *PostgresProvider) deleteCloudSQLInstance(ctx context.Context, networkMa
 			msg := fmt.Sprintf("failed to modify cloudsql instance: %s", cloudSQLDeleteConfig.Name)
 			return croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
 		}
-		return croType.StatusMessage("modifying instance"), nil
+		return "modifying instance", nil
 	}
 
 	logger.Info("deleting cloudSQL secret")
@@ -353,8 +352,10 @@ func (p *PostgresProvider) deleteCloudSQLInstance(ctx context.Context, networkMa
 		msg := "failed to update instance as part of finalizer reconcile"
 		return croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
 	}
+	msg := fmt.Sprintf("successfully deleted gcp postgres instance %s", cloudSQLDeleteConfig.Name)
+	p.Logger.Info(msg)
 
-	return croType.StatusEmpty, nil
+	return croType.StatusMessage(msg), nil
 }
 
 // set metrics about the postgres instance being deleted
@@ -430,10 +431,14 @@ func (p *PostgresProvider) getPostgresConfig(ctx context.Context, pg *v1alpha1.P
 		return nil, nil, nil, errorUtil.Wrapf(err, "failed to build cloudsql instance name")
 	}
 
-	cloudSQLCreateConfig := &gcpiface.DatabaseInstance{}
-	if err := json.Unmarshal(strategyConfig.CreateStrategy, cloudSQLCreateConfig); err != nil {
+	createInstanceRequest := struct {
+		Instance *gcpiface.DatabaseInstance `json:"instance,omitempty"`
+	}{}
+	if err := json.Unmarshal(strategyConfig.CreateStrategy, &createInstanceRequest); err != nil {
 		return nil, nil, nil, errorUtil.Wrap(err, "failed to unmarshal gcp postgres create request")
 	}
+	cloudSQLCreateConfig := createInstanceRequest.Instance
+
 	if cloudSQLCreateConfig.Name == "" {
 		cloudSQLCreateConfig.Name = instanceID
 	}
@@ -546,7 +551,7 @@ func (p *PostgresProvider) buildCloudSQLCreateStrategy(ctx context.Context, pg *
 	return gcpInstanceConfig, cloudSQLCreateConfig, nil
 }
 
-func buildCloudSQLUpdateStrategy(cloudSQLConfig *gcpiface.DatabaseInstance, foundInstanceConfig *sqladmin.DatabaseInstance, pg *v1alpha1.Postgres) (*sqladmin.DatabaseInstance, error) {
+func buildCloudSQLUpdateStrategy(cloudSQLConfig *gcpiface.DatabaseInstance, foundInstanceConfig *sqladmin.DatabaseInstance) (*sqladmin.DatabaseInstance, error) {
 	logrus.Infof("verifying that %s configuration is as expected", foundInstanceConfig.Name)
 	updateFound := false
 	modifiedInstance := &sqladmin.DatabaseInstance{}

--- a/pkg/providers/gcp/tags.go
+++ b/pkg/providers/gcp/tags.go
@@ -25,3 +25,20 @@ func buildDefaultRedisTags(ctx context.Context, client k8sclient.Client, r *v1al
 	}
 	return tags, nil
 }
+
+func buildDefaultPostgresTags(ctx context.Context, client k8sclient.Client, pg *v1alpha1.Postgres) (map[string]string, error) {
+	defaultTags, _, err := resources.GetDefaultResourceTags(ctx, client, pg.Spec.Type, pg.Name, pg.ObjectMeta.Labels["productName"])
+	if err != nil {
+		return nil, errorUtil.Wrapf(err, "failed to get default postgres tags")
+	}
+	tags := make(map[string]string, len(defaultTags))
+	// GCP labels cannot have uppercase, dash or slash characters
+	// ref: https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements
+	replacer := strings.NewReplacer(".", "-", "/", "_")
+	for _, tag := range defaultTags {
+		key := strings.ToLower(replacer.Replace(tag.Key))
+		value := strings.ToLower(replacer.Replace(tag.Value))
+		tags[key] = value
+	}
+	return tags, nil
+}

--- a/pkg/providers/gcp/tags_test.go
+++ b/pkg/providers/gcp/tags_test.go
@@ -78,3 +78,71 @@ func Test_buildDefaultRedisTags(t *testing.T) {
 		})
 	}
 }
+
+func Test_buildDefaultPostgresTags(t *testing.T) {
+	scheme, err := buildTestScheme()
+	if err != nil {
+		t.Fatal("failed to build scheme", err)
+	}
+	type args struct {
+		ctx    context.Context
+		client client.Client
+		pg     *v1alpha1.Postgres
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "success building default postgres tags",
+			args: args{
+				client: moqClient.NewSigsClientMoqWithScheme(scheme, buildTestGcpInfrastructure(nil)),
+				pg: &v1alpha1.Postgres{
+					ObjectMeta: v1.ObjectMeta{
+						Name: testName,
+					},
+					Spec: types.ResourceTypeSpec{
+						Type: "testType",
+					},
+				},
+			},
+			want: map[string]string{
+				"integreatly-org_clusterid":     gcpTestClusterName,
+				"integreatly-org_resource-name": "testname",
+				"integreatly-org_resource-type": "testtype",
+				resources.TagManagedKey:         "true",
+			},
+			wantErr: false,
+		},
+		{
+			name: "failure building default postgres tags",
+			args: args{
+				client: moqClient.NewSigsClientMoqWithScheme(scheme),
+				pg: &v1alpha1.Postgres{
+					ObjectMeta: v1.ObjectMeta{
+						Name: testName,
+					},
+					Spec: types.ResourceTypeSpec{
+						Type: "testType",
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildDefaultPostgresTags(tt.args.ctx, tt.args.client, tt.args.pg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildDefaultPostgresTags() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildDefaultPostgresTags() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/resources/errors.go
+++ b/pkg/resources/errors.go
@@ -33,6 +33,28 @@ func IsNotFoundError(err error) bool {
 	return false
 }
 
+func IsNotAlreadyExistsError(err error) bool {
+	var googleHttpErr *googleHTTP.Error
+	if errors.As(err, &googleHttpErr) {
+		if googleHttpErr.Code == http.StatusConflict {
+			return true
+		}
+	}
+	var googleGrpcErr *googleGRPC.APIError
+	if errors.As(err, &googleGrpcErr) {
+		if googleGrpcErr.GRPCStatus().Code() == grpcCodes.AlreadyExists {
+			return true
+		}
+	}
+	var k8sErr *k8sErrors.StatusError
+	if errors.As(err, &k8sErr) {
+		if k8sErr.ErrStatus.Code == http.StatusConflict {
+			return true
+		}
+	}
+	return false
+}
+
 type ErrorGRPC struct {
 	grpcCode grpcCodes.Code
 	message  string

--- a/pkg/resources/errors.go
+++ b/pkg/resources/errors.go
@@ -33,7 +33,7 @@ func IsNotFoundError(err error) bool {
 	return false
 }
 
-func IsNotAlreadyExistsError(err error) bool {
+func IsNotStatusConflictError(err error) bool {
 	var googleHttpErr *googleHTTP.Error
 	if errors.As(err, &googleHttpErr) {
 		if googleHttpErr.Code == http.StatusConflict {


### PR DESCRIPTION
## Overview
Jira: [MGDAPI-4900](https://issues.redhat.com/browse/MGDAPI-4900)


## Verification
- Provision a GCP cluster
    - From the master branch of the [Delorean](https://github.com/integr8ly/delorean) repo create a file in the root of the repo called gcp_service_account.json. Request GCP credentials and add these to this file.
    - Run `make -f make/ocm.mk ocm/cluster.json BYOC=true CLOUD_PROVIDER=gcp`
    - Edit the cluster.json file to update the name (and remove the expiration timestamp if necessary) You can also reduce the number of nodes to 3.
    - Run `make ocm/cluster/create`

- Create a Postgres instance
   - Checkout this pull request `gh pr checkout <PR>`
   - Log in to your cluster and run `PROVIDER=gcp make cluster/prepare`
   - Run cro `make run`
   - Create a Postgres CR `PROVIDER=gcp make cluster/seed/postgres` and wait for it to provision.
   - On the command line view the current list of instances `gcloud sql instances list`
   - Alternatively you can view your instance on the GCP [console](https://console.cloud.google.com/sql/instances?project=rhoam-317914).

- Update the Postgres instance by patching the strategy config map, and setting the maintenance window to true.
   - Update the database version :
   ``` 
   oc patch configmap cloud-resources-gcp-strategies -n cloud-resource-operator --type=json -p'[{"op":"replace","path":"/data/postgres","value":"{\"development\":{\"region\":\"\",\"projectID\":\"\",\"createStrategy\":{\"instance\":{\"databaseVersion\":\"POSTGRES_14\"}},\"deleteStrategy\":{}}}"}]' 
   oc patch postgres example-postgres -n cloud-resource-operator --type=json -p='[{"op":"replace","path":"/spec/maintenanceWindow","value":true}]'
   ```
   - Wait until it updates and check that it has updated correctly by viewing the instance details
 `gcloud sql instances describe <INSTANCE_NAME>`

   - Update another setting (Other settings cannot be changed at the same time as the database version).
   ```
   oc patch configmap cloud-resources-gcp-strategies -n cloud-resource-operator --type=json -p'[{"op":"replace","path":"/data/postgres","value":"{\"development\":{\"region\":\"\",\"projectID\":\"\",\"createStrategy\":{\"instance\":{\"settings\":{\"storageAutoResizeLimit\":\"80\"}}},\"deleteStrategy\":{}}}"}]' 
   oc patch postgres example-postgres -n cloud-resource-operator --type=json -p='[{"op":"replace","path":"/spec/maintenanceWindow","value":true}]'
   ```

    - Wait until it updates and check that it has updated correctly by viewing the instance details
    `gcloud sql instances describe <INSTANCE_NAME>`

 - Delete the Postgres CR and GCP Postgres Instance
 `oc delete postgres example-postgres -n cloud-resource-operator`

   

