### PR TITLE
MGDAPI-5609 - move serviceUpdates outside of maintenanceWindow

### DIFF
--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -336,12 +336,13 @@ func (p *RedisProvider) createElasticacheCluster(ctx context.Context, r *v1alpha
 			}
 			logger.Infof("set pending modifications to elasticache replication group %s", *foundCache.ReplicationGroupId)
 		}
-		if serviceUpdates != nil && len(serviceUpdates.updates) > 0 {
-			err = p.applySpecifiedSecurityUpdates(cacheSvc, foundCache, serviceUpdates)
-			if err != nil {
-				errMsg := "there was an error applying critical security updates"
-				return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
-			}
+	}
+
+	if serviceUpdates != nil && len(serviceUpdates.updates) > 0 {
+		err = p.applySpecifiedSecurityUpdates(cacheSvc, foundCache, serviceUpdates)
+		if err != nil {
+			errMsg := "there was an error applying critical security updates"
+			return nil, croType.StatusMessage(errMsg), errorUtil.Wrap(err, errMsg)
 		}
 	}
 


### PR DESCRIPTION
## Overview

Jira: [MGDAPI-5609](https://issues.redhat.com/browse/MGDAPI-5609)
Move specifiedUpdate in CRO for redis outside of the serviceMaintenance bloc

## Verification

Eye review of code changes should be sufficient
