### PR TITLE
MGDAPI-6133 Bump default Redis to 6

### DIFF
--- a/pkg/providers/openshift/provider_redis.go
+++ b/pkg/providers/openshift/provider_redis.go
@@ -42,7 +42,7 @@ const (
 	redisConfigMapKey     = "redis.conf"
 	redisContainerName    = "redis"
 	redisPort             = 6379
-	redisContainerCommand = "/opt/rh/rh-redis32/root/usr/bin/redis-server"
+	redisContainerCommand = "/opt/rh/rh-redis6/root/usr/bin/redis-server"
 )
 
 var _ providers.RedisProvider = (*RedisProvider)(nil)
@@ -348,7 +348,7 @@ func buildDefaultRedisDeployment(r *v1alpha1.Redis) *appsv1.Deployment {
 func buildDefaultRedisPodContainers(r *v1alpha1.Redis) []corev1.Container {
 	return []corev1.Container{
 		{
-			Image:           "registry.redhat.io/rhscl/redis-32-rhel7",
+			Image:           "registry.redhat.io/rhscl/redis-6-rhel7",
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Name:            redisContainerName,
 			Command: []string{

--- a/test/e2e/redis_test.go
+++ b/test/e2e/redis_test.go
@@ -79,7 +79,7 @@ func buildRedisContainer(command []string) []v1.Container {
 	return []v1.Container{
 		{
 			Name:            "redis-connection",
-			Image:           "registry.redhat.io/rhscl/redis-32-rhel7",
+			Image:           "registry.redhat.io/rhscl/redis-6-rhel7",
 			Command:         command,
 			ImagePullPolicy: v1.PullIfNotPresent,
 		},


### PR DESCRIPTION
## Overview
JIRA: [MGDAPI-6133](https://issues.redhat.com/browse/MGDAPI-6133)

## Verification
1. Provision non-CCS cluster
2. Build CRO images from this PR
3. Install RHOAM from CatalogSource but before creating the RHMI CR, patch the managed-api-service CSV with the custom CRO image
4. Verify that the RHOAM installation completes