### PR TITLE
MGDAPI-6635 set applyImmediately flag on DBInstanceClass update

### DIFF
--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -783,10 +783,6 @@ func buildRDSUpdateStrategy(rdsConfig *rds.CreateDBInstanceInput, foundConfig *r
 		mi.BackupRetentionPeriod = rdsConfig.BackupRetentionPeriod
 		updateFound = true
 	}
-	if *rdsConfig.DBInstanceClass != *foundConfig.DBInstanceClass {
-		mi.DBInstanceClass = rdsConfig.DBInstanceClass
-		updateFound = true
-	}
 	if *rdsConfig.PubliclyAccessible != *foundConfig.PubliclyAccessible {
 		mi.PubliclyAccessible = rdsConfig.PubliclyAccessible
 		updateFound = true
@@ -811,6 +807,18 @@ func buildRDSUpdateStrategy(rdsConfig *rds.CreateDBInstanceInput, foundConfig *r
 		mi.PreferredMaintenanceWindow = rdsConfig.PreferredMaintenanceWindow
 		updateFound = true
 	}
+	// need to set applyImmediately aws flag when DBInstanceClass updates
+	if rdsConfig.DBInstanceClass != nil {
+		if *foundConfig.DBInstanceClass != *rdsConfig.DBInstanceClass {
+			logrus.Info(fmt.Sprintf("DBInstanceClass upgrade found, the current DBInstanceClass is %s and is upgrading to %s", *foundConfig.DBInstanceClass, *rdsConfig.DBInstanceClass))
+			mi.DBInstanceClass = rdsConfig.DBInstanceClass
+			if cr.Spec.ApplyImmediately {
+				mi.ApplyImmediately = aws.Bool(cr.Spec.ApplyImmediately)
+			}
+			updateFound = true
+		}
+	}
+	// need to set applyImmediately aws flag when Engine updates
 	if rdsConfig.EngineVersion != nil {
 		engineUpgradeNeeded, err := resources.VerifyVersionUpgradeNeeded(*foundConfig.EngineVersion, *rdsConfig.EngineVersion)
 		if err != nil {


### PR DESCRIPTION
## Overview

Jira: MGDAPI-6635

## Verification

- Clone this branch
- Run `make cluster/prepare` this creates an openshift strategy by default
- We need to create a aws strategy configmap (copied from eng-long-lived) but changed the DBInstanceClass to "db.t3.small"
```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: cloud-resources-aws-strategies
  namespace: cloud-resource-operator
data:
  _network: '{"development":{"createStrategy":{"CidrBlock":"10.1.0.0/26"}},"production":{"createStrategy":{"CidrBlock":"10.1.0.0/26"}}}'
  blobstorage: '{"development": { "region": "", "_network": "", "createStrategy": {}, "deleteStrategy": {} }, "production": { "region": "", "_network": "", "createStrategy": {}, "deleteStrategy": {} }}'
  postgres: '{"development":{"region":"","createStrategy":{},"deleteStrategy":{},"serviceUpdates":null},"production":{"region":"","createStrategy":{"AllocatedStorage":null,"AutoMinorVersionUpgrade":null,"AvailabilityZone":null,"BackupRetentionPeriod":null,"BackupTarget":null,"CACertificateIdentifier":null,"CharacterSetName":null,"CopyTagsToSnapshot":null,"CustomIamInstanceProfile":null,"DBClusterIdentifier":null,"DBInstanceClass":"db.t3.small","DBInstanceIdentifier":null,"DBName":null,"DBParameterGroupName":null,"DBSecurityGroups":null,"DBSubnetGroupName":null,"DBSystemId":null,"DedicatedLogVolume":null,"DeletionProtection":null,"Domain":null,"DomainAuthSecretArn":null,"DomainDnsIps":null,"DomainFqdn":null,"DomainIAMRoleName":null,"DomainOu":null,"EnableCloudwatchLogsExports":null,"EnableCustomerOwnedIp":null,"EnableIAMDatabaseAuthentication":null,"EnablePerformanceInsights":null,"Engine":null,"EngineVersion":null,"Iops":null,"KmsKeyId":null,"LicenseModel":null,"ManageMasterUserPassword":null,"MasterUserPassword":null,"MasterUserSecretKmsKeyId":null,"MasterUsername":null,"MaxAllocatedStorage":null,"MonitoringInterval":null,"MonitoringRoleArn":null,"MultiAZ":null,"MultiTenant":null,"NcharCharacterSetName":null,"NetworkType":null,"OptionGroupName":null,"PerformanceInsightsKMSKeyId":null,"PerformanceInsightsRetentionPeriod":null,"Port":null,"PreferredBackupWindow":"03:01-04:01","PreferredMaintenanceWindow":"thu:02:00-thu:03:00","ProcessorFeatures":null,"PromotionTier":null,"PubliclyAccessible":null,"StorageEncrypted":null,"StorageThroughput":null,"StorageType":null,"Tags":null,"TdeCredentialArn":null,"TdeCredentialPassword":null,"Timezone":null,"VpcSecurityGroupIds":null},"deleteStrategy":{},"serviceUpdates":["1642204801"]}}'
  redis: '{"development":{"region":"","createStrategy":{},"deleteStrategy":{},"serviceUpdates":null},"production":{"region":"","createStrategy":{"AtRestEncryptionEnabled":null,"AuthToken":null,"AutoMinorVersionUpgrade":null,"AutomaticFailoverEnabled":null,"CacheNodeType":null,"CacheParameterGroupName":null,"CacheSecurityGroupNames":null,"CacheSubnetGroupName":null,"ClusterMode":null,"DataTieringEnabled":null,"Engine":null,"EngineVersion":null,"GlobalReplicationGroupId":null,"IpDiscovery":null,"KmsKeyId":null,"LogDeliveryConfigurations":null,"MultiAZEnabled":null,"NetworkType":null,"NodeGroupConfiguration":null,"NotificationTopicArn":null,"NumCacheClusters":null,"NumNodeGroups":null,"Port":null,"PreferredCacheClusterAZs":null,"PreferredMaintenanceWindow":"thu:02:00-thu:03:00","PrimaryClusterId":null,"ReplicasPerNodeGroup":null,"ReplicationGroupDescription":null,"ReplicationGroupId":null,"SecurityGroupIds":null,"ServerlessCacheSnapshotName":null,"SnapshotArns":null,"SnapshotName":null,"SnapshotRetentionLimit":null,"SnapshotWindow":"03:01-04:01","Tags":null,"TransitEncryptionEnabled":null,"TransitEncryptionMode":null,"UserGroupIds":null},"deleteStrategy":{},"serviceUpdates":["elasticache-20241007-intel","elasticache-redis-cve-patch-update-202410","elasticache-patch-update-202501","elasticache-20210615-002","elasticache-redis-6-2-6-update-20230109","elasticache-20230315-001","elasticache-redis-6-2-update","elasticache-20240225-intel","elasticache-20240501-intel"]}}'

```  
 
- run ` PROVIDER=aws make cluster/seed/postgres`
- change the `spec.tier` to production , so it will use the strategy above
- Run `make run`
- Wait for the CR to finish reconciling 
- confirm the Instance class 
```bash
aws rds describe-db-instances --region eu-central-1 | jq '.DBInstances.[0].DBInstanceClass'
"db.t3.small"
``` 
- change the `"DBInstanceClass": "db.t3.medium"` in the cloud-resources-aws-strategies config map
- set the apply immediately and maintenance window to true in the CR
```yaml
spec:
  applyImmediately: true
  maintenanceWindow: true
  secretRef:
    name: example-postgres-sec
  tier: production
  type: aws
```
- it should start to modify 
- When it's finished the `spec.maintenanceWindow: true` will be removed 
- and the instance type will be updated 
```bash
aws rds describe-db-instances --region eu-central-1 | jq '.DBInstances.[0].DBInstanceClass'
"db.t3.medium"
```  
 