### PR TITLE
MGDAPI-5705 - set object lifecycle for buckets

### DIFF
--- a/pkg/providers/gcp/gcpiface/storage_api.go
+++ b/pkg/providers/gcp/gcpiface/storage_api.go
@@ -17,6 +17,8 @@ type StorageAPI interface {
 	DeleteBucket(ctx context.Context, bucket string) error
 	SetBucketPolicy(ctx context.Context, bucket, identity, role string) error
 	HasBucketPolicy(ctx context.Context, bucket, identity, role string) (bool, error)
+	SetBucketLifecycle(ctx context.Context, bucket string, days int64) error
+	HasBucketLifecycle(ctx context.Context, bucket string, days int64) (bool, error)
 	ListObjects(ctx context.Context, bucket string, query *storage.Query) ([]*storage.ObjectAttrs, error)
 	GetObjectMetadata(ctx context.Context, bucket, object string) (*storage.ObjectAttrs, error)
 	DeleteObject(ctx context.Context, bucket, object string) error
@@ -42,11 +44,7 @@ func NewStorageAPI(ctx context.Context, opt option.ClientOption, logger *logrus.
 func (c *storageClient) CreateBucket(ctx context.Context, bucket, projectID string, attrs *storage.BucketAttrs) error {
 	c.logger.Infof("creating bucket %q", bucket)
 	bucketHandle := c.storageService.Bucket(bucket)
-	err := bucketHandle.Create(ctx, projectID, attrs)
-	if err != nil {
-		return err
-	}
-	return nil
+	return bucketHandle.Create(ctx, projectID, attrs)
 }
 
 func (c *storageClient) GetBucket(ctx context.Context, bucket string) (*storage.BucketAttrs, error) {
@@ -58,11 +56,7 @@ func (c *storageClient) GetBucket(ctx context.Context, bucket string) (*storage.
 func (c *storageClient) DeleteBucket(ctx context.Context, bucket string) error {
 	c.logger.Infof("deleting bucket %q", bucket)
 	bucketHandle := c.storageService.Bucket(bucket)
-	err := bucketHandle.Delete(ctx)
-	if err != nil {
-		return err
-	}
-	return nil
+	return bucketHandle.Delete(ctx)
 }
 
 func (c *storageClient) SetBucketPolicy(ctx context.Context, bucket, identity, role string) error {
@@ -73,10 +67,7 @@ func (c *storageClient) SetBucketPolicy(ctx context.Context, bucket, identity, r
 		return err
 	}
 	policy.Add(identity, iam.RoleName(role))
-	if err = bucketHandle.IAM().SetPolicy(ctx, policy); err != nil {
-		return err
-	}
-	return nil
+	return bucketHandle.IAM().SetPolicy(ctx, policy)
 }
 
 func (c *storageClient) HasBucketPolicy(ctx context.Context, bucket, identity, role string) (bool, error) {
@@ -87,6 +78,43 @@ func (c *storageClient) HasBucketPolicy(ctx context.Context, bucket, identity, r
 		return false, err
 	}
 	return policy.HasRole(identity, iam.RoleName(role)), nil
+}
+
+func (c *storageClient) SetBucketLifecycle(ctx context.Context, bucket string, days int64) error {
+	c.logger.Infof("setting object lifecycle on bucket %q", bucket)
+	bucketHandle := c.storageService.Bucket(bucket)
+	uattrs := storage.BucketAttrsToUpdate{
+		Lifecycle: &storage.Lifecycle{
+			Rules: []storage.LifecycleRule{
+				{
+					Action: storage.LifecycleAction{
+						Type: storage.DeleteAction,
+					},
+					Condition: storage.LifecycleCondition{
+						AgeInDays: days,
+					},
+				},
+			},
+		},
+	}
+	_, err := bucketHandle.Update(ctx, uattrs)
+	return err
+}
+
+func (c *storageClient) HasBucketLifecycle(ctx context.Context, bucket string, days int64) (bool, error) {
+	c.logger.Infof("checking object lifecycle on bucket %q", bucket)
+	bucketHandle := c.storageService.Bucket(bucket)
+	attrs, err := bucketHandle.Attrs(ctx)
+	if err != nil {
+		return false, err
+	}
+	for i := range attrs.Lifecycle.Rules {
+		if attrs.Lifecycle.Rules[i].Action.Type == storage.DeleteAction &&
+			attrs.Lifecycle.Rules[i].Condition.AgeInDays == days {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (c *storageClient) ListObjects(ctx context.Context, bucket string, query *storage.Query) ([]*storage.ObjectAttrs, error) {
@@ -109,33 +137,27 @@ func (c *storageClient) ListObjects(ctx context.Context, bucket string, query *s
 func (c *storageClient) GetObjectMetadata(ctx context.Context, bucket, object string) (*storage.ObjectAttrs, error) {
 	c.logger.Infof("fetching object %q from bucket %q", object, bucket)
 	objectHandle := c.storageService.Bucket(bucket).Object(object)
-	attrs, err := objectHandle.Attrs(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return attrs, nil
+	return objectHandle.Attrs(ctx)
 }
 
 func (c *storageClient) DeleteObject(ctx context.Context, bucket, object string) error {
 	c.logger.Infof("deleting object %q from bucket %q", object, bucket)
 	objectHandle := c.storageService.Bucket(bucket).Object(object)
-	err := objectHandle.Delete(ctx)
-	if err != nil {
-		return err
-	}
-	return nil
+	return objectHandle.Delete(ctx)
 }
 
 type MockStorageClient struct {
 	StorageAPI
-	CreateBucketFn      func(context.Context, string, string, *storage.BucketAttrs) error
-	GetBucketFn         func(context.Context, string) (*storage.BucketAttrs, error)
-	DeleteBucketFn      func(context.Context, string) error
-	SetBucketPolicyFn   func(context.Context, string, string, string) error
-	HasBucketPolicyFn   func(context.Context, string, string, string) (bool, error)
-	ListObjectsFn       func(context.Context, string, *storage.Query) ([]*storage.ObjectAttrs, error)
-	GetObjectMetadataFn func(context.Context, string, string) (*storage.ObjectAttrs, error)
-	DeleteObjectFn      func(context.Context, string, string) error
+	CreateBucketFn       func(context.Context, string, string, *storage.BucketAttrs) error
+	GetBucketFn          func(context.Context, string) (*storage.BucketAttrs, error)
+	DeleteBucketFn       func(context.Context, string) error
+	SetBucketPolicyFn    func(context.Context, string, string, string) error
+	HasBucketPolicyFn    func(context.Context, string, string, string) (bool, error)
+	SetBucketLifecycleFn func(context.Context, string, int64) error
+	HasBucketLifecycleFn func(context.Context, string, int64) (bool, error)
+	ListObjectsFn        func(context.Context, string, *storage.Query) ([]*storage.ObjectAttrs, error)
+	GetObjectMetadataFn  func(context.Context, string, string) (*storage.ObjectAttrs, error)
+	DeleteObjectFn       func(context.Context, string, string) error
 }
 
 func GetMockStorageClient(modifyFn func(storageClient *MockStorageClient)) *MockStorageClient {
@@ -153,6 +175,12 @@ func GetMockStorageClient(modifyFn func(storageClient *MockStorageClient)) *Mock
 			return nil
 		},
 		HasBucketPolicyFn: func(ctx context.Context, bucket, identity, role string) (bool, error) {
+			return false, nil
+		},
+		SetBucketLifecycleFn: func(ctx context.Context, bucket string, days int64) error {
+			return nil
+		},
+		HasBucketLifecycleFn: func(ctx context.Context, bucket string, days int64) (bool, error) {
 			return false, nil
 		},
 		ListObjectsFn: func(ctx context.Context, bucket string, query *storage.Query) ([]*storage.ObjectAttrs, error) {
@@ -189,6 +217,14 @@ func (m *MockStorageClient) SetBucketPolicy(ctx context.Context, bucket, identit
 
 func (m *MockStorageClient) HasBucketPolicy(ctx context.Context, bucket, identity, role string) (bool, error) {
 	return m.HasBucketPolicyFn(ctx, bucket, identity, role)
+}
+
+func (m *MockStorageClient) SetBucketLifecycle(ctx context.Context, bucket string, days int64) error {
+	return m.SetBucketLifecycleFn(ctx, bucket, days)
+}
+
+func (m *MockStorageClient) HasBucketLifecycle(ctx context.Context, bucket string, days int64) (bool, error) {
+	return m.HasBucketLifecycleFn(ctx, bucket, days)
 }
 
 func (m *MockStorageClient) ListObjects(ctx context.Context, bucket string, query *storage.Query) ([]*storage.ObjectAttrs, error) {


### PR DESCRIPTION
## Overview

[MGDAPI-5705](https://issues.redhat.com/browse/MGDAPI-5705)

## Verification

### Provision a GCP CCS cluster

From the master branch of the [Delorean](https://github.com/integr8ly/delorean) repo create a file in the root of the repo called gcp_service_account.json. Request GCP credentials and add these to this file. Adjust this command to suit your needs, it will generate a config at ocm/cluster.json:
 ```sh
OCM_CLUSTER_NAME=acatterm-ccs OCM_CLUSTER_LIFESPAN=24 COMPUTE_NODES_COUNT=2 BYOC=true CLOUD_PROVIDER=gcp make -f make/ocm.mk ocm/cluster.json
```
Once you have checked the ocm/cluster.json, create the cluster:
```sh
make -f make/ocm.mk ocm/cluster/create
```

### Verify changes

Run the operator from this branch:

```
PROVIDER=gcp make cluster/prepare
make run
```

Create a new Postgres CR:

```
PROVIDER=gcp make cluster/seed/postgres
```

Set the snapshot fields (this will trigger a new snapshot every 30 minutes, retaining for 10 days):

```
oc patch postgres/example-postgres -n cloud-resource-operator --type=merge -p '{"spec":{"snapshotRetention": "10d", "snapshotFrequency": "30m"}}'
```

In the GCP UI check the bucket for your postgres instance and look at the lifecycle rules. The rule should match the retention time + 10 days (as specified by `lifecycleAdditionalDays` in this PR). Update the `snapshotRetention` and the lifecycle rule will be reconciled to match. Note that any `snapshotRetention` setting that is in between days is rounded up to the nearest day.

![image](https://github.com/integr8ly/cloud-resource-operator/assets/6575004/ffafa1a0-406a-4cf1-bd30-e00f8212e67d)

