### PR TITLE
MGDAPI-5458 - refactor: remove blocking gcp calls

### DIFF
--- a/apis/integreatly/v1alpha1/types/types.go
+++ b/apis/integreatly/v1alpha1/types/types.go
@@ -5,15 +5,19 @@ import (
 )
 
 var (
-	PhaseInProgress                StatusPhase   = "in progress"
-	PhaseDeleteInProgress          StatusPhase   = "deletion in progress"
-	PhaseComplete                  StatusPhase   = "complete"
-	PhasePaused                    StatusPhase   = "paused"
-	PhaseFailed                    StatusPhase   = "failed"
-	StatusEmpty                    StatusMessage = ""
-	StatusUnsupportedType          StatusMessage = "unsupported deployment type"
-	StatusDeploymentConfigNotFound StatusMessage = "deployment configuration not found"
-	StatusSkipCreate               StatusMessage = "skipping create or update for maintenance"
+	PhaseInProgress                               StatusPhase   = "in progress"
+	PhaseDeleteInProgress                         StatusPhase   = "deletion in progress"
+	PhaseComplete                                 StatusPhase   = "complete"
+	PhasePaused                                   StatusPhase   = "paused"
+	PhaseFailed                                   StatusPhase   = "failed"
+	StatusEmpty                                   StatusMessage = ""
+	StatusUnsupportedType                         StatusMessage = "unsupported deployment type"
+	StatusDeploymentConfigNotFound                StatusMessage = "deployment configuration not found"
+	StatusSkipCreate                              StatusMessage = "skipping create or update for maintenance"
+	StatusNetworkCreateError                      StatusMessage = "failed to create network service"
+	StatusNetworkIPRangePendingCreation           StatusMessage = "ip address range is pending creation"
+	StatusNetworkIPRangeNotExistOrPendingCreation StatusMessage = "ip address range does not exist or is pending creation"
+	StatusNetworkServiceConnectionPendingCreation StatusMessage = "service connection is pending creation"
 )
 
 type SecretRef struct {

--- a/pkg/providers/gcp/cluster_network_provider.go
+++ b/pkg/providers/gcp/cluster_network_provider.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/compute/apiv1/computepb"
+	croType "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1/types"
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers"
 	"github.com/integr8ly/cloud-resource-operator/pkg/providers/gcp/gcpiface"
 	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
@@ -36,8 +37,8 @@ const (
 
 //go:generate moq -out cluster_network_provider_moq.go . NetworkManager
 type NetworkManager interface {
-	CreateNetworkIpRange(context.Context, *net.IPNet) (*computepb.Address, error)
-	CreateNetworkService(context.Context) (*servicenetworking.Connection, error)
+	CreateNetworkIpRange(context.Context, *net.IPNet) (*computepb.Address, croType.StatusMessage, error)
+	CreateNetworkService(context.Context) (*servicenetworking.Connection, croType.StatusMessage, error)
 	DeleteNetworkPeering(context.Context) error
 	DeleteNetworkService(context.Context) error
 	DeleteNetworkIpRange(context.Context) error
@@ -96,78 +97,78 @@ func NewNetworkManager(ctx context.Context, projectID string, opt option.ClientO
 	}, nil
 }
 
-func (n *NetworkProvider) CreateNetworkIpRange(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, error) {
+func (n *NetworkProvider) CreateNetworkIpRange(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, croType.StatusMessage, error) {
 	// build ip address range name
 	ipRangeName, err := resources.BuildInfraName(ctx, n.Client, defaultIpRangePostfix, defaultGcpIdentifierLength)
 	if err != nil {
-		return nil, errorUtil.Wrap(err, "failed to build ip address range infra name")
+		return nil, croType.StatusNetworkCreateError, errorUtil.Wrap(err, "failed to build ip address range infra name")
 	}
 	address, err := n.getAddressRange(ctx, ipRangeName)
 	if err != nil {
-		return nil, errorUtil.Wrap(err, "failed to retrieve ip address range")
+		return nil, croType.StatusNetworkCreateError, errorUtil.Wrap(err, "failed to retrieve ip address range")
 	}
 	// if it does not exist, create it
 	if address == nil {
 		clusterVpc, err := getClusterVpc(ctx, n.Client, n.NetworkApi, n.ProjectID, n.Logger)
 		if err != nil {
-			return nil, errorUtil.Wrap(err, "failed to get cluster vpc")
+			return nil, croType.StatusNetworkCreateError, errorUtil.Wrap(err, "failed to get cluster vpc")
 		}
 		subnets, err := n.getClusterSubnets(ctx, clusterVpc)
 		if err != nil {
-			return nil, errorUtil.Wrap(err, "failed to get cluster subnetworks")
+			return nil, croType.StatusNetworkCreateError, errorUtil.Wrap(err, "failed to get cluster subnetworks")
 		}
 		err = validateCidrBlock(cidrRange, subnets)
 		if err != nil {
-			return nil, errorUtil.Wrap(err, "ip range validation failure")
+			return nil, croType.StatusNetworkCreateError, errorUtil.Wrap(err, "ip range validation failure")
 		}
 		err = n.createAddressRange(ctx, clusterVpc, ipRangeName, cidrRange)
 		if err != nil {
-			return nil, errorUtil.Wrap(err, "failed to create ip address range")
+			return nil, croType.StatusNetworkCreateError, errorUtil.Wrap(err, "failed to create ip address range")
 		}
 
-		return nil, errorUtil.New("ip address range is pending creation")
+		return nil, croType.StatusNetworkIPRangePendingCreation, nil
 	}
 	n.Logger.Infof("created ip address range %s: %s/%d", address.GetName(), address.GetAddress(), address.GetPrefixLength())
-	return address, nil
+	return address, "", nil
 }
 
 // CreateNetworkService Creates the network service connection and will return the service if it has been created successfully
 // This automatically creates a peering connection to the clusterVpc named after the service connection
-func (n *NetworkProvider) CreateNetworkService(ctx context.Context) (*servicenetworking.Connection, error) {
+func (n *NetworkProvider) CreateNetworkService(ctx context.Context) (*servicenetworking.Connection, croType.StatusMessage, error) {
 	clusterVpc, err := getClusterVpc(ctx, n.Client, n.NetworkApi, n.ProjectID, n.Logger)
 	if err != nil {
-		return nil, errorUtil.Wrap(err, "failed to get cluster vpc")
+		return nil, croType.StatusNetworkCreateError, errorUtil.Wrap(err, "failed to get cluster vpc")
 	}
 	service, err := n.getServiceConnection(clusterVpc)
 	if err != nil {
-		return nil, errorUtil.Wrap(err, "failed to retrieve service connection")
+		return nil, croType.StatusNetworkCreateError, errorUtil.Wrap(err, "failed to retrieve service connection")
 	}
 	// if it does not exist, create it
 	if service == nil {
 		// build ip address range name
 		ipRange, err := resources.BuildInfraName(ctx, n.Client, defaultIpRangePostfix, defaultGcpIdentifierLength)
 		if err != nil {
-			return nil, errorUtil.Wrap(err, "failed to build ip address range infra name")
+			return nil, croType.StatusNetworkCreateError, errorUtil.Wrap(err, "failed to build ip address range infra name")
 		}
 		address, err := n.getAddressRange(ctx, ipRange)
 		if err != nil {
-			return nil, errorUtil.Wrap(err, "failed to retrieve ip address range")
+			return nil, croType.StatusNetworkCreateError, errorUtil.Wrap(err, "failed to retrieve ip address range")
 		}
 		// if the ip range is present, and is ready for use
 		// possible states for address are RESERVING, RESERVED, IN_USE
 		if address == nil || address.GetStatus() == computepb.Address_RESERVING.String() {
-			return nil, errors.New("ip address range does not exist or is pending creation")
+			return nil, croType.StatusNetworkIPRangeNotExistOrPendingCreation, nil
 		}
 		if address != nil && address.GetStatus() == computepb.Address_RESERVED.String() {
 			err = n.createServiceConnection(clusterVpc, ipRange)
 			if err != nil {
-				return nil, errorUtil.Wrap(err, "failed to create service connection")
+				return nil, croType.StatusNetworkCreateError, errorUtil.Wrap(err, "failed to create service connection")
 			}
-			return nil, errorUtil.New("service connection is pending creation")
+			return nil, croType.StatusNetworkServiceConnectionPendingCreation, nil
 		}
 	}
 	n.Logger.Infof("created network service connection %s", service)
-	return service, nil
+	return service, "", nil
 }
 
 // DeleteNetworkPeering Removes the peering connection from the cluster vpc

--- a/pkg/providers/gcp/cluster_network_provider_moq.go
+++ b/pkg/providers/gcp/cluster_network_provider_moq.go
@@ -6,6 +6,7 @@ package gcp
 import (
 	"cloud.google.com/go/compute/apiv1/computepb"
 	"context"
+	croType "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1/types"
 	"google.golang.org/api/servicenetworking/v1"
 	"net"
 	"sync"
@@ -24,10 +25,10 @@ var _ NetworkManager = &NetworkManagerMock{}
 //			ComponentsExistFunc: func(contextMoqParam context.Context) (bool, error) {
 //				panic("mock out the ComponentsExist method")
 //			},
-//			CreateNetworkIpRangeFunc: func(contextMoqParam context.Context, iPNet *net.IPNet) (*computepb.Address, error) {
+//			CreateNetworkIpRangeFunc: func(contextMoqParam context.Context, iPNet *net.IPNet) (*computepb.Address, croType.StatusMessage, error) {
 //				panic("mock out the CreateNetworkIpRange method")
 //			},
-//			CreateNetworkServiceFunc: func(contextMoqParam context.Context) (*servicenetworking.Connection, error) {
+//			CreateNetworkServiceFunc: func(contextMoqParam context.Context) (*servicenetworking.Connection, croType.StatusMessage, error) {
 //				panic("mock out the CreateNetworkService method")
 //			},
 //			DeleteNetworkIpRangeFunc: func(contextMoqParam context.Context) error {
@@ -53,10 +54,10 @@ type NetworkManagerMock struct {
 	ComponentsExistFunc func(contextMoqParam context.Context) (bool, error)
 
 	// CreateNetworkIpRangeFunc mocks the CreateNetworkIpRange method.
-	CreateNetworkIpRangeFunc func(contextMoqParam context.Context, iPNet *net.IPNet) (*computepb.Address, error)
+	CreateNetworkIpRangeFunc func(contextMoqParam context.Context, iPNet *net.IPNet) (*computepb.Address, croType.StatusMessage, error)
 
 	// CreateNetworkServiceFunc mocks the CreateNetworkService method.
-	CreateNetworkServiceFunc func(contextMoqParam context.Context) (*servicenetworking.Connection, error)
+	CreateNetworkServiceFunc func(contextMoqParam context.Context) (*servicenetworking.Connection, croType.StatusMessage, error)
 
 	// DeleteNetworkIpRangeFunc mocks the DeleteNetworkIpRange method.
 	DeleteNetworkIpRangeFunc func(contextMoqParam context.Context) error
@@ -156,7 +157,7 @@ func (mock *NetworkManagerMock) ComponentsExistCalls() []struct {
 }
 
 // CreateNetworkIpRange calls CreateNetworkIpRangeFunc.
-func (mock *NetworkManagerMock) CreateNetworkIpRange(contextMoqParam context.Context, iPNet *net.IPNet) (*computepb.Address, error) {
+func (mock *NetworkManagerMock) CreateNetworkIpRange(contextMoqParam context.Context, iPNet *net.IPNet) (*computepb.Address, croType.StatusMessage, error) {
 	if mock.CreateNetworkIpRangeFunc == nil {
 		panic("NetworkManagerMock.CreateNetworkIpRangeFunc: method is nil but NetworkManager.CreateNetworkIpRange was just called")
 	}
@@ -192,7 +193,7 @@ func (mock *NetworkManagerMock) CreateNetworkIpRangeCalls() []struct {
 }
 
 // CreateNetworkService calls CreateNetworkServiceFunc.
-func (mock *NetworkManagerMock) CreateNetworkService(contextMoqParam context.Context) (*servicenetworking.Connection, error) {
+func (mock *NetworkManagerMock) CreateNetworkService(contextMoqParam context.Context) (*servicenetworking.Connection, croType.StatusMessage, error) {
 	if mock.CreateNetworkServiceFunc == nil {
 		panic("NetworkManagerMock.CreateNetworkServiceFunc: method is nil but NetworkManager.CreateNetworkService was just called")
 	}

--- a/pkg/providers/gcp/cluster_network_provider_test.go
+++ b/pkg/providers/gcp/cluster_network_provider_test.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	"cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/integr8ly/cloud-resource-operator/apis"
@@ -266,6 +265,9 @@ func TestNetworkProvider_CreateNetworkIpRange(t *testing.T) {
 					}
 				}),
 				AddressApi: gcpiface.GetMockAddressClient(func(addressClient *gcpiface.MockAddressClient) {
+					addressClient.GetFn = func(request *computepb.GetGlobalAddressRequest) (*computepb.Address, error) {
+						return buildValidGcpAddressRange(gcpTestIpRangeName), nil
+					}
 					addressClient.GetFnTwo = func(*computepb.GetGlobalAddressRequest) (*computepb.Address, error) {
 						return buildValidGcpAddressRange(gcpTestIpRangeName), nil
 					}
@@ -330,8 +332,8 @@ func TestNetworkProvider_CreateNetworkIpRange(t *testing.T) {
 					Mask: net.CIDRMask(defaultIpRangeCIDRMask, defaultIpv4Length),
 				},
 			},
-			want:    buildValidGcpAddressRange(gcpTestIpRangeName),
-			wantErr: false,
+			want:    nil,
+			wantErr: true,
 		},
 		{
 			name: "googleapi error retrieving ip address range",
@@ -612,6 +614,9 @@ func TestNetworkProvider_CreateNetworkService(t *testing.T) {
 					}
 				}),
 				ServicesApi: gcpiface.GetMockServicesClient(func(servicesClient *gcpiface.MockServicesClient) {
+					servicesClient.ConnectionsListFn = func(clusterVpc *computepb.Network, projectID, parent string) (*servicenetworking.ListConnectionsResponse, error) {
+						return buildValidListConnectionsResponse(resources.SafeStringDereference(clusterVpc.Name), projectID, parent), nil
+					}
 					servicesClient.ConnectionsListFnTwo = func(clusterVpc *computepb.Network, projectID, parent string) (*servicenetworking.ListConnectionsResponse, error) {
 						return buildValidListConnectionsResponse(resources.SafeStringDereference(clusterVpc.Name), projectID, parent), nil
 					}
@@ -1418,190 +1423,6 @@ func TestNetworkProvider_ReconcileNetworkProviderConfig(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ReconcileNetworkProviderConfig() got = %s/%s, want %s/%s", got.IP.String(), got.Mask.String(), tt.want.IP.String(), tt.want.Mask.String())
-			}
-		})
-	}
-}
-
-func TestNetworkProvider_waitForAddress(t *testing.T) {
-	type fields struct {
-		AddressApi gcpiface.AddressAPI
-		ProjectID  string
-	}
-	type args struct {
-		ipRangeName string
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    *computepb.Address
-		wantErr bool
-		mockFn  func()
-	}{
-		{
-			name: "success waiting for address creation",
-			fields: fields{
-				AddressApi: gcpiface.GetMockAddressClient(func(addressClient *gcpiface.MockAddressClient) {
-					addressClient.GetFn = func(request *computepb.GetGlobalAddressRequest) (*computepb.Address, error) {
-						return &computepb.Address{}, nil
-					}
-				}),
-				ProjectID: "testProjectID",
-			},
-			args: args{
-				ipRangeName: "testIpRangeName",
-			},
-			want:    &computepb.Address{},
-			wantErr: false,
-		},
-		{
-			name: "failure waiting for address creation",
-			fields: fields{
-				AddressApi: gcpiface.GetMockAddressClient(func(addressClient *gcpiface.MockAddressClient) {
-					addressClient.GetFn = func(request *computepb.GetGlobalAddressRequest) (*computepb.Address, error) {
-						return nil, fmt.Errorf("generic error")
-					}
-				}),
-				ProjectID: "testProjectID",
-			},
-			args: args{
-				ipRangeName: "testIpRangeName",
-			},
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			name: "timed out waiting for address creation",
-			fields: fields{
-				AddressApi: gcpiface.GetMockAddressClient(func(addressClient *gcpiface.MockAddressClient) {
-					addressClient.GetFn = func(request *computepb.GetGlobalAddressRequest) (*computepb.Address, error) {
-						return nil, nil
-					}
-				}),
-				ProjectID: "testProjectID",
-			},
-			args: args{
-				ipRangeName: "testIpRangeName",
-			},
-			want:    nil,
-			wantErr: true,
-			mockFn: func() {
-				defaultTimeout = time.Second * 1
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.mockFn != nil {
-				tt.mockFn()
-				defer func() {
-					defaultTimeout = time.Minute
-				}()
-			}
-			n := &NetworkProvider{
-				AddressApi: tt.fields.AddressApi,
-				Logger:     logrus.NewEntry(logrus.StandardLogger()),
-				ProjectID:  tt.fields.ProjectID,
-			}
-			got, err := n.waitForAddress(context.TODO(), tt.args.ipRangeName)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("waitForAddress() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("waitForAddress() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestNetworkProvider_waitForConnection(t *testing.T) {
-	type fields struct {
-		ServicesApi gcpiface.ServicesAPI
-		ProjectID   string
-	}
-	type args struct {
-		clusterVpc *computepb.Network
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    *servicenetworking.Connection
-		wantErr bool
-		mockFn  func()
-	}{
-		{
-			name: "success waiting for connection creation",
-			fields: fields{
-				ServicesApi: gcpiface.GetMockServicesClient(func(servicesClient *gcpiface.MockServicesClient) {
-					servicesClient.ConnectionsListFn = func(network *computepb.Network, s string, s2 string) (*servicenetworking.ListConnectionsResponse, error) {
-						return &servicenetworking.ListConnectionsResponse{
-							Connections: []*servicenetworking.Connection{{}},
-						}, nil
-					}
-				}),
-				ProjectID: "testProjectID",
-			},
-			args:    args{},
-			want:    &servicenetworking.Connection{},
-			wantErr: false,
-		},
-		{
-			name: "failure waiting for connection creation",
-			fields: fields{
-				ServicesApi: gcpiface.GetMockServicesClient(func(servicesClient *gcpiface.MockServicesClient) {
-					servicesClient.ConnectionsListFn = func(network *computepb.Network, s string, s2 string) (*servicenetworking.ListConnectionsResponse, error) {
-						return nil, fmt.Errorf("generic error")
-					}
-				}),
-				ProjectID: "testProjectID",
-			},
-			args:    args{},
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			name: "timed out waiting for connection creation",
-			fields: fields{
-				ServicesApi: gcpiface.GetMockServicesClient(func(servicesClient *gcpiface.MockServicesClient) {
-					servicesClient.ConnectionsListFn = func(network *computepb.Network, s string, s2 string) (*servicenetworking.ListConnectionsResponse, error) {
-						return &servicenetworking.ListConnectionsResponse{
-							Connections: []*servicenetworking.Connection{},
-						}, nil
-					}
-				}),
-				ProjectID: "testProjectID",
-			},
-			args:    args{},
-			want:    nil,
-			wantErr: true,
-			mockFn: func() {
-				defaultTimeout = time.Second * 1
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.mockFn != nil {
-				tt.mockFn()
-				defer func() {
-					defaultTimeout = time.Minute
-				}()
-			}
-			n := &NetworkProvider{
-				ServicesApi: tt.fields.ServicesApi,
-				Logger:      logrus.NewEntry(logrus.StandardLogger()),
-				ProjectID:   tt.fields.ProjectID,
-			}
-			got, err := n.waitForConnection(tt.args.clusterVpc)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("waitForConnection() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("waitForConnection() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/providers/gcp/provider_postgres.go
+++ b/pkg/providers/gcp/provider_postgres.go
@@ -127,15 +127,13 @@ func (p *PostgresProvider) ReconcilePostgres(ctx context.Context, pg *v1alpha1.P
 		errMsg := "failed to reconcile network provider config"
 		return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
 	}
-	address, err := networkManager.CreateNetworkIpRange(ctx, ipRangeCidr)
-	if err != nil {
-		msg := "failed to create network service"
-		return nil, croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
+	address, msg, err := networkManager.CreateNetworkIpRange(ctx, ipRangeCidr)
+	if err != nil || msg != "" {
+		return nil, msg, err
 	}
-	_, err = networkManager.CreateNetworkService(ctx)
-	if err != nil {
-		msg := "failed to create network service"
-		return nil, croType.StatusMessage(msg), errorUtil.Wrap(err, msg)
+	_, msg, err = networkManager.CreateNetworkService(ctx)
+	if err != nil || msg != "" {
+		return nil, msg, err
 	}
 
 	return p.reconcileCloudSQLInstance(ctx, pg, sqlClient, strategyConfig, address, maintenanceWindowEnabled)

--- a/pkg/providers/gcp/provider_redis.go
+++ b/pkg/providers/gcp/provider_redis.go
@@ -106,15 +106,13 @@ func (p *RedisProvider) createRedisInstance(ctx context.Context, networkManager 
 		errMsg := "failed to reconcile network provider config"
 		return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
 	}
-	address, err := networkManager.CreateNetworkIpRange(ctx, ipRangeCidr)
-	if err != nil {
-		statusMessage := "failed to create network service"
-		return nil, croType.StatusMessage(statusMessage), errorUtil.Wrap(err, statusMessage)
+	address, msg, err := networkManager.CreateNetworkIpRange(ctx, ipRangeCidr)
+	if err != nil || msg != "" {
+		return nil, msg, err
 	}
-	_, err = networkManager.CreateNetworkService(ctx)
-	if err != nil {
-		statusMessage := "failed to create network service"
-		return nil, croType.StatusMessage(statusMessage), errorUtil.Wrap(err, statusMessage)
+	_, msg, err = networkManager.CreateNetworkService(ctx)
+	if err != nil || msg != "" {
+		return nil, msg, err
 	}
 	createInstanceRequest, err := p.buildCreateInstanceRequest(ctx, r, strategyConfig, address)
 	if err != nil {

--- a/pkg/providers/gcp/provider_redis_test.go
+++ b/pkg/providers/gcp/provider_redis_test.go
@@ -1044,11 +1044,11 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 			},
 			args: args{
 				networkManager: &NetworkManagerMock{
-					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, error) {
-						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), nil
+					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, types.StatusMessage, error) {
+						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), "", nil
 					},
-					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, error) {
-						return &servicenetworking.Connection{}, nil
+					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, types.StatusMessage, error) {
+						return &servicenetworking.Connection{}, "", nil
 					},
 					ReconcileNetworkProviderConfigFunc: func(ctx context.Context, configManager ConfigManager, tier string) (*net.IPNet, error) {
 						return &net.IPNet{
@@ -1112,14 +1112,14 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 							Mask: net.CIDRMask(defaultIpRangeCIDRMask, defaultIpv4Length),
 						}, nil
 					},
-					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, error) {
-						return nil, fmt.Errorf("generic error")
+					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, types.StatusMessage, error) {
+						return nil, types.StatusNetworkCreateError, fmt.Errorf("generic error")
 					},
 				},
 				r: &v1alpha1.Redis{},
 			},
 			redisCluster:  nil,
-			statusMessage: "failed to create network service",
+			statusMessage: types.StatusNetworkCreateError,
 			wantErr:       true,
 		},
 		{
@@ -1132,17 +1132,17 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 							Mask: net.CIDRMask(defaultIpRangeCIDRMask, defaultIpv4Length),
 						}, nil
 					},
-					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, error) {
-						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), nil
+					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, types.StatusMessage, error) {
+						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), "", nil
 					},
-					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, error) {
-						return nil, fmt.Errorf("generic error")
+					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, types.StatusMessage, error) {
+						return nil, types.StatusNetworkCreateError, fmt.Errorf("generic error")
 					},
 				},
 				r: &v1alpha1.Redis{},
 			},
 			redisCluster:  nil,
-			statusMessage: "failed to create network service",
+			statusMessage: types.StatusNetworkCreateError,
 			wantErr:       true,
 		},
 		{
@@ -1155,11 +1155,11 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 							Mask: net.CIDRMask(defaultIpRangeCIDRMask, defaultIpv4Length),
 						}, nil
 					},
-					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, error) {
-						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), nil
+					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, types.StatusMessage, error) {
+						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), "", nil
 					},
-					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, error) {
-						return &servicenetworking.Connection{}, nil
+					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, types.StatusMessage, error) {
+						return &servicenetworking.Connection{}, "", nil
 					},
 				},
 				strategyConfig: &StrategyConfig{
@@ -1183,11 +1183,11 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 							Mask: net.CIDRMask(defaultIpRangeCIDRMask, defaultIpv4Length),
 						}, nil
 					},
-					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, error) {
-						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), nil
+					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, types.StatusMessage, error) {
+						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), "", nil
 					},
-					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, error) {
-						return &servicenetworking.Connection{}, nil
+					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, types.StatusMessage, error) {
+						return &servicenetworking.Connection{}, "", nil
 					},
 				},
 				redisClient: gcpiface.GetMockRedisClient(func(redisClient *gcpiface.MockRedisClient) {
@@ -1218,11 +1218,11 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 							Mask: net.CIDRMask(defaultIpRangeCIDRMask, defaultIpv4Length),
 						}, nil
 					},
-					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, error) {
-						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), nil
+					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, types.StatusMessage, error) {
+						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), "", nil
 					},
-					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, error) {
-						return &servicenetworking.Connection{}, nil
+					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, types.StatusMessage, error) {
+						return &servicenetworking.Connection{}, "", nil
 					},
 				},
 				redisClient: gcpiface.GetMockRedisClient(func(redisClient *gcpiface.MockRedisClient) {
@@ -1262,11 +1262,11 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 							Mask: net.CIDRMask(defaultIpRangeCIDRMask, defaultIpv4Length),
 						}, nil
 					},
-					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, error) {
-						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), nil
+					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, types.StatusMessage, error) {
+						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), "", nil
 					},
-					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, error) {
-						return &servicenetworking.Connection{}, nil
+					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, types.StatusMessage, error) {
+						return &servicenetworking.Connection{}, "", nil
 					},
 				},
 				redisClient: gcpiface.GetMockRedisClient(func(redisClient *gcpiface.MockRedisClient) {
@@ -1306,11 +1306,11 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 							Mask: net.CIDRMask(defaultIpRangeCIDRMask, defaultIpv4Length),
 						}, nil
 					},
-					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, error) {
-						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), nil
+					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, types.StatusMessage, error) {
+						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), "", nil
 					},
-					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, error) {
-						return &servicenetworking.Connection{}, nil
+					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, types.StatusMessage, error) {
+						return &servicenetworking.Connection{}, "", nil
 					},
 				},
 				redisClient: gcpiface.GetMockRedisClient(func(redisClient *gcpiface.MockRedisClient) {
@@ -1343,11 +1343,11 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 							Mask: net.CIDRMask(defaultIpRangeCIDRMask, defaultIpv4Length),
 						}, nil
 					},
-					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, error) {
-						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), nil
+					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, types.StatusMessage, error) {
+						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), "", nil
 					},
-					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, error) {
-						return &servicenetworking.Connection{}, nil
+					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, types.StatusMessage, error) {
+						return &servicenetworking.Connection{}, "", nil
 					},
 				},
 				redisClient: gcpiface.GetMockRedisClient(func(redisClient *gcpiface.MockRedisClient) {
@@ -1381,11 +1381,11 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 			},
 			args: args{
 				networkManager: &NetworkManagerMock{
-					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, error) {
-						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), nil
+					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, types.StatusMessage, error) {
+						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), "", nil
 					},
-					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, error) {
-						return &servicenetworking.Connection{}, nil
+					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, types.StatusMessage, error) {
+						return &servicenetworking.Connection{}, "", nil
 					},
 					ReconcileNetworkProviderConfigFunc: func(ctx context.Context, configManager ConfigManager, tier string) (*net.IPNet, error) {
 						return &net.IPNet{
@@ -1434,11 +1434,11 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 			},
 			args: args{
 				networkManager: &NetworkManagerMock{
-					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, error) {
-						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), nil
+					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, types.StatusMessage, error) {
+						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), "", nil
 					},
-					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, error) {
-						return &servicenetworking.Connection{}, nil
+					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, types.StatusMessage, error) {
+						return &servicenetworking.Connection{}, "", nil
 					},
 					ReconcileNetworkProviderConfigFunc: func(ctx context.Context, configManager ConfigManager, tier string) (*net.IPNet, error) {
 						return &net.IPNet{
@@ -1487,11 +1487,11 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 			},
 			args: args{
 				networkManager: &NetworkManagerMock{
-					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, error) {
-						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), nil
+					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, types.StatusMessage, error) {
+						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), "", nil
 					},
-					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, error) {
-						return &servicenetworking.Connection{}, nil
+					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, types.StatusMessage, error) {
+						return &servicenetworking.Connection{}, "", nil
 					},
 					ReconcileNetworkProviderConfigFunc: func(ctx context.Context, configManager ConfigManager, tier string) (*net.IPNet, error) {
 						return &net.IPNet{
@@ -1546,11 +1546,11 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 			},
 			args: args{
 				networkManager: &NetworkManagerMock{
-					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, error) {
-						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), nil
+					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, types.StatusMessage, error) {
+						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), "", nil
 					},
-					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, error) {
-						return &servicenetworking.Connection{}, nil
+					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, types.StatusMessage, error) {
+						return &servicenetworking.Connection{}, "", nil
 					},
 					ReconcileNetworkProviderConfigFunc: func(ctx context.Context, configManager ConfigManager, tier string) (*net.IPNet, error) {
 						return &net.IPNet{
@@ -1612,11 +1612,11 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 			},
 			args: args{
 				networkManager: &NetworkManagerMock{
-					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, error) {
-						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), nil
+					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, types.StatusMessage, error) {
+						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), "", nil
 					},
-					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, error) {
-						return &servicenetworking.Connection{}, nil
+					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, types.StatusMessage, error) {
+						return &servicenetworking.Connection{}, "", nil
 					},
 					ReconcileNetworkProviderConfigFunc: func(ctx context.Context, configManager ConfigManager, tier string) (*net.IPNet, error) {
 						return &net.IPNet{
@@ -1669,11 +1669,11 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 			},
 			args: args{
 				networkManager: &NetworkManagerMock{
-					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, error) {
-						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), nil
+					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, types.StatusMessage, error) {
+						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), "", nil
 					},
-					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, error) {
-						return &servicenetworking.Connection{}, nil
+					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, types.StatusMessage, error) {
+						return &servicenetworking.Connection{}, "", nil
 					},
 					ReconcileNetworkProviderConfigFunc: func(ctx context.Context, configManager ConfigManager, tier string) (*net.IPNet, error) {
 						return &net.IPNet{
@@ -1739,11 +1739,11 @@ func TestRedisProvider_createRedisInstance(t *testing.T) {
 			},
 			args: args{
 				networkManager: &NetworkManagerMock{
-					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, error) {
-						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), nil
+					CreateNetworkIpRangeFunc: func(ctx context.Context, cidrRange *net.IPNet) (*computepb.Address, types.StatusMessage, error) {
+						return buildTestComputeAddress(map[string]string{"status": computepb.Address_RESERVED.String()}), "", nil
 					},
-					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, error) {
-						return &servicenetworking.Connection{}, nil
+					CreateNetworkServiceFunc: func(ctx context.Context) (*servicenetworking.Connection, types.StatusMessage, error) {
+						return &servicenetworking.Connection{}, "", nil
 					},
 					ReconcileNetworkProviderConfigFunc: func(ctx context.Context, configManager ConfigManager, tier string) (*net.IPNet, error) {
 						return &net.IPNet{


### PR DESCRIPTION
## Overview

Jira: issues.redhat.com/browse/MGDAPI-5458

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make run` against a GCP cluster
- Seed Postgres
```
PROVIDER=gcp make cluster/seed/postgres
```
* Verify phase is in progress during ip address range or connection service creation
```
oc get postgres example-postgres -n cloud-resource-operator -o json | jq '.status'
```
![image](https://user-images.githubusercontent.com/24636860/231484475-143d8b26-06f3-4f40-97af-3e84f42f1ab0.png)
* Delete postgres
- Seed Redis
```
PROVIDER=gcp make cluster/seed/redis
```
- Verify phase is in progress during ip address range or connection service creation
```
oc get redis example-redis -n cloud-resource-operator -o json | jq '.status'
```

![image](https://user-images.githubusercontent.com/24636860/231488360-b3e7bc18-733b-4e50-91a3-e0af9aebd1ce.png)
* Delete redis
## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below