### PR TITLE
MGDAPI-6539 bump postgres 13.18

### DIFF
--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -44,7 +44,7 @@ const (
 	defaultAwsDBInstanceClass            = "db.t3.small"
 	defaultAwsDeleteAutomatedBackups     = true
 	defaultAwsEngine                     = "postgres"
-	defaultAwsEngineVersion              = "13.13"
+	defaultAwsEngineVersion              = "13.18"
 	defaultAwsIdentifierLength           = 40
 	defaultAwsMaxAllocatedStorage        = 100
 	defaultAwsMultiAZ                    = true


### PR DESCRIPTION
## Overview

Jira: [MGDAPI-6539](https://issues.redhat.com/browse/MGDAPI-6539)

## Verification
- CCS cluster required
- Clone this branch
- Run `make cluster/prepare`
- Run `PROVIDER=aws make cluster/seed/postgres`
- Run `make run`
- Confirm the postgres cr finishes creation and the engine version is 13.18
```bash
oc get postgres example-postgres -oyaml | yq '.status'
message: rds instance aucunninccsqnpxccloudresourceoperat-snit is as expected, aws rds status is available
phase: complete
provider: aws-rds
secretRef:
  name: example-postgres-sec
strategy: aws
version: "13.18"
```
