### PR TITLE
MGDAPI-5815 - configure golangci-lint checks

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,33 @@
+output:
+  format: tab
+  sort-results: true
+
+linters:
+  disable:
+    - errcheck
+    - ineffassign
+    - unused
+    - govet
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+linters-settings:
+  gosimple:
+    checks: ["all"]
+  staticcheck:
+    checks: ["all", -SA4006, -SA9003, -SA1019]
+  errcheck:
+    check-blank: true
+
+presets:
+  - bugs
+  - error
+  - metalinter
+  - style
+  - unused
+
+run:
+  modules-download-mode: readonly
+  timeout: 5m


### PR DESCRIPTION
## Overview

[MGDAPI-5815](https://issues.redhat.com/browse/MGDAPI-5815)

Configure and add golangci-lint file for running checks

## Verification

- Run the lint make command:
```
make test/lint
```
- It will install the golangci-lint binary to the bin folder of your project if it doesn't already exist there. The output of running should be empty. 


## Checklist
