### PR TITLE
MGDAPI-5082 - fix issue with metrics creation

### DIFF
--- a/controllers/cloudmetrics/cloudmetrics_controller.go
+++ b/controllers/cloudmetrics/cloudmetrics_controller.go
@@ -4,10 +4,11 @@
 package cloudmetrics
 
 import (
-	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	"context"
-	"github.com/integr8ly/cloud-resource-operator/pkg/providers/gcp"
 	"time"
+
+	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
+	"github.com/integr8ly/cloud-resource-operator/pkg/providers/gcp"
 
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers"
@@ -408,10 +409,12 @@ func registerGaugeVectorMetrics(logger *logrus.Entry) {
 	for _, metric := range postgresGaugeMetrics {
 		logger.Infof("registering metric: %s ", metric.Name)
 		customMetrics.Registry.MustRegister(metric.GaugeVec)
+		resources.MetricVecs[metric.Name] = *metric.GaugeVec
 	}
 	for _, metric := range redisGaugeMetrics {
 		logger.Infof("registering metric: %s ", metric.Name)
 		customMetrics.Registry.MustRegister(metric.GaugeVec)
+		resources.MetricVecs[metric.Name] = *metric.GaugeVec
 	}
 }
 


### PR DESCRIPTION
## Overview

[MGDAPI-5082](https://issues.redhat.com/browse/MGDAPI-5082)

## What

Discovered an issue in v1.0.0 - metrics were added during the cloudmetrics_controller initialisation here for GCP [`553f8d9` (#671)](https://github.com/integr8ly/cloud-resource-operator/pull/671/commits/553f8d9bcbf6747f8b6a68ec0cb6290fc95d9600#diff-25b42e67d7d5bf1384b1a2dbdbe0fb4d0c3ecb16681879be4637aed3d7d95270R106-R134) but the result was that the original metrics created by AWS were registered twice. Once the Postgres instance is created, the metric is re-registered when setting for the first time [here](https://github.com/integr8ly/integreatly-operator/blob/master/vendor/github.com/integr8ly/cloud-resource-operator/pkg/resources/custom_metrics.go#L90-L91) but without the help message. This results in a conflict and the pod was crash looping.

```
1.6799907382457628e+09 INFO Observed a panic in reconciler: a previously registered descriptor with the same fully-qualified name as Desc{fqName: "cro_postgres_current_allocated_storage", help: "", constLabels: {}, variableLabels: [clusterID resourceID namespace instanceID productName strategy]} has different label names or a different help string {"controller": "postgres", "controllerGroup": "integreatly.org", "controllerKind": "Postgres", "postgres": {"name":"rhsso-postgres-rhoam","namespace":"redhat-rhoam-operator"}, "namespace": "redhat-rhoam-operator", "name": "rhsso-postgres-rhoam", "reconcileID": "1be6bb90-c28f-4a9e-b3ab-42f5fc50ba37"}
panic: a previously registered descriptor with the same fully-qualified name as Desc{fqName: "cro_postgres_current_allocated_storage", help: "", constLabels: {}, variableLabels: [clusterID resourceID namespace instanceID productName strategy]} has different label names or a different help string [recovered]
panic: a previously registered descriptor with the same fully-qualified name as Desc{fqName: "cro_postgres_current_allocated_storage", help: "", constLabels: {}, variableLabels: [clusterID resourceID namespace instanceID productName strategy]} has different label names or a different help string
```

The change here is to add all initially registered metrics from the cloudmetrics controller to the overall metrics vector so that any subsequent calls to SetMetric do not try to re-register the metric.

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make run`
- Ensure...
