### PR TITLE
MGDAPI-5153 Update default workshop PostgreSQL version from 10.x to 13.x

### DIFF
--- a/pkg/providers/openshift/provider_postgres.go
+++ b/pkg/providers/openshift/provider_postgres.go
@@ -446,7 +446,7 @@ func buildDefaultPostgresPodContainers(ps *v1alpha1.Postgres) []v1.Container {
 	return []v1.Container{
 		{
 			Name:  ps.Name,
-			Image: "registry.redhat.io/rhscl/postgresql-10-rhel7",
+			Image: "registry.redhat.io/rhscl/postgresql-13-rhel7",
 			Ports: []v1.ContainerPort{
 				{
 					ContainerPort: int32(defaultPostgresPort),


### PR DESCRIPTION
## Overview

Jira: [MGDAPI-5153](https://issues.redhat.com/browse/MGDAPI-5153)

## Verification

- Clone this branch
- Prepare the cluster for CRO: `make cluster/prepare`
- Run the operator locally: `make run`
- Create the Postgre CR: `make cluster/seed/workshop/postgres`
- Wait for Postgres CR to reconcile
- Verify that the version of `psql` inside the postgres pod is `13.7`: 
```
oc rsh $(oc get pods -n cloud-resource-operator --no-headers | awk '{print $1}') psql -V
```
