### PR TITLE
MGDAPI-7069 bump Postgres default engine version to 15.18

### DIFF
--- a/pkg/providers/aws/provider_postgres.go
+++ b/pkg/providers/aws/provider_postgres.go
@@ -45,7 +45,7 @@ const (
 	defaultAwsDBInstanceClass            = "db.t3.small"
 	defaultAwsDeleteAutomatedBackups     = true
 	defaultAwsEngine                     = "postgres"
-	defaultAwsEngineVersion              = "15.15"
+	defaultAwsEngineVersion              = "15.18"
 	defaultAwsIdentifierLength           = 40
 	defaultAwsMaxAllocatedStorage        = 100
 	defaultAwsMultiAZ                    = true
@@ -65,7 +65,7 @@ const (
 )
 
 var (
-	defaultSupportedEngineVersions = []string{"15.15", "13.18", "13.13", "13.12", "13.11"}
+	defaultSupportedEngineVersions = []string{"15.18", "15.15", "13.18", "13.13", "13.12", "13.11"}
 	healthyAWSDBInstanceStatuses   = []string{
 		"backtracking",
 		"available",


### PR DESCRIPTION
## Overview

Jira: https://redhat.atlassian.net/browse/MGDAPI-7069


## Verification

- CCS cluster required
- Clone this branch
- Run make cluster/prepare
- Run PROVIDER=aws make cluster/seed/postgres
- Run make run
- Confirm the postgres cr finishes creation and the engine version is 15.18

<img width="1429" height="283" alt="image" src="https://github.com/user-attachments/assets/94db924b-e6e5-4abc-8692-5a0e2fb59af3" />


#### Notes
- PR is similar to https://github.com/integr8ly/cloud-resource-operator/pull/926