### PR TITLE
MGDAPI-6290-3 set openshift-ci to go1.20

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.19
+FROM registry.ci.openshift.org/openshift/release:golang-1.20
 
 ENV OPERATOR_SDK_VERSION=v1.14.0
 


### PR DESCRIPTION
## Overview

Jira: https://issues.redhat.com/browse/MGDAPI-6290

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make run`
- Ensure...

## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below