### PR TITLE
MGDAPI-6292 bump the redis engine version to 7.1

### DIFF
--- a/pkg/providers/aws/provider_redis.go
+++ b/pkg/providers/aws/provider_redis.go
@@ -39,7 +39,7 @@ const (
 	defaultAtRestEncryption = true
 	defaultCacheNodeType    = "cache.t3.micro"
 	defaultDescription      = "A Redis replication group"
-	defaultEngineVersion    = "6.2"
+	defaultEngineVersion    = "7.1"
 	// 3scale does not support in transit encryption (redis with tls)
 	defaultInTransitEncryption = false
 	defaultNumCacheClusters    = 2


### PR DESCRIPTION
## Overview

Jira: MGDAPI-6292

## Verification
### Fresh install
- Use a ccs cluster
- Clone this branch
- Run `make cluster/prepare`
- Run `PROVIDER=aws make cluster/seed/redis`
- Run `make run`
- Ensure that the version in the status is 7.1
```yaml
status:
  message: 'successfully created and tagged, aws elasticache status is available'
  phase: complete
  provider: aws-elasticache
  secretRef:
    name: example-redis-sec
  strategy: aws
  version: 7.1.0
```
- Delete the redis CR

### Upgrade
- checkout master
- Run `PROVIDER=aws make cluster/seed/redis`
- Run `make run`
- Wait for status `phase: completed` in the cr
- modify the maintenance window in the aws to the current time ( or do it in the ui)
```bash
# get the replication group id
~ aws elasticache describe-replication-groups | jq -r '.ReplicationGroups[].ReplicationGroupId'  
<your-replication-group-id>
# set the maintenance window
~ aws elasticache modify-replication-group \
    --replication-group-id  <your-replication-group-id>\
    --preferred-maintenance-window mon:03:00-mon:04:00
```
- set the `maintanceWindow : true` & `applyImmediately: true` in the redis spec
- stop the operator running
- checkout out this branch and `make run` again
- Ensure that the version in the status updated from 6.2.6 to 7.1
```yaml
status:
  message: 'successfully created and tagged, aws elasticache status is available'
  phase: complete
  provider: aws-elasticache
  secretRef:
    name: example-redis-sec
  strategy: aws
  version: 7.1.0
```
