### PR TITLE
MGDAPI-5691 - allow specifying redis size for GCP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ cluster/seed/blobstorage:
 
 .PHONY: cluster/seed/redis
 cluster/seed/redis:
-	@cat config/samples/integreatly_v1alpha1_redis.yaml | sed "s/name: REPLACE_ME/name: $(REDIS_NAME)/g" | sed "s/type: REPLACE_ME/type: $(PROVIDER)/g" | sed "s/size: REPLACE_ME/size: $(REDIS_NODE_SIZE)/g" | oc apply -f - -n $(NAMESPACE)
+	@cat config/samples/integreatly_v1alpha1_redis.yaml | sed "s/name: REPLACE_ME/name: $(REDIS_NAME)/g" | sed "s/type: REPLACE_ME/type: $(PROVIDER)/g" | sed "s/size: REPLACE_ME/size: '$(REDIS_NODE_SIZE)'/g" | oc apply -f - -n $(NAMESPACE)
 
 .PHONY: cluster/seed/redissnapshot
 cluster/seed/redissnapshot:

--- a/pkg/providers/gcp/provider_redis.go
+++ b/pkg/providers/gcp/provider_redis.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -378,6 +379,14 @@ func (p *RedisProvider) buildCreateInstanceRequest(ctx context.Context, r *v1alp
 		RedisVersion:      redisVersion,
 		Labels:            tags,
 	}
+	// Override if node size is defined in the CR spec
+	if r.Spec.Size != "" {
+		size, err := strconv.ParseInt(r.Spec.Size, 10, 64)
+		if err != nil {
+			return nil, errorUtil.Wrap(err, "failed to parse redis spec size")
+		}
+		defaultInstance.MemorySizeGb = int32(size)
+	}
 	if createInstanceRequest.Instance == nil {
 		createInstanceRequest.Instance = defaultInstance
 		return createInstanceRequest, nil
@@ -412,6 +421,7 @@ func (p *RedisProvider) buildCreateInstanceRequest(ctx context.Context, r *v1alp
 	if createInstanceRequest.Instance.RedisVersion == "" {
 		createInstanceRequest.Instance.RedisVersion = defaultInstance.RedisVersion
 	}
+
 	return createInstanceRequest, nil
 }
 

--- a/pkg/providers/gcp/provider_redis_test.go
+++ b/pkg/providers/gcp/provider_redis_test.go
@@ -928,6 +928,64 @@ func TestRedisProvider_buildCreateInstanceRequest(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "success building redis create instance request with custom size",
+			fields: fields{
+				Client: moqClient.NewSigsClientMoqWithScheme(scheme, buildTestGcpInfrastructure(nil)),
+			},
+			args: args{
+				r: &v1alpha1.Redis{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testName,
+						Namespace: testNs,
+					},
+					Spec: types.ResourceTypeSpec{
+						Size: "7",
+					},
+				},
+				strategyConfig: &StrategyConfig{
+					Region:         gcpTestRegion,
+					ProjectID:      gcpTestProjectId,
+					CreateStrategy: json.RawMessage(`{}`),
+				},
+				address: buildTestComputeAddress(nil),
+			},
+			want: &redispb.CreateInstanceRequest{
+				Parent:     parent,
+				InstanceId: instanceID,
+				Instance: func() *redispb.Instance {
+					inst := *redisInstance
+					inst.MemorySizeGb = 7
+					return &inst
+				}(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "fail to parse redis spec size",
+			fields: fields{
+				Client: moqClient.NewSigsClientMoqWithScheme(scheme, buildTestGcpInfrastructure(nil)),
+			},
+			args: args{
+				r: &v1alpha1.Redis{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testName,
+						Namespace: testNs,
+					},
+					Spec: types.ResourceTypeSpec{
+						Size: "invalid",
+					},
+				},
+				strategyConfig: &StrategyConfig{
+					Region:         gcpTestRegion,
+					ProjectID:      gcpTestProjectId,
+					CreateStrategy: json.RawMessage(`{}`),
+				},
+				address: buildTestComputeAddress(nil),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name:   "fail to unmarshal gcp redis create strategy",
 			fields: fields{},
 			args: args{


### PR DESCRIPTION
## Overview

[MGDAPI-5691](https://issues.redhat.com/browse/MGDAPI-5691)

## Verification

### Provision a GCP CCS cluster

From the master branch of the [Delorean](https://github.com/integr8ly/delorean) repo create a file in the root of the repo called gcp_service_account.json. Request GCP credentials and add these to this file. Adjust this command to suit your needs, it will generate a config at ocm/cluster.json:
 ```sh
OCM_CLUSTER_NAME=acatterm-ccs OCM_CLUSTER_LIFESPAN=24 COMPUTE_NODES_COUNT=2 BYOC=true CLOUD_PROVIDER=gcp make -f make/ocm.mk ocm/cluster.json
```
Once you have checked the ocm/cluster.json, create the cluster:
```sh
make -f make/ocm.mk ocm/cluster/create
```

### Verify changes

Run the operator from this branch:

```
PROVIDER=gcp make cluster/prepare
make run
```

Create a new Redis CR with a custom size:

```
REDIS_NODE_SIZE=7 PROVIDER=gcp make cluster/seed/redis
```

You should see the redis instance get created with this memory configured. Update the CR to a different value and watch the redis instance change.

Removing the `Spec.Size` will result in the Redis instance reverting to the default of 1GB.