### PR TITLE
MGDAPI-6421 Use root to support CRO base image build via podman v4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Build the manager binary	
-FROM registry.redhat.io/ubi9/go-toolset:1.20.12 as builder
-		
+FROM registry.redhat.io/ubi9/go-toolset:1.20.12 AS builder
+
+# this is required for podman
+USER root
+
 WORKDIR /workspace	
 # Copy the Go Modules manifests	
 COPY go.mod go.mod	


### PR DESCRIPTION
## Overview

Jira: [MGDAPI-6421](https://issues.redhat.com/browse/MGDAPI-6421)

Adding `USER root` is required to avoid permission issues if building via podman v4

## Verification

Have a podman v4 (I validated with v4.9.4 because our ci-cd pipeline uses that version) installed. Then execute
`make image/build/pipelines`

Alternatively, you can trigger ci-cd pipeline I created to validate this:
https://master-jenkins-csb-intly.apps.ocp-c1.prod.psi.redhat.com/job/Playground/job/trepel/job/cro-release/

Or simply just review its successful build:
https://master-jenkins-csb-intly.apps.ocp-c1.prod.psi.redhat.com/job/Playground/job/trepel/job/cro-release/13/
- see Parameters -> that this PR was used
- see Console Output -> that the `podman bulid...` passed there successfully
