### PR TITLE
MGDAPI-5649 - fix redis update on each reconcile

### DIFF
--- a/pkg/providers/gcp/provider_redis.go
+++ b/pkg/providers/gcp/provider_redis.go
@@ -471,6 +471,13 @@ func isMaintenancePolicyOutdated(a *redispb.MaintenancePolicy, b *redispb.Mainte
 	if (a == nil && b != nil) || (a != nil && b == nil) {
 		return true
 	}
+	// remove output-only duration field from comparison
+	for i := range a.WeeklyMaintenanceWindow {
+		a.WeeklyMaintenanceWindow[i].Duration = nil
+	}
+	for i := range b.WeeklyMaintenanceWindow {
+		b.WeeklyMaintenanceWindow[i].Duration = nil
+	}
 	return !reflect.DeepEqual(a.WeeklyMaintenanceWindow, b.WeeklyMaintenanceWindow)
 }
 


### PR DESCRIPTION
## Overview

[MGDAPI-5649](https://issues.redhat.com/browse/MGDAPI-5649)

## Verification

### Provision a GCP CCS cluster

From the master branch of the [Delorean](https://github.com/integr8ly/delorean) repo create a file in the root of the repo called gcp_service_account.json. Request GCP credentials and add these to this file. Adjust this command to suit your needs, it will generate a config at ocm/cluster.json:
 ```sh
OCM_CLUSTER_NAME=acatterm-ccs OCM_CLUSTER_LIFESPAN=24 COMPUTE_NODES_COUNT=2 BYOC=true CLOUD_PROVIDER=gcp make -f make/ocm.mk ocm/cluster.json
```
Once you have checked the ocm/cluster.json, create the cluster:
```sh
make -f make/ocm.mk ocm/cluster/create
```

### Verify changes

Run the operator from master:
```
PROVIDER=gcp make cluster/prepare
oc patch configmap cloud-resources-gcp-strategies -n cloud-resource-operator --type=json -p='[{"op": "replace", "path": /data/redis, "value": "{\"development\": { \"region\": \"\", \"projectID\": \"\", \"createStrategy\": {\"instance\": { \"maintenance_policy\": { \"weekly_maintenance_window\": [ { \"day\": 4, \"start_time\": { \"hours\": 2 } } ] } }}, \"deleteStrategy\": {} }}"}]'
make run
```

Deploy a redis instance:
```
PROVIDER=gcp make cluster/seed/redis
```

Once deployed on each reconcile you'll see log output stating that the redis instance was updated:
```
INFO[1309] updating gcp redis instance ...
```

Stop the operator and switch to the changes in this PR. Re-run and the log output will no longer contain the 'update' lines as the Redis instance is already up to date.
