### PR TITLE
[WIP]. Close it. Error in local git. MGDAPI-6635 CRO RDS - apply immediately does not work with edits via config map

### DIFF
--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -800,11 +800,14 @@ func buildRDSUpdateStrategy(rdsConfig *rds.CreateDBInstanceInput, foundConfig *r
 			logrus.Info(fmt.Sprintf("Engine upgrade found, the current EngineVersion is %s and is upgrading to %s", *foundConfig.EngineVersion, *rdsConfig.EngineVersion))
 			mi.EngineVersion = rdsConfig.EngineVersion
 			mi.AllowMajorVersionUpgrade = aws.Bool(true)
-			if cr.Spec.ApplyImmediately {
-				mi.ApplyImmediately = aws.Bool(cr.Spec.ApplyImmediately)
-			}
 			updateFound = true
 		}
+	}
+
+	// ApplyImmediately should not be dependent to EngineVersion change
+	// EngineVersion should not prevent Immediate DBInstanceClass update
+	if cr.Spec.ApplyImmediately {
+		mi.ApplyImmediately = aws.Bool(cr.Spec.ApplyImmediately)
 	}
 
 	if (!updateFound || !verifyPendingModification(mi, foundConfig.PendingModifiedValues)) && (mi.ApplyImmediately == nil || !*mi.ApplyImmediately) {


### PR DESCRIPTION
## Overview

Jira: [MGDAPI-6635](https://issues.redhat.com/browse/MGDAPI-6635)

Update: change in buildRDSUpdateStrategy(...) function logics:
- ApplyImmediately should not be dependent to EngineVersion change
- EngineVersion should not prevent Immediate DBInstanceClass update

## Verification

1. Clone this branch
2. create CCS cluster
3. Prepare:
    - Ensure that  `PROVIDER ?= aws` is set in your Makefile
    - Run `make cluster/prepare`
        - check that Provider and Strategy config-maps created:

        ```bash
            oc get cm |grep cloud
            cloud-resource-config            3      7m10s
            cloud-resources-aws-strategies   4      7m9s

        ``` 
4. Create Postgres CR.

```bash
kubectl apply -f - <<EOF
apiVersion: integreatly.org/v1alpha1
kind: Postgres
metadata:
  name: example-postgres
  labels:
    productName: 3scale
spec:
  applyImmediately: false
  secretRef:
    name: example-postgres-sec
  tier: development
  type: aws
EOF
```

5.  Run make run.
6. Check your AWS RDS instance:
    6.1 it will use the DB instance class db.t3.small by default (if DBInstanceClass is not set in the cloud-resources-aws-strategies ConfigMap, as set by the operator).
    6.2. Wait for the DB status to be `Available`.
    
![image](https://github.com/user-attachments/assets/cb566cdb-f272-474d-a476-cc2970434f8d)

7. Update the DBInstanceClass from db.t3.small to db.t3.medium by modifying the Strategies ConfigMap.
    Ensure that the same `tier` is used in CM as in the Postgres CR (in our case, `development`)

```bash
oc get cm cloud-resources-aws-strategies -o yaml | yq .data.postgres - | jq --arg type db.t3.medium '.development.createStrategy.DBInstanceClass=$type' > strattemp.json
oc get cm cloud-resources-aws-strategies -o json | jq --arg add "`cat strattemp.json`" '.data.postgres = $add' | oc apply -f -
```

9. Allow maintenance

```
oc patch postgres example-postgres -n cloud-resource-operator --type=merge -p '{"spec": {"maintenanceWindow": true, "applyImmediately": true}}'
```

10. check your AWS RDS - Instance Class will be changed to db.t3.medium. Please note that the process can take few minutes. You can follow the progress in Logs or Database window in AWS RDS.
   - DB modification is in progress:
   
![image](https://github.com/user-attachments/assets/efd2dd4c-5445-4d3f-b388-7fa8138044e0)
  
   - Update done. Instance Class changed to db.t3.medium
 
![image](https://github.com/user-attachments/assets/cdaa2881-9df5-4afa-8ff5-98e0f0112272)


 More logs of tests:  we tried to change Instance Class was changed from db.t3.small to db.t3.medium and also change  back to db.t3.small . Done successfully.

![image](https://github.com/user-attachments/assets/4649bde4-1f22-47f0-bfc6-1e0cba55276a)

11. Note: After completing the test, please ensure you delete the AWS resources, including the DB and snapshots

## Checklist
see Verification steps
