### PR TITLE
MGDAPI-5220 allowing default redis and postgres gcp versions to be ex…

### DIFF
--- a/pkg/providers/gcp/provider_postgres.go
+++ b/pkg/providers/gcp/provider_postgres.go
@@ -31,7 +31,7 @@ const (
 	postgresProviderName                          = "gcp-cloudsql"
 	ResourceIdentifierAnnotation                  = "resourceIdentifier"
 	defaultCredSecSuffix                          = "-gcp-sql-credentials"
-	defaultGCPCLoudSQLDatabaseVersion             = "POSTGRES_13"
+	DefaultGCPCLoudSQLDatabaseVersion             = "POSTGRES_13"
 	defaultGCPCloudSQLRegion                      = "us-central1"
 	defaultGCPPostgresUser                        = "postgres"
 	defaultPostgresPasswordKey                    = "password"
@@ -457,7 +457,7 @@ func (p *PostgresProvider) buildCloudSQLCreateStrategy(ctx context.Context, pg *
 		instance.Name = instanceID
 	}
 	if instance.DatabaseVersion == "" {
-		instance.DatabaseVersion = defaultGCPCLoudSQLDatabaseVersion
+		instance.DatabaseVersion = DefaultGCPCLoudSQLDatabaseVersion
 	}
 	if instance.Region == "" {
 		instance.Region = strategyConfig.Region

--- a/pkg/providers/gcp/provider_postgres_test.go
+++ b/pkg/providers/gcp/provider_postgres_test.go
@@ -1387,7 +1387,7 @@ func TestPostgresProvider_reconcileCloudSQLInstance(t *testing.T) {
 						return &sqladmin.DatabaseInstance{
 							Name:            gcpTestPostgresInstanceName,
 							State:           "RUNNABLE",
-							DatabaseVersion: defaultGCPCLoudSQLDatabaseVersion,
+							DatabaseVersion: DefaultGCPCLoudSQLDatabaseVersion,
 							Settings: &sqladmin.Settings{
 								BackupConfiguration: &sqladmin.BackupConfiguration{
 									BackupRetentionSettings: &sqladmin.BackupRetentionSettings{
@@ -1435,7 +1435,7 @@ func TestPostgresProvider_reconcileCloudSQLInstance(t *testing.T) {
 						return &sqladmin.DatabaseInstance{
 							Name:            gcpTestPostgresInstanceName,
 							State:           "RUNNABLE",
-							DatabaseVersion: defaultGCPCLoudSQLDatabaseVersion,
+							DatabaseVersion: DefaultGCPCLoudSQLDatabaseVersion,
 							IpAddresses: []*sqladmin.IpMapping{
 								{
 									IpAddress: "",
@@ -1513,7 +1513,7 @@ func TestPostgresProvider_reconcileCloudSQLInstance(t *testing.T) {
 						return &sqladmin.DatabaseInstance{
 							Name:            gcpTestPostgresInstanceName,
 							State:           "RUNNABLE",
-							DatabaseVersion: defaultGCPCLoudSQLDatabaseVersion,
+							DatabaseVersion: DefaultGCPCLoudSQLDatabaseVersion,
 							IpAddresses: []*sqladmin.IpMapping{
 								{
 									IpAddress: "",

--- a/pkg/providers/gcp/provider_redis.go
+++ b/pkg/providers/gcp/provider_redis.go
@@ -31,7 +31,7 @@ const (
 	redisMemorySizeGB       = 1
 	redisParentFormat       = "projects/%s/locations/%s"
 	redisProviderName       = "gcp-memorystore"
-	redisVersion            = "REDIS_6_X"
+	RedisVersion            = "REDIS_6_X"
 )
 
 type RedisProvider struct {
@@ -404,7 +404,7 @@ func (p *RedisProvider) buildCreateInstanceRequest(ctx context.Context, r *v1alp
 		AuthorizedNetwork: strings.Split(address.GetNetwork(), "v1/")[1],
 		ConnectMode:       redispb.Instance_PRIVATE_SERVICE_ACCESS,
 		ReservedIpRange:   address.GetName(),
-		RedisVersion:      redisVersion,
+		RedisVersion:      RedisVersion,
 		Labels:            tags,
 	}
 	if createInstanceRequest.Instance == nil {

--- a/pkg/providers/gcp/provider_redis_test.go
+++ b/pkg/providers/gcp/provider_redis_test.go
@@ -969,7 +969,7 @@ func TestRedisProvider_buildCreateInstanceRequest(t *testing.T) {
 		AuthorizedNetwork: fmt.Sprintf("projects/%s/global/networks/%s", gcpTestProjectId, gcpTestNetworkName),
 		ConnectMode:       redispb.Instance_PRIVATE_SERVICE_ACCESS,
 		ReservedIpRange:   gcpTestIpRangeName,
-		RedisVersion:      redisVersion,
+		RedisVersion:      RedisVersion,
 		Labels: map[string]string{
 			"integreatly-org_clusterid":     gcpTestClusterName,
 			"integreatly-org_resource-name": "testname",
@@ -1575,7 +1575,7 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 					redisClient.GetInstanceFn = func(ctx context.Context, request *redispb.GetInstanceRequest, option ...gax.CallOption) (*redispb.Instance, error) {
 						return &redispb.Instance{
 							State:        redispb.Instance_READY,
-							RedisVersion: redisVersion,
+							RedisVersion: RedisVersion,
 						}, nil
 					}
 					redisClient.UpdateInstanceFn = func(ctx context.Context, request *redispb.UpdateInstanceRequest, option ...gax.CallOption) (*redis.UpdateInstanceOperation, error) {
@@ -1694,7 +1694,7 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 					redisClient.GetInstanceFn = func(ctx context.Context, request *redispb.GetInstanceRequest, option ...gax.CallOption) (*redispb.Instance, error) {
 						return &redispb.Instance{
 							State:        redispb.Instance_READY,
-							RedisVersion: redisVersion,
+							RedisVersion: RedisVersion,
 						}, nil
 					}
 					redisClient.UpdateInstanceFn = func(ctx context.Context, request *redispb.UpdateInstanceRequest, option ...gax.CallOption) (*redis.UpdateInstanceOperation, error) {
@@ -1815,7 +1815,7 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 					redisClient.GetInstanceFn = func(ctx context.Context, request *redispb.GetInstanceRequest, option ...gax.CallOption) (*redispb.Instance, error) {
 						return &redispb.Instance{
 							State:        redispb.Instance_READY,
-							RedisVersion: redisVersion,
+							RedisVersion: RedisVersion,
 						}, nil
 					}
 					redisClient.UpdateInstanceFn = func(ctx context.Context, request *redispb.UpdateInstanceRequest, option ...gax.CallOption) (*redis.UpdateInstanceOperation, error) {
@@ -1962,7 +1962,7 @@ func TestRedisProvider_buildUpgradeInstanceRequest(t *testing.T) {
 			args: args{
 				instanceConfig: &redispb.Instance{
 					Name:         testName,
-					RedisVersion: redisVersion,
+					RedisVersion: RedisVersion,
 				},
 				instance: &redispb.Instance{
 					Name:         testName,
@@ -1971,7 +1971,7 @@ func TestRedisProvider_buildUpgradeInstanceRequest(t *testing.T) {
 			},
 			want: &redispb.UpgradeInstanceRequest{
 				Name:         testName,
-				RedisVersion: redisVersion,
+				RedisVersion: RedisVersion,
 			},
 		},
 		{
@@ -1979,11 +1979,11 @@ func TestRedisProvider_buildUpgradeInstanceRequest(t *testing.T) {
 			args: args{
 				instanceConfig: &redispb.Instance{
 					Name:         testName,
-					RedisVersion: redisVersion,
+					RedisVersion: RedisVersion,
 				},
 				instance: &redispb.Instance{
 					Name:         testName,
-					RedisVersion: redisVersion,
+					RedisVersion: RedisVersion,
 				},
 			},
 			want: nil,


### PR DESCRIPTION

## Overview
Jira: [MGDAPI-5220](https://issues.redhat.com/browse/MGDAPI-5220)

Allowing default redis and postgres gcp versions to be exported for use in integreatly operator E2E tests.


## Verification

Eye review.