### PR TITLE
MGDAPI-6668 bump prow to go1.23

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.20
+FROM registry.ci.openshift.org/openshift/release:golang-1.23
 
 ENV OPERATOR_SDK_VERSION=v1.14.0
 


### PR DESCRIPTION
## Overview

Jira: MGDAPI-6668 

## Verification

visual inspection only prow jobs won't pass 


## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below