### PR TITLE
MGDAPI-1142 add request and limits to the operator deployment

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -54,6 +54,13 @@ spec:
         volumeMounts:
         - name: bound-sa-token
           mountPath: /var/run/secrets/openshift/serviceaccount
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "300m"
+            memory: "256Mi"
       volumes:
       - name: bound-sa-token
         projected:


### PR DESCRIPTION
## Overview

Jira: MGDAPI-1142

## Verification

- checkout this branch
- update the IMAGE_ORG in the makefile to point at your quay repo
```bash
IMAGE_REG ?= quay.io
IMAGE_ORG ?= <your_quay_username>
IMAGE_NAME ?= cloud-resource-operator
```
- build an image and push it
```bash
make image/build
make image/push
```
- you can then deploy the image
```bash
make cluster/prepare
OPERATOR_IMAGE=<your-image> make cluster/deploy
```
- this will create an CRO operator deployment
- check the operator deployment yaml for the request and limits 
```bash
oc -n cloud-resource-operator get deployment cloud-resource-operator -o jsonpath='{.spec.template.spec.containers[0].resources}'
```


## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below