### PR TITLE
MGDAPI-6317 change the provider openshift redis to version 7

### DIFF
--- a/pkg/providers/openshift/provider_redis.go
+++ b/pkg/providers/openshift/provider_redis.go
@@ -42,7 +42,7 @@ const (
 	redisConfigMapKey     = "redis.conf"
 	redisContainerName    = "redis"
 	redisPort             = 6379
-	redisContainerCommand = "/opt/rh/rh-redis6/root/usr/bin/redis-server"
+	redisContainerCommand = "/usr/bin/redis-server"
 )
 
 var _ providers.RedisProvider = (*RedisProvider)(nil)
@@ -348,7 +348,7 @@ func buildDefaultRedisDeployment(r *v1alpha1.Redis) *appsv1.Deployment {
 func buildDefaultRedisPodContainers(r *v1alpha1.Redis) []corev1.Container {
 	return []corev1.Container{
 		{
-			Image:           "registry.redhat.io/rhscl/redis-6-rhel7",
+			Image:           "registry.redhat.io/rhel9/redis-7",
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Name:            redisContainerName,
 			Command: []string{


### PR DESCRIPTION
## Overview

Jira: MGDAPI-6317

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make cluster/seed/redis`
- Run `make run`
- wait for the redis pod to be ready and check the version
```bash
oc logs $(oc get po | awk '{print $1}'| sed -n '2 p') 
1:C 21 May 2024 14:26:31.604 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
1:C 21 May 2024 14:26:31.604 # Redis version=7.0.12, bits=64, commit=00000000, modified=0, pid=1, just started
1:C 21 May 2024 14:26:31.604 # Configuration loaded
1:M 21 May 2024 14:26:31.604 * monotonic clock: POSIX clock_gettime
1:M 21 May 2024 14:26:31.605 * Running mode=standalone, port=6379.
1:M 21 May 2024 14:26:31.605 # Server initialized
1:M 21 May 2024 14:26:31.605 * Ready to accept connections
```

## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below