### PR TITLE
MGDAPI-6598: allow CRO upgrade from 1.1.6 to 1.1.8 via olm.skipRange

### DIFF
--- a/bundles/1.1.8/manifests/cloud-resource-operator.clusterserviceversion.yaml
+++ b/bundles/1.1.8/manifests/cloud-resource-operator.clusterserviceversion.yaml
@@ -87,6 +87,7 @@ metadata:
     createdAt: "2026-07-16T09:15:29Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    olm.skipRange: ">=1.1.6 <1.1.8"
   name: cloud-resources.v1.1.8
   namespace: placeholder
 spec:

--- a/config/manifests/bases/cloud-resource-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cloud-resource-operator.clusterserviceversion.yaml
@@ -7,6 +7,7 @@ metadata:
     containerImage: quay.io/integreatly/cloud-resource-operator:v1.1.8
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
+    olm.skipRange: ">=1.1.6 <1.1.8"
   name: cloud-resource-operator.v1.1.8
   namespace: placeholder
 spec:


### PR DESCRIPTION
## Overview

Jira: https://redhat.atlassian.net/browse/MGDAPI-6598

allow CRO upgrade from 1.1.6 to 1.1.8 via olm.skipRange

## Verification

- Clone this branch
- Run `make cluster/prepare`
- Run `make run`
- Ensure...

## Checklist
- [ ] This PR includes a change to an instance type, I have used script `hack/<provider>/supported_types.sh` and attached the result below