### PR TITLE
MGDAPI-6535 move to public go image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary	
-FROM registry.redhat.io/ubi9/go-toolset:1.20.12 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20.12 AS builder
 
 # this is required for podman
 USER root

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset:1.20.12
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20.12
 
 ENV OPERATOR=/usr/local/bin/cloud-resource-operator \
     USER_UID=1001 \


### PR DESCRIPTION
## Overview

Move builder image to public registry

## Verification

- e2e pass

## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below