### PR TITLE
MGDAPI-5303 Annotation missing from CRO CR's on GCP

### DIFF
--- a/pkg/providers/gcp/provider_postgres.go
+++ b/pkg/providers/gcp/provider_postgres.go
@@ -173,6 +173,16 @@ func (p *PostgresProvider) reconcileCloudSQLInstance(ctx context.Context, pg *v1
 	}
 	defer p.exposePostgresInstanceMetrics(ctx, pg, foundInstance)
 
+	if foundInstance != nil {
+		if !annotations.Has(pg, ResourceIdentifierAnnotation) {
+			annotations.Add(pg, ResourceIdentifierAnnotation, foundInstance.Name)
+			if err := p.Client.Update(ctx, pg); err != nil {
+				msg := "failed to add annotation to postgres cr"
+				return nil, croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
+			}
+		}
+	}
+
 	if foundInstance == nil {
 		logger.Infof("no instance found, creating one")
 		_, err := sqladminService.CreateInstance(ctx, strategyConfig.ProjectID, gcpInstanceConfig.MapToGcpDatabaseInstance())

--- a/pkg/providers/gcp/provider_redis.go
+++ b/pkg/providers/gcp/provider_redis.go
@@ -128,6 +128,17 @@ func (p *RedisProvider) createRedisInstance(ctx context.Context, networkManager 
 		return nil, croType.StatusMessage(statusMessage), errorUtil.Wrap(err, statusMessage)
 	}
 	defer p.exposeRedisInstanceMetrics(ctx, r, foundInstance)
+
+	if foundInstance != nil {
+		if !annotations.Has(r, ResourceIdentifierAnnotation) {
+			annotations.Add(r, ResourceIdentifierAnnotation, createInstanceRequest.InstanceId)
+			if err := p.Client.Update(ctx, r); err != nil {
+				statusMessage := "failed to add annotation to redis cr"
+				return nil, croType.StatusMessage(statusMessage), errorUtil.Wrap(err, statusMessage)
+			}
+		}
+	}
+
 	if foundInstance == nil {
 		_, err = redisClient.CreateInstance(ctx, createInstanceRequest)
 		if err != nil {

--- a/pkg/providers/gcp/provider_redis_test.go
+++ b/pkg/providers/gcp/provider_redis_test.go
@@ -1196,6 +1196,9 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      testName,
 						Namespace: testNs,
+						Annotations: map[string]string{
+							ResourceIdentifierAnnotation: testName,
+						},
 					},
 					Spec: types.ResourceTypeSpec{
 						Tier: "development",
@@ -1530,6 +1533,9 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      testName,
 						Namespace: testNs,
+						Annotations: map[string]string{
+							ResourceIdentifierAnnotation: testName,
+						},
 					},
 					Spec: types.ResourceTypeSpec{
 						Tier: "development",
@@ -1580,6 +1586,9 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      testName,
 						Namespace: testNs,
+						Annotations: map[string]string{
+							ResourceIdentifierAnnotation: testName,
+						},
 					},
 					Spec: types.ResourceTypeSpec{
 						Tier: "development",
@@ -1634,6 +1643,9 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      testName,
 						Namespace: testNs,
+						Annotations: map[string]string{
+							ResourceIdentifierAnnotation: testName,
+						},
 					},
 					Spec: types.ResourceTypeSpec{
 						Tier: "development",
@@ -1697,6 +1709,9 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      testName,
 						Namespace: testNs,
+						Annotations: map[string]string{
+							ResourceIdentifierAnnotation: testName,
+						},
 					},
 					Spec: types.ResourceTypeSpec{
 						Tier: "development",
@@ -1753,6 +1768,9 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      testName,
 						Namespace: testNs,
+						Annotations: map[string]string{
+							ResourceIdentifierAnnotation: testName,
+						},
 					},
 					Spec: types.ResourceTypeSpec{
 						Tier: "development",
@@ -1814,6 +1832,9 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      testName,
 						Namespace: testNs,
+						Annotations: map[string]string{
+							ResourceIdentifierAnnotation: testName,
+						},
 					},
 					Spec: types.ResourceTypeSpec{
 						Tier: "development",
@@ -1874,6 +1895,9 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      testName,
 						Namespace: testNs,
+						Annotations: map[string]string{
+							ResourceIdentifierAnnotation: testName,
+						},
 					},
 					Spec: types.ResourceTypeSpec{
 						Tier: "development",


### PR DESCRIPTION
## Overview

Jira: [MGDAPI-5303](https://issues.redhat.com/browse/MGDAPI-5303)
Adding logic to add the resourceIdentifier annotation to postgres and redis CRs if they have not been successfully added on creation of these resources.

## Verification

  - Provision a GCP cluster
    - From the master branch of the [Delorean](https://github.com/integr8ly/delorean) repo create a file in the root of the repo called gcp_service_account.json. Request GCP credentials and add these to this file.
    - Run make -f make/ocm.mk ocm/cluster.json BYOC=true CLOUD_PROVIDER=gcp
    - Edit the cluster.json file to update the name (and remove the expiration timestamp if necessary) You can also reduce the number of nodes to 3.
    - Run `make ocm/cluster/create`

- Create a Postgres instance
    - Checkout this pull request `gh pr checkout 667`
    - Log in to your cluster and run `PROVIDER=gcp make cluster/prepare`
    - Run CRO `make run`
    - Create a Postgres CR `PROVIDER=gcp make cluster/seed/postgres` and wait for the instance to provision.
    - You can view it in the console [here](https://console.cloud.google.com/sql/instances?project=rhoam-317914), or using the gcloud cli `gcloud sql instances list`
    - Navigate to the postgres CR in OSD, remove the `resourceIdentifier` annotation and see that CRO puts it back.

- Create a Redis instance
    - Create a Redis CR `PROVIDER=gcp make cluster/seed/redis` and wait for the instance to provision.
    - You can view it in the console [here](https://console.cloud.google.com/memorystore/redis/instances?referrer=search&project=rhoam-317914), or using the gcloud cli `gcloud redis instances list`
    - Navigate to the redis CR in OSD, remove the `resourceIdentifier` annotation and see that CRO puts it back.

- Delete Postgres and Redis Instances
``` 
oc delete postgres example-postgres -n cloud-resource-operator
oc delete redis example-redis -n cloud-resource-operator
```
- Cleanup and remove cluster.
